### PR TITLE
feat(web): auth flow + dashboard + presentation management

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,6 +72,7 @@ services:
       NEXT_PUBLIC_COLLAB_URL: ws://localhost/ws/collab
       NEXT_PUBLIC_REALTIME_URL: ws://localhost/ws/realtime
       NEXT_PUBLIC_ASSETS_URL: http://localhost/assets
+      INTERNAL_API_URL: http://api:8080
     ports:
       - "3000:3000"
     volumes:

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  async rewrites() {
+    const apiUrl = process.env.INTERNAL_API_URL ?? "http://localhost:8080";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiUrl}/:path*`,
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/web/src/app/(auth)/dashboard/page.tsx
+++ b/web/src/app/(auth)/dashboard/page.tsx
@@ -1,8 +1,95 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { presentationsApi, type Presentation } from "@shared/api/presentations";
+
 export default function DashboardPage() {
+  const { accessToken } = useAuthStore();
+  const router = useRouter();
+  const [presentations, setPresentations] = useState<Presentation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+
+  const loadPresentations = useCallback(async () => {
+    if (!accessToken) return;
+    try {
+      const res = await presentationsApi.list(accessToken);
+      setPresentations(res.items ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => { loadPresentations(); }, [loadPresentations]);
+
+  async function handleCreate() {
+    if (!accessToken) return;
+    setCreating(true);
+    try {
+      const p = await presentationsApi.create(accessToken, "Untitled");
+      router.push(`/editor/${p.id}`);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!accessToken) return;
+    await presentationsApi.delete(accessToken, id);
+    setPresentations((prev) => prev.filter((p) => p.id !== id));
+  }
+
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-      <p className="mt-2 text-gray-500">Coming in PR-005</p>
+    <main className="min-h-screen bg-gray-50">
+      <header className="flex items-center justify-between border-b bg-white px-6 py-4">
+        <h1 className="text-lg font-bold text-gray-900">PresentsAI</h1>
+        <button
+          onClick={handleCreate}
+          disabled={creating}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {creating ? "作成中..." : "+ 新しいプレゼンテーション"}
+        </button>
+      </header>
+
+      <div className="mx-auto max-w-6xl p-6">
+        {loading ? (
+          <div className="flex justify-center py-24">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+          </div>
+        ) : presentations.length === 0 ? (
+          <div className="flex flex-col items-center py-24 text-center">
+            <svg className="mb-4 h-16 w-16 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7" />
+            </svg>
+            <p className="text-xl font-semibold text-gray-600">プレゼンテーションがありません</p>
+            <p className="mt-2 text-sm text-gray-400">上のボタンから最初のプレゼンテーションを作成しましょう</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            {presentations.map((p) => (
+              <div key={p.id} className="group relative rounded-xl border bg-white shadow-sm transition hover:shadow-md">
+                <button onClick={() => router.push(`/editor/${p.id}`)} className="block w-full p-4 text-left">
+                  <div className="mb-3 aspect-video w-full rounded-lg bg-gradient-to-br from-blue-50 to-gray-100" />
+                  <p className="truncate text-sm font-medium text-gray-900">{p.title}</p>
+                  <p className="mt-1 text-xs text-gray-400">
+                    {new Date(p.updatedAt).toLocaleDateString("ja-JP")}
+                  </p>
+                </button>
+                <button
+                  onClick={() => handleDelete(p.id)}
+                  className="absolute right-2 top-2 hidden rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-500 group-hover:block"
+                  aria-label="削除"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/web/src/app/(auth)/layout.tsx
+++ b/web/src/app/(auth)/layout.tsx
@@ -1,7 +1,8 @@
-export default function AuthLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+"use client";
+import { useRequireAuth } from "@shared/hooks/useAuth";
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useRequireAuth();
+  if (!isAuthenticated) return null;
   return <>{children}</>;
 }

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,9 +1,89 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { authApi } from "@shared/api/auth";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+
 export default function LoginPage() {
+  const router = useRouter();
+  const { setTokens } = useAuthStore();
+  const [tab, setTab] = useState<"login" | "register">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const pair =
+        tab === "login"
+          ? await authApi.login(email, password)
+          : await authApi.register(email, password, displayName);
+      setTokens(pair.accessToken, pair.refreshToken);
+      router.push("/dashboard");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-sm">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-md">
         <h1 className="mb-6 text-2xl font-bold text-gray-900">PresentsAI</h1>
-        <p className="text-gray-500">Authentication — coming in PR-003</p>
+        <div className="mb-6 flex rounded-lg bg-gray-100 p-1">
+          {(["login", "register"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`flex-1 rounded-md py-1.5 text-sm font-medium transition-colors ${
+                tab === t ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {t === "login" ? "ログイン" : "新規登録"}
+            </button>
+          ))}
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {tab === "register" && (
+            <input
+              type="text"
+              placeholder="表示名"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+            />
+          )}
+          <input
+            type="email"
+            placeholder="メールアドレス"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+          />
+          <input
+            type="password"
+            placeholder={tab === "register" ? "パスワード（8文字以上）" : "パスワード"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? "処理中..." : tab === "login" ? "ログイン" : "アカウント作成"}
+          </button>
+        </form>
       </div>
     </main>
   );

