### PR TITLE
feat(editor): debounced auto-save (2s debounce)

### DIFF
--- a/web/src/features/editor/hooks/useCanvas.ts
+++ b/web/src/features/editor/hooks/useCanvas.ts
@@ -4,35 +4,62 @@ import { Canvas } from "fabric";
 import { createCanvas, loadFromJSON, toJSON, fitToContainer } from "@lib/fabric/canvas";
 import { useEditorStore } from "../stores/editorStore";
 import { useSlideStore } from "../stores/slideStore";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { slidesApi } from "@shared/api/slides";
+import type { SlideContent } from "@shared/types/slide";
+
+const AUTOSAVE_DELAY = 2000; // 2 seconds debounce
 
 export function useCanvas(containerRef: React.RefObject<HTMLDivElement | null>) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const fabricRef = useRef<Canvas | null>(null);
-  const { setCanvas, setDirty, setZoom, activeSlideId } = useEditorStore();
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { setCanvas, setDirty, setZoom, activeSlideId, presentationId } = useEditorStore();
   const { slides, updateSlide } = useSlideStore();
+  const { accessToken } = useAuthStore();
 
-  // Initialize canvas
+  const saveToServer = useCallback(async (canvas: Canvas, slideId: string, presId: string, token: string) => {
+    try {
+      const content = toJSON(canvas) as unknown as SlideContent;
+      await slidesApi.updateContent(token, presId, slideId, content);
+      setDirty(false);
+    } catch { /* ignore network errors during auto-save */ }
+  }, [setDirty]);
+
+  const scheduleAutoSave = useCallback((canvas: Canvas) => {
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = setTimeout(() => {
+      const { activeSlideId: sid, presentationId: pid } = useEditorStore.getState();
+      const { accessToken: tok } = useAuthStore.getState();
+      if (sid && pid && tok) {
+        saveToServer(canvas, sid, pid, tok);
+      }
+    }, AUTOSAVE_DELAY);
+  }, [saveToServer]);
+
   const initCanvas = useCallback((el: HTMLCanvasElement) => {
     if (fabricRef.current) fabricRef.current.dispose();
     const canvas = createCanvas(el);
     fabricRef.current = canvas;
     setCanvas(canvas);
 
-    canvas.on("object:modified", () => {
+    const onChanged = () => {
       setDirty(true);
-      if (activeSlideId) {
-        updateSlide(activeSlideId, toJSON(canvas));
-      }
-    });
-    canvas.on("object:added", () => setDirty(true));
-    canvas.on("object:removed", () => setDirty(true));
+      const { activeSlideId: sid } = useEditorStore.getState();
+      if (sid) updateSlide(sid, toJSON(canvas));
+      scheduleAutoSave(canvas);
+    };
+
+    canvas.on("object:modified", onChanged);
+    canvas.on("object:added", onChanged);
+    canvas.on("object:removed", onChanged);
 
     // Fit to container
     if (containerRef.current) {
       const scale = fitToContainer(canvas, containerRef.current.clientWidth);
       setZoom(scale);
     }
-  }, [setCanvas, setDirty, setZoom, activeSlideId, updateSlide, containerRef]);
+  }, [setCanvas, setDirty, setZoom, updateSlide, containerRef, scheduleAutoSave]);
 
   // Resize observer
   useEffect(() => {
@@ -52,9 +79,18 @@ export function useCanvas(containerRef: React.RefObject<HTMLDivElement | null>) 
     if (!fabricRef.current || !activeSlideId) return;
     const slide = slides.find((s) => s.id === activeSlideId);
     if (slide?.content) {
-      loadFromJSON(fabricRef.current, slide.content as unknown as Record<string, unknown>);
+      loadFromJSON(fabricRef.current, slide.content as unknown as Record<string, unknown>).then(() => {
+        fabricRef.current?.renderAll();
+      });
     }
   }, [activeSlideId, slides]);
+
+  // Cleanup autosave timer on unmount
+  useEffect(() => {
+    return () => {
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    };
+  }, []);
 
   return { canvasRef, fabricRef, initCanvas, zoom: useEditorStore.getState().zoom };
 }


### PR DESCRIPTION
## Summary
- Auto-save triggered on canvas object:modified/added/removed events
- 2-second debounce prevents excessive API calls during active editing
- Reads latest store state at save time (handles slide switches correctly)
- Autosave timer cleaned up on unmount

## Test plan
- [ ] Edit canvas object — after 2s, save happens automatically
- [ ] Rapid edits coalesce into single save
- [ ] Manual save button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)