### PR TITLE
feat(editor): zoom controls + mouse wheel zoom + asset deletion

### DIFF
--- a/services/assets/cmd/assets/main.go
+++ b/services/assets/cmd/assets/main.go
@@ -93,6 +93,24 @@ func main() {
 		json.NewEncoder(w).Encode(map[string]string{"id": id, "url": url, "filename": filename})
 	}).Methods(http.MethodPost)
 
+	// Delete file
+	r.HandleFunc("/files/{filename}", func(w http.ResponseWriter, r *http.Request) {
+		filename := mux.Vars(r)["filename"]
+		// Sanitize: only allow alphanumeric, hyphen, underscore, and dot
+		for _, c := range filename {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.') {
+				http.Error(w, `{"error":"invalid filename"}`, http.StatusBadRequest)
+				return
+			}
+		}
+		path := filepath.Join(storagePath, filename)
+		if err := os.Remove(path); err != nil {
+			http.Error(w, `{"error":"file not found"}`, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}).Methods(http.MethodDelete)
+
 	// Serve files
 	r.PathPrefix("/files/").Handler(http.StripPrefix("/files/", http.FileServer(http.Dir(storagePath))))
 

--- a/web/src/features/editor/components/Canvas/Canvas.tsx
+++ b/web/src/features/editor/components/Canvas/Canvas.tsx
@@ -1,14 +1,30 @@
 "use client";
 import { useRef, useEffect } from "react";
 import { useCanvas } from "../../hooks/useCanvas";
+import { useEditorStore } from "../../stores/editorStore";
 
 export function EditorCanvas() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { canvasRef, initCanvas } = useCanvas(containerRef);
 
+  // Ctrl/Cmd + scroll to zoom
   useEffect(() => {
-    if (canvasRef.current) return; // already initialized
-  }, [canvasRef]);
+    const el = containerRef.current;
+    if (!el) return;
+    const handleWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      e.preventDefault();
+      const { canvas, zoom, setZoom } = useEditorStore.getState();
+      if (!canvas) return;
+      const delta = e.deltaY > 0 ? -0.05 : 0.05;
+      const newZoom = Math.max(0.1, Math.min(3, zoom + delta));
+      canvas.setZoom(newZoom);
+      canvas.renderAll();
+      setZoom(newZoom);
+    };
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, []);
 
   return (
     <div ref={containerRef} className="flex h-full items-center justify-center bg-gray-200 p-8">

--- a/web/src/features/editor/components/MenuBar/MenuBar.tsx
+++ b/web/src/features/editor/components/MenuBar/MenuBar.tsx
@@ -16,6 +16,7 @@ import { ComponentPanel } from "../Toolbar/ComponentPanel";
 import { ExportButton } from "../Toolbar/ExportButton";
 import { ViewOptions } from "../Toolbar/ViewOptions";
 import { AutoLayoutButton } from "../Toolbar/AutoLayoutButton";
+import { ZoomControls } from "../Toolbar/ZoomControls";
 import type { EditorTool } from "@shared/types/slide";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
@@ -96,6 +97,7 @@ export function MenuBar() {
 
       {/* View */}
       <ViewOptions />
+      <ZoomControls />
 
       <div className="flex-1" />
 

--- a/web/src/features/editor/components/Toolbar/ZoomControls.tsx
+++ b/web/src/features/editor/components/Toolbar/ZoomControls.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEditorStore } from "../../stores/editorStore";
+import { fitToContainer, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+
+export function ZoomControls() {
+  const { canvas, zoom, setZoom } = useEditorStore();
+
+  function adjustZoom(delta: number) {
+    if (!canvas) return;
+    const newZoom = Math.max(0.1, Math.min(3, zoom + delta));
+    canvas.setZoom(newZoom);
+    canvas.setWidth(SLIDE_WIDTH * newZoom);
+    canvas.setHeight(SLIDE_HEIGHT * newZoom);
+    canvas.renderAll();
+    setZoom(newZoom);
+  }
+
+  function resetZoom() {
+    if (!canvas) return;
+    const el = (canvas.wrapperEl as HTMLElement)?.parentElement?.parentElement;
+    if (el) {
+      const scale = fitToContainer(canvas, el.clientWidth);
+      setZoom(scale);
+    }
+  }
+
+  const pct = Math.round(zoom * 100);
+
+  return (
+    <div className="flex items-center gap-0.5 border-l pl-2">
+      <button
+        onClick={() => adjustZoom(-0.1)}
+        className="rounded px-2 py-1 text-sm hover:bg-gray-100"
+        title="縮小 (-)"
+      >
+        −
+      </button>
+      <button
+        onClick={resetZoom}
+        className="rounded px-2 py-1 text-xs font-mono hover:bg-gray-100 min-w-12 text-center"
+        title="ズームリセット"
+      >
+        {pct}%
+      </button>
+      <button
+        onClick={() => adjustZoom(0.1)}
+        className="rounded px-2 py-1 text-sm hover:bg-gray-100"
+        title="拡大 (+)"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/web/src/features/editor/components/Toolbar/index.ts
+++ b/web/src/features/editor/components/Toolbar/index.ts
@@ -10,3 +10,4 @@ export { ViewOptions } from "./ViewOptions";
 export { TransitionPanel } from "./TransitionPanel";
 export { AutoLayoutButton } from "./AutoLayoutButton";
 export { ImageUploadButton } from "./ImageUploadButton";
+export { ZoomControls } from "./ZoomControls";


### PR DESCRIPTION
## Summary
- `ZoomControls` component: minus/plus buttons and clickable % reset in MenuBar
- Ctrl/Cmd+scroll to zoom canvas (non-destructive, 0.1-3x range)
- `DELETE /files/:filename` in assets service with filename character sanitization

## Test plan
- [ ] ZoomControls buttons visible in toolbar, show correct %
- [ ] Ctrl+scroll zooms canvas in/out
- [ ] DELETE /files/test.jpg removes file, returns 204
- [ ] DELETE /files/../secret.txt returns 400 (sanitization)
- [ ] Go build passes: `cd services/assets && go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)