### PR TITLE
feat(api): JWT auto-refresh on 401 with concurrent request queue

### DIFF
--- a/web/src/shared/api/api-client.ts
+++ b/web/src/shared/api/api-client.ts
@@ -3,20 +3,78 @@ const API_BASE =
     ? process.env.INTERNAL_API_URL ?? "http://api:8080"
     : "/api";
 
+let isRefreshing = false;
+let pendingQueue: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
+
+function flushQueue(token: string | null, error?: unknown) {
+  pendingQueue.forEach(({ resolve, reject }) => {
+    if (token) resolve(token);
+    else reject(error);
+  });
+  pendingQueue = [];
+}
+
+async function refreshAccessToken(): Promise<string> {
+  const { useAuthStore } = await import("@features/dashboard/stores/authStore");
+  const { refreshToken, setTokens, clearTokens } = useAuthStore.getState();
+  if (!refreshToken) throw new Error("No refresh token");
+
+  const res = await fetch(`${API_BASE}/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!res.ok) {
+    clearTokens();
+    throw new Error("Refresh failed");
+  }
+
+  const data = await res.json() as { accessToken: string; refreshToken: string };
+  setTokens(data.accessToken, data.refreshToken);
+  return data.accessToken;
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
+    headers: { "Content-Type": "application/json", ...options.headers },
   });
+
+  if (res.status === 401 && !path.startsWith("/auth/")) {
+    if (isRefreshing) {
+      return new Promise<T>((resolve, reject) => {
+        pendingQueue.push({
+          resolve: async (token) => {
+            const headers = { ...(options.headers as Record<string, string>), Authorization: `Bearer ${token}` };
+            const retried = await fetch(`${API_BASE}${path}`, { ...options, headers });
+            resolve((await retried.json()) as T);
+          },
+          reject,
+        });
+      });
+    }
+
+    isRefreshing = true;
+    try {
+      const newToken = await refreshAccessToken();
+      flushQueue(newToken);
+      isRefreshing = false;
+      const headers = { ...(options.headers as Record<string, string>), Authorization: `Bearer ${newToken}` };
+      const retried = await fetch(`${API_BASE}${path}`, { ...options, headers });
+      if (!retried.ok) throw new Error((await retried.json() as { message?: string }).message ?? "Request failed");
+      return retried.json() as Promise<T>;
+    } catch (e) {
+      flushQueue(null, e);
+      isRefreshing = false;
+      throw e;
+    }
+  }
 
   if (!res.ok) {
     const error = await res.json().catch(() => ({ message: res.statusText }));
     throw new Error((error as { message?: string }).message ?? "Request failed");
   }
-
   return res.json() as Promise<T>;
 }
 
@@ -24,17 +82,11 @@ export const apiClient = {
   get: <T>(path: string, options?: RequestInit) =>
     request<T>(path, { ...options, method: "GET" }),
   post: <T>(path: string, body: unknown, options?: RequestInit) =>
-    request<T>(path, {
-      ...options,
-      method: "POST",
-      body: JSON.stringify(body),
-    }),
+    request<T>(path, { ...options, method: "POST", body: JSON.stringify(body) }),
   put: <T>(path: string, body: unknown, options?: RequestInit) =>
-    request<T>(path, {
-      ...options,
-      method: "PUT",
-      body: JSON.stringify(body),
-    }),
+    request<T>(path, { ...options, method: "PUT", body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown, options?: RequestInit) =>
+    request<T>(path, { ...options, method: "PATCH", body: JSON.stringify(body) }),
   delete: <T>(path: string, options?: RequestInit) =>
     request<T>(path, { ...options, method: "DELETE" }),
 };


### PR DESCRIPTION
## Summary
- Intercept 401 responses, refresh token automatically, and retry
- Concurrent requests during refresh are queued (single refresh call)
- On refresh failure, clears tokens (forces re-login)
- Adds `patch()` method to apiClient

## Test plan
- [ ] Token expiry auto-triggers refresh transparently
- [ ] Concurrent requests during refresh all retry after token is renewed
- [ ] Invalid refresh token redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)