### PR TITLE
feat(editor): reusable component library

### DIFF
--- a/web/src/features/editor/components/Toolbar/ComponentPanel.tsx
+++ b/web/src/features/editor/components/Toolbar/ComponentPanel.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState } from "react";
+import { useEditorStore } from "../../stores/editorStore";
+import { globalComponentLibrary, createComponentFromSelection } from "@lib/fabric/components";
+
+export function ComponentPanel() {
+  const { canvas } = useEditorStore();
+  const [components, setComponents] = useState(() => globalComponentLibrary.list());
+  const [name, setName] = useState("");
+  const [open, setOpen] = useState(false);
+
+  async function saveAsComponent() {
+    if (!canvas || !name.trim()) return;
+    await createComponentFromSelection(canvas, globalComponentLibrary, name);
+    setComponents(globalComponentLibrary.list());
+    setName("");
+  }
+
+  async function instantiate(id: string) {
+    if (!canvas) return;
+    await globalComponentLibrary.instantiate(canvas, id);
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative">
+      <button onClick={() => setOpen(!open)}
+        className="flex h-10 items-center gap-1 rounded-lg px-3 text-sm hover:bg-blue-50"
+        title="コンポーネント">
+        🧩<span className="text-xs">コンポ</span>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-12 z-10 rounded-xl border bg-white shadow-lg p-3 w-56 space-y-3">
+          <div>
+            <p className="text-xs font-medium text-gray-500 mb-1">選択中をコンポーネントとして保存</p>
+            <div className="flex gap-1">
+              <input value={name} onChange={e => setName(e.target.value)} placeholder="名前"
+                className="flex-1 rounded border px-2 py-1 text-xs focus:outline-none" />
+              <button onClick={saveAsComponent} className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700">保存</button>
+            </div>
+          </div>
+          {components.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-1">コンポーネント一覧</p>
+              {components.map(c => (
+                <button key={c.id} onClick={() => instantiate(c.id)}
+                  className="w-full rounded px-3 py-2 text-left text-xs hover:bg-gray-50">
+                  🧩 {c.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/fabric/components.ts
+++ b/web/src/lib/fabric/components.ts
@@ -1,0 +1,47 @@
+import { Canvas, FabricObject } from "fabric";
+
+export interface ComponentDefinition {
+  id: string;
+  name: string;
+  content: Record<string, unknown>; // Fabric.js JSON of the object
+}
+
+export class ComponentLibrary {
+  private components: Map<string, ComponentDefinition> = new Map();
+
+  register(def: ComponentDefinition) {
+    this.components.set(def.id, def);
+  }
+
+  list(): ComponentDefinition[] {
+    return Array.from(this.components.values());
+  }
+
+  async instantiate(canvas: Canvas, id: string): Promise<FabricObject | null> {
+    const def = this.components.get(id);
+    if (!def) return null;
+    await canvas.loadFromJSON({ version: "6.0.0", objects: [def.content] });
+    const obj = canvas.getObjects().at(-1);
+    if (obj) {
+      (obj as FabricObject & { _componentId?: string })._componentId = id;
+      canvas.setActiveObject(obj);
+      canvas.renderAll();
+    }
+    return obj ?? null;
+  }
+}
+
+export const globalComponentLibrary = new ComponentLibrary();
+
+export async function createComponentFromSelection(
+  canvas: Canvas,
+  library: ComponentLibrary,
+  name: string
+): Promise<string | null> {
+  const obj = canvas.getActiveObject();
+  if (!obj) return null;
+  const id = `comp-${Date.now()}`;
+  const json = obj.toJSON() as Record<string, unknown>;
+  library.register({ id, name, content: json });
+  return id;
+}


### PR DESCRIPTION
Save canvas selections as named components, re-instantiate from panel. 🤖 Generated with Claude Code