### PR TITLE
feat(api): Presentations & Slides CRUD API

### DIFF
--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 
+	appPresentation "github.com/ko-tarou/presentsai/services/api/internal/application/presentation"
+	appSlide "github.com/ko-tarou/presentsai/services/api/internal/application/slide"
 	appUser "github.com/ko-tarou/presentsai/services/api/internal/application/user"
 	infraHTTP "github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http"
 	"github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http/middleware"
@@ -24,7 +26,6 @@ func main() {
 		log.Println("No .env file found, using environment variables")
 	}
 
-	// Fix #2: Validate JWT secrets on startup
 	jwtSecret := os.Getenv("JWT_SECRET")
 	refreshSecret := os.Getenv("JWT_REFRESH_SECRET")
 	if jwtSecret == "" || refreshSecret == "" {
@@ -42,11 +43,19 @@ func main() {
 	// Repositories
 	userRepo := postgres.NewUserRepository(db)
 	refreshRepo := postgres.NewRefreshTokenRepository(db)
+	presentationRepo := postgres.NewPresentationRepository(db)
+	slideRepo := postgres.NewSlideRepository(db)
 
-	// Services
+	// Use cases
 	authService := appUser.NewAuthService(userRepo, refreshRepo)
+	presentationUC := appPresentation.NewUseCase(presentationRepo, slideRepo)
+	slideUC := appSlide.NewUseCase(slideRepo, presentationRepo)
 
-	// Router
+	// Handlers
+	authHandler := infraHTTP.NewAuthHandler(authService)
+	presentationHandler := infraHTTP.NewPresentationHandler(presentationUC)
+	slideHandler := infraHTTP.NewSlideHandler(slideUC)
+
 	r := mux.NewRouter()
 	r.Use(middleware.CORS)
 	r.Use(middleware.JSON)
@@ -55,29 +64,39 @@ func main() {
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "presentsai-api"})
 	}).Methods(http.MethodGet)
 
-	// Public auth routes (no JWT required)
-	authHandler := infraHTTP.NewAuthHandler(authService)
+	// Public auth routes
 	r.HandleFunc("/auth/register", authHandler.HandleRegister).Methods(http.MethodPost)
 	r.HandleFunc("/auth/login", authHandler.HandleLogin).Methods(http.MethodPost)
 	r.HandleFunc("/auth/refresh", authHandler.HandleRefresh).Methods(http.MethodPost)
 
-	// Fix #1: Protected routes — Apply Auth middleware
+	// Protected routes
 	protected := r.PathPrefix("").Subrouter()
 	protected.Use(middleware.Auth(jwtSecret))
+
 	protected.HandleFunc("/auth/logout", authHandler.HandleLogout).Methods(http.MethodPost)
-	// Future protected routes go here (PR-004: presentations, slides, etc.)
+
+	// Presentations
+	protected.HandleFunc("/presentations", presentationHandler.HandleList).Methods(http.MethodGet)
+	protected.HandleFunc("/presentations", presentationHandler.HandleCreate).Methods(http.MethodPost)
+	protected.HandleFunc("/presentations/{id}", presentationHandler.HandleGet).Methods(http.MethodGet)
+	protected.HandleFunc("/presentations/{id}", presentationHandler.HandleUpdate).Methods(http.MethodPut)
+	protected.HandleFunc("/presentations/{id}", presentationHandler.HandleDelete).Methods(http.MethodDelete)
+
+	// Slides
+	protected.HandleFunc("/presentations/{id}/slides", slideHandler.HandleList).Methods(http.MethodGet)
+	protected.HandleFunc("/presentations/{id}/slides", slideHandler.HandleCreate).Methods(http.MethodPost)
+	protected.HandleFunc("/presentations/{id}/slides/reorder", slideHandler.HandleReorder).Methods(http.MethodPut)
+	protected.HandleFunc("/presentations/{id}/slides/{slideId}", slideHandler.HandleGet).Methods(http.MethodGet)
+	protected.HandleFunc("/presentations/{id}/slides/{slideId}", slideHandler.HandleUpdate).Methods(http.MethodPut)
+	protected.HandleFunc("/presentations/{id}/slides/{slideId}", slideHandler.HandleDelete).Methods(http.MethodDelete)
 
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 
-	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: r,
-	}
+	srv := &http.Server{Addr: ":" + port, Handler: r}
 
-	// Graceful shutdown
 	go func() {
 		quit := make(chan os.Signal, 1)
 		signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)

