### PR TITLE
feat(realtime): wire collab provider and presenter socket

### DIFF
--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useRef, useState, useCallback } from "react";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { createCanvas, loadFromJSON, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+import { PresenterSocket } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
 export default function PresentPage({ params }: { params: Promise<{ id: string }> }) {
@@ -12,45 +13,64 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   const [cur, setCur] = useState(0);
   const [elapsed, setElapsed] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const presenterRef = useRef<PresenterSocket | null>(null);
 
   useEffect(() => {
     if (!accessToken) return;
     slidesApi.list(accessToken, id).then(r => setSlides(r.items as Slide[]));
+    presenterRef.current = new PresenterSocket(id);
+    return () => { presenterRef.current?.destroy(); };
   }, [id, accessToken]);
 
   useEffect(() => {
     if (!canvasRef.current || !slides[cur]) return;
-    const c = createCanvas(canvasRef.current, { width: SLIDE_WIDTH/2, height: SLIDE_HEIGHT/2 });
-    loadFromJSON(c, slides[cur].content as Record<string,unknown>);
+    const c = createCanvas(canvasRef.current, { width: SLIDE_WIDTH / 2, height: SLIDE_HEIGHT / 2 });
+    loadFromJSON(c, slides[cur].content as Record<string, unknown>);
     return () => { c.dispose(); };
   }, [cur, slides]);
 
   useEffect(() => {
-    const t = setInterval(() => setElapsed(e => e+1), 1000);
+    const t = setInterval(() => setElapsed(e => e + 1), 1000);
     return () => clearInterval(t);
   }, []);
 
-  const fmt = (s: number) => `${String(Math.floor(s/60)).padStart(2,"0")}:${String(s%60).padStart(2,"0")}`;
-  const next = useCallback(() => setCur(c => Math.min(c+1, slides.length-1)), [slides.length]);
-  const prev = useCallback(() => setCur(c => Math.max(c-1, 0)), []);
+  const fmt = (s: number) => `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+
+  const next = useCallback(() => {
+    setCur(c => {
+      const newIdx = Math.min(c + 1, slides.length - 1);
+      presenterRef.current?.sendSlideChange(newIdx);
+      return newIdx;
+    });
+  }, [slides.length]);
+
+  const prev = useCallback(() => {
+    setCur(c => {
+      const newIdx = Math.max(c - 1, 0);
+      presenterRef.current?.sendSlideChange(newIdx);
+      return newIdx;
+    });
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key==="ArrowRight"||e.key===" ") next();
-      if (e.key==="ArrowLeft") prev();
+      if (e.key === "ArrowRight" || e.key === " ") next();
+      if (e.key === "ArrowLeft") prev();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [next, prev]);
 
+  const currentNotes = slides[cur]?.notes;
+
   return (
     <div className="flex h-screen bg-gray-900 text-white">
       <div className="flex flex-1 flex-col items-center justify-center p-8">
-        <div className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef}/></div>
+        <div className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
         <div className="mt-4 flex items-center gap-6">
-          <button onClick={prev} disabled={cur===0} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">← 前へ</button>
-          <span className="text-sm text-gray-400">{cur+1} / {slides.length}</span>
-          <button onClick={next} disabled={cur>=slides.length-1} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">次へ →</button>
+          <button onClick={prev} disabled={cur === 0} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">← 前へ</button>
+          <span className="text-sm text-gray-400">{cur + 1} / {slides.length}</span>
+          <button onClick={next} disabled={cur >= slides.length - 1} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">次へ →</button>
         </div>
       </div>
       <aside className="w-64 border-l border-gray-700 flex flex-col p-4 gap-4">
@@ -59,8 +79,10 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
           <p className="text-3xl font-mono font-bold text-green-400">{fmt(elapsed)}</p>
         </div>
         <div>
-          <p className="text-xs text-gray-400 mb-2">スライド {cur+1} のノート</p>
-          <div className="rounded-xl bg-gray-800 p-3 text-sm text-gray-300 min-h-24">ここにノートが表示されます</div>
+          <p className="text-xs text-gray-400 mb-2">スライド {cur + 1} のノート</p>
+          <div className="rounded-xl bg-gray-800 p-3 text-sm text-gray-300 min-h-24 whitespace-pre-wrap">
+            {currentNotes || "ノートはありません"}
+          </div>
         </div>
       </aside>
     </div>

--- a/web/src/features/editor/hooks/useCollaboration.ts
+++ b/web/src/features/editor/hooks/useCollaboration.ts
@@ -1,0 +1,39 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { CollabProvider } from "@lib/collab/provider";
+import { useEditorStore } from "../stores/editorStore";
+import { useSlideStore } from "../stores/slideStore";
+import { loadFromJSON, toJSON } from "@lib/fabric/canvas";
+
+export function useCollaboration(presentationId: string | null) {
+  const providerRef = useRef<CollabProvider | null>(null);
+  const { canvas, activeSlideId } = useEditorStore();
+  const { updateSlide } = useSlideStore();
+
+  useEffect(() => {
+    if (!presentationId) return;
+    providerRef.current = new CollabProvider(presentationId, (msg) => {
+      if (msg.type === "update" && canvas && activeSlideId) {
+        try {
+          const data =
+            typeof msg.data === "string"
+              ? (JSON.parse(msg.data) as Record<string, unknown>)
+              : (msg.data as Record<string, unknown>);
+          loadFromJSON(canvas, data).then(() => {
+            canvas.renderAll();
+            updateSlide(activeSlideId, data);
+          });
+        } catch { /* ignore malformed messages */ }
+      }
+    });
+    return () => {
+      providerRef.current?.destroy();
+    };
+  }, [presentationId, canvas, activeSlideId, updateSlide]);
+
+  const broadcast = (slideContent: Record<string, unknown>) => {
+    providerRef.current?.send({ type: "update", data: slideContent });
+  };
+
+  return { broadcast };
+}


### PR DESCRIPTION
## Summary
- `useCollaboration` hook: subscribes to collab WebSocket and applies incoming canvas updates
- `PresenterSocket` now broadcasts slide-change index on next/prev navigation
- Presenter page reads `slide.notes` for speaker notes display

## Test plan
- [ ] Multiple editor tabs — canvas changes propagate in real time
- [ ] Presenter next/prev broadcasts slide-change to viewers
- [ ] Speaker notes shown in presenter sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)