### PR TITLE
feat(editor): built-in slide templates

### DIFF
--- a/web/src/features/editor/components/Toolbar/TemplatePanel.tsx
+++ b/web/src/features/editor/components/Toolbar/TemplatePanel.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useState } from "react";
+import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStore } from "../../stores/slideStore";
+import { BUILT_IN_TEMPLATES } from "@lib/fabric/templates";
+import type { SlideContent } from "@shared/types/slide";
+
+export function TemplatePanel() {
+  const { canvas, activeSlideId } = useEditorStore();
+  const { updateSlide } = useSlideStore();
+  const [open, setOpen] = useState(false);
+  function apply(content: SlideContent) {
+    if (!canvas||!activeSlideId) return;
+    canvas.loadFromJSON(content).then(()=>{ canvas.renderAll(); updateSlide(activeSlideId, content as Record<string, unknown>); });
+    setOpen(false);
+  }
+  return (
+    <div className="relative">
+      <button onClick={()=>setOpen(!open)} className="flex h-10 items-center gap-1 rounded-lg px-3 text-sm hover:bg-blue-50" title="テンプレート">📑<span className="text-xs">テンプレ</span></button>
+      {open && (
+        <div className="absolute left-0 top-12 z-10 grid grid-cols-2 gap-2 rounded-xl border bg-white shadow-lg p-3 w-60">
+          {BUILT_IN_TEMPLATES.map(t=>(
+            <button key={t.id} onClick={()=>apply(t.content)} className="flex flex-col items-center gap-1 rounded-lg border p-3 text-xs hover:bg-blue-50 hover:border-blue-300">
+              <span className="text-2xl">{t.thumbnail}</span>
+              <span className="text-gray-600">{t.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/fabric/templates.ts
+++ b/web/src/lib/fabric/templates.ts
@@ -1,0 +1,18 @@
+import type { SlideContent } from "@shared/types/slide";
+export interface Template { id: string; name: string; thumbnail: string; content: SlideContent; }
+
+export const BUILT_IN_TEMPLATES: Template[] = [
+  { id:"blank", name:"ブランク", thumbnail:"⬜", content:{ version:"6.0.0", objects:[], background:"#ffffff" } },
+  { id:"title", name:"タイトル", thumbnail:"📋", content:{ version:"6.0.0", background:"#3B5BDB", objects:[
+    { type:"textbox",version:"6.0.0",left:100,top:260,width:1080,fontSize:56,fontWeight:"bold",fill:"#ffffff",textAlign:"center",text:"プレゼンテーションタイトル" },
+    { type:"textbox",version:"6.0.0",left:100,top:360,width:1080,fontSize:28,fill:"rgba(255,255,255,0.8)",textAlign:"center",text:"サブタイトルを入力" }
+  ]}},
+  { id:"two-col", name:"2カラム", thumbnail:"📰", content:{ version:"6.0.0", background:"#ffffff", objects:[
+    { type:"textbox",version:"6.0.0",left:60,top:40,width:1160,fontSize:36,fontWeight:"bold",fill:"#212529",text:"セクションタイトル" },
+    { type:"rect",version:"6.0.0",left:60,top:120,width:550,height:520,fill:"#f1f3f5",rx:8,ry:8 },
+    { type:"rect",version:"6.0.0",left:670,top:120,width:550,height:520,fill:"#f1f3f5",rx:8,ry:8 }
+  ]}},
+  { id:"dark", name:"ダーク", thumbnail:"🌙", content:{ version:"6.0.0", background:"#1a1b1e", objects:[
+    { type:"textbox",version:"6.0.0",left:100,top:280,width:1080,fontSize:52,fontWeight:"bold",fill:"#ffffff",textAlign:"center",text:"ダークテーマスライド" }
+  ]}}
+];


### PR DESCRIPTION
4 built-in templates: blank, title, two-column, dark. 🤖 Generated with Claude Code