--- a/services/api/internal/application/presentation/usecase.go
+++ b/services/api/internal/application/presentation/usecase.go
@@ -1,0 +1,65 @@
+package presentation
+
+import (
+	"context"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainSlide "github.com/ko-tarou/presentsai/services/api/internal/domain/slide"
+	domainUser "github.com/ko-tarou/presentsai/services/api/internal/domain/user"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+type UseCase struct {
+	repo      domainPresentation.Repository
+	slideRepo domainSlide.Repository
+}
+
+func NewUseCase(repo domainPresentation.Repository, slideRepo domainSlide.Repository) *UseCase {
+	return &UseCase{repo: repo, slideRepo: slideRepo}
+}
+
+type CreateInput struct {
+	OwnerID string
+	Title   string
+}
+
+func (uc *UseCase) Create(ctx context.Context, in CreateInput) (*domainPresentation.Presentation, error) {
+	p := domainPresentation.New(domainUser.ID(in.OwnerID), in.Title)
+	if err := uc.repo.Create(ctx, p); err != nil {
+		return nil, err
+	}
+	s := domainSlide.New(p.ID, 0)
+	_ = uc.slideRepo.Create(ctx, s)
+	return p, nil
+}
+
+func (uc *UseCase) List(ctx context.Context, ownerID string, limit, offset int) ([]*domainPresentation.Presentation, int64, error) {
+	return uc.repo.FindByOwner(ctx, ownerID, limit, offset)
+}
+
+func (uc *UseCase) Get(ctx context.Context, id, ownerID string) (*domainPresentation.Presentation, error) {
+	p, err := uc.repo.FindByID(ctx, domainPresentation.ID(id))
+	if err != nil {
+		return nil, err
+	}
+	if string(p.OwnerID) != ownerID {
+		return nil, sharedErr.ErrForbidden
+	}
+	return p, nil
+}
+
+func (uc *UseCase) Update(ctx context.Context, id, ownerID, title string) (*domainPresentation.Presentation, error) {
+	p, err := uc.Get(ctx, id, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	p.Title = title
+	return p, uc.repo.Update(ctx, p)
+}
+
+func (uc *UseCase) Delete(ctx context.Context, id, ownerID string) error {
+	if _, err := uc.Get(ctx, id, ownerID); err != nil {
+		return err
+	}
+	return uc.repo.Delete(ctx, domainPresentation.ID(id))
+}

--- a/services/api/internal/application/slide/usecase.go
+++ b/services/api/internal/application/slide/usecase.go
@@ -1,0 +1,82 @@
+package slide
+
+import (
+	"context"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainSlide "github.com/ko-tarou/presentsai/services/api/internal/domain/slide"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+type UseCase struct {
+	repo             domainSlide.Repository
+	presentationRepo domainPresentation.Repository
+}
+
+func NewUseCase(repo domainSlide.Repository, presentationRepo domainPresentation.Repository) *UseCase {
+	return &UseCase{repo: repo, presentationRepo: presentationRepo}
+}
+
+func (uc *UseCase) ownerCheck(ctx context.Context, presentationID, ownerID string) error {
+	p, err := uc.presentationRepo.FindByID(ctx, domainPresentation.ID(presentationID))
+	if err != nil {
+		return err
+	}
+	if string(p.OwnerID) != ownerID {
+		return sharedErr.ErrForbidden
+	}
+	return nil
+}
+
+func (uc *UseCase) List(ctx context.Context, presentationID, ownerID string) ([]*domainSlide.Slide, error) {
+	if err := uc.ownerCheck(ctx, presentationID, ownerID); err != nil {
+		return nil, err
+	}
+	return uc.repo.FindByPresentation(ctx, presentationID)
+}
+
+func (uc *UseCase) Get(ctx context.Context, id, ownerID string) (*domainSlide.Slide, error) {
+	s, err := uc.repo.FindByID(ctx, domainSlide.ID(id))
+	if err != nil {
+		return nil, err
+	}
+	if err := uc.ownerCheck(ctx, string(s.PresentationID), ownerID); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (uc *UseCase) Create(ctx context.Context, presentationID, ownerID string) (*domainSlide.Slide, error) {
+	if err := uc.ownerCheck(ctx, presentationID, ownerID); err != nil {
+		return nil, err
+	}
+	existing, err := uc.repo.FindByPresentation(ctx, presentationID)
+	if err != nil {
+		return nil, err
+	}
+	s := domainSlide.New(domainPresentation.ID(presentationID), len(existing))
+	return s, uc.repo.Create(ctx, s)
+}
+
+func (uc *UseCase) UpdateContent(ctx context.Context, id, ownerID string, content domainSlide.Content) (*domainSlide.Slide, error) {
+	s, err := uc.Get(ctx, id, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	s.Content = content
+	return s, uc.repo.Update(ctx, s)
+}
+
+func (uc *UseCase) Delete(ctx context.Context, id, ownerID string) error {
+	if _, err := uc.Get(ctx, id, ownerID); err != nil {
+		return err
+	}
+	return uc.repo.Delete(ctx, domainSlide.ID(id))
+}
+
+func (uc *UseCase) Reorder(ctx context.Context, presentationID, ownerID string, positions map[string]int) error {
+	if err := uc.ownerCheck(ctx, presentationID, ownerID); err != nil {
+		return err
+	}
+	return uc.repo.ReorderSlides(ctx, presentationID, positions)
+}

--- a/services/api/internal/infrastructure/http/helpers.go
+++ b/services/api/internal/infrastructure/http/helpers.go
@@ -2,7 +2,10 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
 )
 
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
@@ -13,4 +16,19 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeHTTPError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, sharedErr.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not found")
+	case errors.Is(err, sharedErr.ErrForbidden):
+		writeError(w, http.StatusForbidden, "forbidden")
+	case errors.Is(err, sharedErr.ErrUnauthorized):
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+	case errors.Is(err, sharedErr.ErrAlreadyExists):
+		writeError(w, http.StatusConflict, "already exists")
+	default:
+		writeError(w, http.StatusInternalServerError, "internal server error")
+	}
 }

--- a/services/api/internal/infrastructure/http/presentation_handler.go
+++ b/services/api/internal/infrastructure/http/presentation_handler.go
@@ -1,0 +1,87 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	appPresentation "github.com/ko-tarou/presentsai/services/api/internal/application/presentation"
+	"github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http/middleware"
+)
+
+type PresentationHandler struct {
+	uc *appPresentation.UseCase
+}
+
+func NewPresentationHandler(uc *appPresentation.UseCase) *PresentationHandler {
+	return &PresentationHandler{uc: uc}
+}
+
+func (h *PresentationHandler) HandleList(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	items, total, err := h.uc.List(r.Context(), ownerID, 50, 0)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list presentations")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"items": items, "total": total})
+}
+
+func (h *PresentationHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		req.Title = "Untitled"
+	}
+	if req.Title == "" {
+		req.Title = "Untitled"
+	}
+	p, err := h.uc.Create(r.Context(), appPresentation.CreateInput{OwnerID: ownerID, Title: req.Title})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create presentation")
+		return
+	}
+	writeJSON(w, http.StatusCreated, p)
+}
+
+func (h *PresentationHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["id"]
+	p, err := h.uc.Get(r.Context(), id, ownerID)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+func (h *PresentationHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["id"]
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Title == "" {
+		writeError(w, http.StatusBadRequest, "title is required")
+		return
+	}
+	p, err := h.uc.Update(r.Context(), id, ownerID, req.Title)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+func (h *PresentationHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["id"]
+	if err := h.uc.Delete(r.Context(), id, ownerID); err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/services/api/internal/infrastructure/http/slide_handler.go
+++ b/services/api/internal/infrastructure/http/slide_handler.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	appSlide "github.com/ko-tarou/presentsai/services/api/internal/application/slide"
+	domainSlide "github.com/ko-tarou/presentsai/services/api/internal/domain/slide"
+	"github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http/middleware"
+)
+
+type SlideHandler struct {
+	uc *appSlide.UseCase
+}
+
+func NewSlideHandler(uc *appSlide.UseCase) *SlideHandler {
+	return &SlideHandler{uc: uc}
+}
+
+func (h *SlideHandler) HandleList(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	presentationID := mux.Vars(r)["id"]
+	slides, err := h.uc.List(r.Context(), presentationID, ownerID)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"items": slides})
+}
+
+func (h *SlideHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	presentationID := mux.Vars(r)["id"]
+	s, err := h.uc.Create(r.Context(), presentationID, ownerID)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, s)
+}
+
+func (h *SlideHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["slideId"]
+	s, err := h.uc.Get(r.Context(), id, ownerID)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s)
+}
+
+func (h *SlideHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["slideId"]
+	var req struct {
+		Content domainSlide.Content `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	s, err := h.uc.UpdateContent(r.Context(), id, ownerID, req.Content)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s)
+}
+
+func (h *SlideHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["slideId"]
+	if err := h.uc.Delete(r.Context(), id, ownerID); err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *SlideHandler) HandleReorder(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	presentationID := mux.Vars(r)["id"]
+	var req struct {
+		Positions map[string]int `json:"positions"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Positions) == 0 {
+		writeError(w, http.StatusBadRequest, "positions map is required")
+		return
+	}
+	if err := h.uc.Reorder(r.Context(), presentationID, ownerID, req.Positions); err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
## Summary
- Application use case layer: PresentationUseCase + SlideUseCase
- 11 REST endpoints, all behind JWT auth with ownership check

## Endpoints
| Method | Path |
|--------|------|
| GET/POST | /presentations |
| GET/PUT/DELETE | /presentations/:id |
| GET/POST | /presentations/:id/slides |
| PUT | /presentations/:id/slides/reorder |
| GET/PUT/DELETE | /presentations/:id/slides/:slideId |

🤖 Generated with [Claude Code](https://claude.com/claude-code)