### PR TITLE
fix(api): fix logout 401 bug + JWT secret validation + graceful shutdown

### DIFF
--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -18,6 +22,13 @@ import (
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found, using environment variables")
+	}
+
+	// Fix #2: Validate JWT secrets on startup
+	jwtSecret := os.Getenv("JWT_SECRET")
+	refreshSecret := os.Getenv("JWT_REFRESH_SECRET")
+	if jwtSecret == "" || refreshSecret == "" {
+		log.Fatal("JWT_SECRET and JWT_REFRESH_SECRET must be set")
 	}
 
 	db, err := postgres.Connect()
@@ -44,20 +55,44 @@ func main() {
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "presentsai-api"})
 	}).Methods(http.MethodGet)
 
-	// Auth routes (no auth required)
+	// Public auth routes (no JWT required)
 	authHandler := infraHTTP.NewAuthHandler(authService)
-	authHandler.Register(r)
+	r.HandleFunc("/auth/register", authHandler.HandleRegister).Methods(http.MethodPost)
+	r.HandleFunc("/auth/login", authHandler.HandleLogin).Methods(http.MethodPost)
+	r.HandleFunc("/auth/refresh", authHandler.HandleRefresh).Methods(http.MethodPost)
+
+	// Fix #1: Protected routes — Apply Auth middleware
+	protected := r.PathPrefix("").Subrouter()
+	protected.Use(middleware.Auth(jwtSecret))
+	protected.HandleFunc("/auth/logout", authHandler.HandleLogout).Methods(http.MethodPost)
+	// Future protected routes go here (PR-004: presentations, slides, etc.)
 
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 
-	jwtSecret := os.Getenv("JWT_SECRET")
-	_ = jwtSecret // will be used when adding protected routes in PR-004
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: r,
+	}
+
+	// Graceful shutdown
+	go func() {
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+		<-quit
+		log.Println("Shutting down server...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("Server forced to shutdown: %v", err)
+		}
+	}()
 
 	log.Printf("api service starting on :%s", port)
-	if err := http.ListenAndServe(":"+port, r); err != nil {
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)
 	}
+	log.Println("Server stopped")
 }

--- a/services/api/internal/infrastructure/http/auth_handler.go
+++ b/services/api/internal/infrastructure/http/auth_handler.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	appUser "github.com/ko-tarou/presentsai/services/api/internal/application/user"
 	"github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http/middleware"
 	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
@@ -20,14 +18,7 @@ func NewAuthHandler(authService *appUser.AuthService) *AuthHandler {
 	return &AuthHandler{authService: authService}
 }
 
-func (h *AuthHandler) Register(r *mux.Router) {
-	r.HandleFunc("/auth/register", h.register).Methods(http.MethodPost)
-	r.HandleFunc("/auth/login", h.login).Methods(http.MethodPost)
-	r.HandleFunc("/auth/refresh", h.refresh).Methods(http.MethodPost)
-	r.HandleFunc("/auth/logout", h.logout).Methods(http.MethodPost)
-}
-
-func (h *AuthHandler) register(w http.ResponseWriter, r *http.Request) {
+func (h *AuthHandler) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email       string `json:"email"`
 		Password    string `json:"password"`
@@ -39,6 +30,10 @@ func (h *AuthHandler) register(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Email == "" || req.Password == "" {
 		writeError(w, http.StatusBadRequest, "email and password are required")
+		return
+	}
+	if len(req.Password) < 8 {
+		writeError(w, http.StatusBadRequest, "password must be at least 8 characters")
 		return
 	}
 
@@ -55,7 +50,7 @@ func (h *AuthHandler) register(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, pair)
 }
 
-func (h *AuthHandler) login(w http.ResponseWriter, r *http.Request) {
+func (h *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
@@ -78,7 +73,7 @@ func (h *AuthHandler) login(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, pair)
 }
 
-func (h *AuthHandler) refresh(w http.ResponseWriter, r *http.Request) {
+func (h *AuthHandler) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		RefreshToken string `json:"refreshToken"`
 	}
@@ -96,9 +91,10 @@ func (h *AuthHandler) refresh(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, pair)
 }
 
-func (h *AuthHandler) logout(w http.ResponseWriter, r *http.Request) {
+// HandleLogout requires Auth middleware to be applied upstream (sets UserIDKey in context).
+func (h *AuthHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	userID, ok := r.Context().Value(middleware.UserIDKey).(string)
-	if !ok {
+	if !ok || userID == "" {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}


### PR DESCRIPTION
## Summary
- `/auth/logout` に Auth ミドルウェアを適用 (logout 常時 401 バグを修正)
- 起動時に JWT_SECRET/JWT_REFRESH_SECRET が空なら fatal exit
- ハンドラーメソッドを public 化 (HandleRegister, HandleLogin 等)
- パスワード最低8文字バリデーション追加
- SIGTERM/SIGINT でのグレースフルシャットダウン (10秒タイムアウト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)