--- a/web/src/features/dashboard/stores/authStore.ts
+++ b/web/src/features/dashboard/stores/authStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  userId: string | null;
+  setTokens: (access: string, refresh: string) => void;
+  clearTokens: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      refreshToken: null,
+      userId: null,
+      setTokens: (access, refresh) => {
+        try {
+          const payload = JSON.parse(atob(access.split(".")[1]));
+          set({ accessToken: access, refreshToken: refresh, userId: payload.sub as string });
+        } catch {
+          set({ accessToken: access, refreshToken: refresh, userId: null });
+        }
+      },
+      clearTokens: () =>
+        set({ accessToken: null, refreshToken: null, userId: null }),
+    }),
+    { name: "presentsai-auth" }
+  )
+);

--- a/web/src/shared/api/auth.ts
+++ b/web/src/shared/api/auth.ts
@@ -1,0 +1,23 @@
+import { apiClient } from "./api-client";
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+export const authApi = {
+  register: (email: string, password: string, displayName: string) =>
+    apiClient.post<TokenPair>("/auth/register", { email, password, displayName }),
+
+  login: (email: string, password: string) =>
+    apiClient.post<TokenPair>("/auth/login", { email, password }),
+
+  refresh: (refreshToken: string) =>
+    apiClient.post<TokenPair>("/auth/refresh", { refreshToken }),
+
+  logout: (accessToken: string) =>
+    apiClient.delete<void>("/auth/logout", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }),
+};

--- a/web/src/shared/api/presentations.ts
+++ b/web/src/shared/api/presentations.ts
@@ -1,0 +1,43 @@
+import { apiClient } from "./api-client";
+
+export interface Presentation {
+  id: string;
+  ownerId: string;
+  title: string;
+  thumbnailUrl: string;
+  slideCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PresentationsListResponse {
+  items: Presentation[];
+  total: number;
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export const presentationsApi = {
+  list: (token: string) =>
+    apiClient.get<PresentationsListResponse>("/presentations", {
+      headers: authHeaders(token),
+    }),
+  create: (token: string, title: string) =>
+    apiClient.post<Presentation>("/presentations", { title }, {
+      headers: authHeaders(token),
+    }),
+  get: (token: string, id: string) =>
+    apiClient.get<Presentation>(`/presentations/${id}`, {
+      headers: authHeaders(token),
+    }),
+  update: (token: string, id: string, title: string) =>
+    apiClient.put<Presentation>(`/presentations/${id}`, { title }, {
+      headers: authHeaders(token),
+    }),
+  delete: (token: string, id: string) =>
+    apiClient.delete<void>(`/presentations/${id}`, {
+      headers: authHeaders(token),
+    }),
+};

--- a/web/src/shared/hooks/useAuth.ts
+++ b/web/src/shared/hooks/useAuth.ts
@@ -1,0 +1,17 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+
+export function useRequireAuth() {
+  const { accessToken } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!accessToken) {
+      router.replace("/login");
+    }
+  }, [accessToken, router]);
+
+  return { isAuthenticated: !!accessToken };
+}


### PR DESCRIPTION
## Summary
- Login/Register ページ (JWT 2-token, Zustand localStorage永続化)
- ダッシュボード: プレゼンテーション一覧・作成・削除
- Protected route guard (未認証 → /login リダイレクト)
- Next.js rewrite proxy: /api/* → api:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)