### PR TITLE
feat(editor): slide thumbnail generation

### DIFF
--- a/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
+++ b/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
@@ -45,7 +45,22 @@ export function SlidePanel() {
                 i === currentIndex ? "border-blue-500" : "border-transparent hover:border-gray-300"
               }`}
             >
-              <div className="w-full rounded bg-white" style={{ aspectRatio: `${SLIDE_WIDTH}/${SLIDE_HEIGHT}` }} />
+              <div
+                className="w-full rounded bg-white overflow-hidden"
+                style={{ aspectRatio: `${SLIDE_WIDTH}/${SLIDE_HEIGHT}` }}
+              >
+                {slide.thumbnailUrl ? (
+                  <img
+                    src={slide.thumbnailUrl}
+                    alt={`スライド ${i + 1}`}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                    <span className="text-xs text-gray-300">{i + 1}</span>
+                  </div>
+                )}
+              </div>
               <span className="absolute bottom-1 left-1 text-xs text-gray-400">{i + 1}</span>
             </button>
             <button

--- a/web/src/features/editor/hooks/useCanvas.ts
+++ b/web/src/features/editor/hooks/useCanvas.ts
@@ -18,13 +18,25 @@ export function useCanvas(containerRef: React.RefObject<HTMLDivElement | null>) 
   const { slides, updateSlide } = useSlideStore();
   const { accessToken } = useAuthStore();
 
+  const updateThumbnail = useCallback(async (canvas: Canvas, slideId: string) => {
+    try {
+      const { generateThumbnail, uploadThumbnailDataURL } = await import("@lib/fabric/thumbnail");
+      const dataURL = generateThumbnail(canvas);
+      const url = await uploadThumbnailDataURL(dataURL, slideId);
+      if (url) {
+        useSlideStore.getState().updateSlide(slideId, { thumbnailUrl: url });
+      }
+    } catch { /* ignore thumbnail errors */ }
+  }, []);
+
   const saveToServer = useCallback(async (canvas: Canvas, slideId: string, presId: string, token: string) => {
     try {
       const content = toJSON(canvas) as unknown as SlideContent;
       await slidesApi.updateContent(token, presId, slideId, content);
       setDirty(false);
+      void updateThumbnail(canvas, slideId);
     } catch { /* ignore network errors during auto-save */ }
-  }, [setDirty]);
+  }, [setDirty, updateThumbnail]);
 
   const scheduleAutoSave = useCallback((canvas: Canvas) => {
     if (autosaveTimer.current) clearTimeout(autosaveTimer.current);

--- a/web/src/lib/fabric/thumbnail.ts
+++ b/web/src/lib/fabric/thumbnail.ts
@@ -1,0 +1,19 @@
+import type { Canvas } from "fabric";
+
+export function generateThumbnail(canvas: Canvas): string {
+  return canvas.toDataURL({ format: "jpeg", quality: 0.6, multiplier: 0.15 });
+}
+
+export async function uploadThumbnailDataURL(dataURL: string, slideId: string): Promise<string | null> {
+  try {
+    const blob = await (await fetch(dataURL)).blob();
+    const formData = new FormData();
+    formData.append("file", new File([blob], `thumb-${slideId}.jpg`, { type: "image/jpeg" }));
+    const res = await fetch("/assets/upload", { method: "POST", body: formData });
+    if (!res.ok) return null;
+    const { url } = await res.json() as { url: string };
+    return url;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- `thumbnail.ts`: `generateThumbnail()` creates JPEG dataURL at 15% scale via Fabric's `toDataURL`
- `uploadThumbnailDataURL()`: uploads to assets service after save
- `useCanvas`: triggers thumbnail update after each successful auto-save
- `SlidePanel`: renders thumbnail image when available, placeholder otherwise

## Test plan
- [ ] Edit a slide — thumbnail appears in panel after ~2s auto-save
- [ ] New slides show placeholder until first save
- [ ] Thumbnail updates on subsequent edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)