### PR TITLE
feat(sharing): full presentation member management

### DIFF
--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 
+	appMember "github.com/ko-tarou/presentsai/services/api/internal/application/member"
 	appPresentation "github.com/ko-tarou/presentsai/services/api/internal/application/presentation"
 	appSlide "github.com/ko-tarou/presentsai/services/api/internal/application/slide"
 	appUser "github.com/ko-tarou/presentsai/services/api/internal/application/user"
@@ -50,6 +51,8 @@ func main() {
 	authService := appUser.NewAuthService(userRepo, refreshRepo)
 	presentationUC := appPresentation.NewUseCase(presentationRepo, slideRepo)
 	slideUC := appSlide.NewUseCase(slideRepo, presentationRepo)
+	memberRepo := postgres.NewMemberRepository(db)
+	memberUC := appMember.NewUseCase(memberRepo, presentationRepo, userRepo)
 
 	// Handlers
 	authHandler := infraHTTP.NewAuthHandler(authService)
@@ -57,6 +60,7 @@ func main() {
 	slideHandler := infraHTTP.NewSlideHandler(slideUC)
 	commentHandler := infraHTTP.NewCommentHandler(db)
 	versionHandler := infraHTTP.NewVersionHandler(db)
+	memberHandler := infraHTTP.NewMemberHandler(memberUC)
 
 	r := mux.NewRouter()
 	r.Use(middleware.CORS)
@@ -101,6 +105,12 @@ func main() {
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}/versions", versionHandler.HandleList).Methods(http.MethodGet)
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}/versions", versionHandler.HandleCreate).Methods(http.MethodPost)
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}/versions/{versionId}/restore", versionHandler.HandleRestore).Methods(http.MethodPost)
+
+	// Members
+	protected.HandleFunc("/presentations/{id}/members", memberHandler.HandleList).Methods(http.MethodGet)
+	protected.HandleFunc("/presentations/{id}/members", memberHandler.HandleInvite).Methods(http.MethodPost)
+	protected.HandleFunc("/presentations/{id}/members/{userId}", memberHandler.HandleUpdateRole).Methods(http.MethodPut)
+	protected.HandleFunc("/presentations/{id}/members/{userId}", memberHandler.HandleRemove).Methods(http.MethodDelete)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/services/api/internal/application/member/usecase.go
+++ b/services/api/internal/application/member/usecase.go
@@ -1,0 +1,102 @@
+package member
+
+import (
+	"context"
+	"errors"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainUser "github.com/ko-tarou/presentsai/services/api/internal/domain/user"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+type Member struct {
+	ID             string
+	PresentationID string
+	UserID         string
+	Email          string
+	DisplayName    string
+	Role           string
+	CreatedAt      string
+}
+
+type Repository interface {
+	AddMember(ctx context.Context, presentationID, userID, role string) error
+	ListMembers(ctx context.Context, presentationID string) ([]Member, error)
+	GetMember(ctx context.Context, presentationID, userID string) (*Member, error)
+	UpdateRole(ctx context.Context, presentationID, userID, role string) error
+	RemoveMember(ctx context.Context, presentationID, userID string) error
+}
+
+type UseCase struct {
+	repo             Repository
+	presentationRepo domainPresentation.Repository
+	userRepo         domainUser.Repository
+}
+
+func NewUseCase(repo Repository, presentationRepo domainPresentation.Repository, userRepo domainUser.Repository) *UseCase {
+	return &UseCase{repo: repo, presentationRepo: presentationRepo, userRepo: userRepo}
+}
+
+func (uc *UseCase) isOwner(ctx context.Context, presentationID, callerID string) error {
+	p, err := uc.presentationRepo.FindByID(ctx, domainPresentation.ID(presentationID))
+	if err != nil {
+		return err
+	}
+	if string(p.OwnerID) != callerID {
+		return sharedErr.ErrForbidden
+	}
+	return nil
+}
+
+func (uc *UseCase) ListMembers(ctx context.Context, presentationID, callerID string) ([]Member, error) {
+	// allow any member to list
+	m, err := uc.repo.GetMember(ctx, presentationID, callerID)
+	if err != nil {
+		// also allow if owner
+		if ownerErr := uc.isOwner(ctx, presentationID, callerID); ownerErr != nil {
+			return nil, sharedErr.ErrForbidden
+		}
+	}
+	_ = m
+	return uc.repo.ListMembers(ctx, presentationID)
+}
+
+func (uc *UseCase) InviteByEmail(ctx context.Context, presentationID, callerID, email, role string) (*Member, error) {
+	if err := uc.isOwner(ctx, presentationID, callerID); err != nil {
+		return nil, err
+	}
+	if role != "editor" && role != "viewer" {
+		return nil, sharedErr.ErrInvalidInput
+	}
+	target, err := uc.userRepo.FindByEmail(ctx, email)
+	if err != nil {
+		return nil, errors.New("user not found")
+	}
+	if err := uc.repo.AddMember(ctx, presentationID, string(target.ID), role); err != nil {
+		return nil, err
+	}
+	return &Member{
+		PresentationID: presentationID,
+		UserID:         string(target.ID),
+		Email:          target.Email,
+		DisplayName:    target.DisplayName,
+		Role:           role,
+	}, nil
+}
+
+func (uc *UseCase) UpdateRole(ctx context.Context, presentationID, callerID, targetUserID, role string) error {
+	if err := uc.isOwner(ctx, presentationID, callerID); err != nil {
+		return err
+	}
+	if role != "editor" && role != "viewer" {
+		return sharedErr.ErrInvalidInput
+	}
+	return uc.repo.UpdateRole(ctx, presentationID, targetUserID, role)
+}
+
+func (uc *UseCase) RemoveMember(ctx context.Context, presentationID, callerID, targetUserID string) error {
+	if err := uc.isOwner(ctx, presentationID, callerID); err != nil {
+		return err
+	}
+	return uc.repo.RemoveMember(ctx, presentationID, targetUserID)
+}

--- a/services/api/internal/infrastructure/http/member_handler.go
+++ b/services/api/internal/infrastructure/http/member_handler.go
@@ -1,0 +1,85 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	appMember "github.com/ko-tarou/presentsai/services/api/internal/application/member"
+	"github.com/ko-tarou/presentsai/services/api/internal/infrastructure/http/middleware"
+)
+
+type MemberHandler struct {
+	uc *appMember.UseCase
+}
+
+func NewMemberHandler(uc *appMember.UseCase) *MemberHandler {
+	return &MemberHandler{uc: uc}
+}
+
+func (h *MemberHandler) HandleList(w http.ResponseWriter, r *http.Request) {
+	callerID := r.Context().Value(middleware.UserIDKey).(string)
+	presentationID := mux.Vars(r)["id"]
+	members, err := h.uc.ListMembers(r.Context(), presentationID, callerID)
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"items": members})
+}
+
+func (h *MemberHandler) HandleInvite(w http.ResponseWriter, r *http.Request) {
+	callerID := r.Context().Value(middleware.UserIDKey).(string)
+	presentationID := mux.Vars(r)["id"]
+	var req struct {
+		Email string `json:"email"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Email == "" {
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if req.Role == "" {
+		req.Role = "viewer"
+	}
+	member, err := h.uc.InviteByEmail(r.Context(), presentationID, callerID, req.Email, req.Role)
+	if err != nil {
+		if err.Error() == "user not found" {
+			writeError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, member)
+}
+
+func (h *MemberHandler) HandleUpdateRole(w http.ResponseWriter, r *http.Request) {
+	callerID := r.Context().Value(middleware.UserIDKey).(string)
+	vars := mux.Vars(r)
+	presentationID, targetUserID := vars["id"], vars["userId"]
+	var req struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Role == "" {
+		writeError(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	if err := h.uc.UpdateRole(r.Context(), presentationID, callerID, targetUserID, req.Role); err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *MemberHandler) HandleRemove(w http.ResponseWriter, r *http.Request) {
+	callerID := r.Context().Value(middleware.UserIDKey).(string)
+	vars := mux.Vars(r)
+	presentationID, targetUserID := vars["id"], vars["userId"]
+	if err := h.uc.RemoveMember(r.Context(), presentationID, callerID, targetUserID); err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/services/api/internal/infrastructure/postgres/member_repository.go
+++ b/services/api/internal/infrastructure/postgres/member_repository.go
@@ -1,0 +1,85 @@
+package postgres
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	appMember "github.com/ko-tarou/presentsai/services/api/internal/application/member"
+)
+
+type memberRepository struct{ db *gorm.DB }
+
+func NewMemberRepository(db *gorm.DB) appMember.Repository {
+	return &memberRepository{db: db}
+}
+
+func (r *memberRepository) AddMember(ctx context.Context, presentationID, userID, role string) error {
+	m := &PresentationMemberModel{
+		PresentationID: presentationID,
+		UserID:         userID,
+		Role:           role,
+	}
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *memberRepository) ListMembers(ctx context.Context, presentationID string) ([]appMember.Member, error) {
+	type row struct {
+		PresentationMemberModel
+		Email       string
+		DisplayName string
+	}
+	var rows []row
+	err := r.db.WithContext(ctx).
+		Table("presentation_members pm").
+		Select("pm.*, u.email, u.display_name").
+		Joins("JOIN users u ON u.id = pm.user_id").
+		Where("pm.presentation_id = ?", presentationID).
+		Order("pm.created_at ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appMember.Member, len(rows))
+	for i, r := range rows {
+		result[i] = appMember.Member{
+			ID:             r.PresentationMemberModel.ID,
+			PresentationID: r.PresentationMemberModel.PresentationID,
+			UserID:         r.PresentationMemberModel.UserID,
+			Email:          r.Email,
+			DisplayName:    r.DisplayName,
+			Role:           r.PresentationMemberModel.Role,
+			CreatedAt:      r.PresentationMemberModel.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		}
+	}
+	return result, nil
+}
+
+func (r *memberRepository) GetMember(ctx context.Context, presentationID, userID string) (*appMember.Member, error) {
+	var m PresentationMemberModel
+	err := r.db.WithContext(ctx).
+		Where("presentation_id = ? AND user_id = ?", presentationID, userID).
+		First(&m).Error
+	if err != nil {
+		return nil, err
+	}
+	return &appMember.Member{
+		ID:             m.ID,
+		PresentationID: m.PresentationID,
+		UserID:         m.UserID,
+		Role:           m.Role,
+	}, nil
+}
+
+func (r *memberRepository) UpdateRole(ctx context.Context, presentationID, userID, role string) error {
+	return r.db.WithContext(ctx).
+		Model(&PresentationMemberModel{}).
+		Where("presentation_id = ? AND user_id = ?", presentationID, userID).
+		Update("role", role).Error
+}
+
+func (r *memberRepository) RemoveMember(ctx context.Context, presentationID, userID string) error {
+	return r.db.WithContext(ctx).
+		Where("presentation_id = ? AND user_id = ?", presentationID, userID).
+		Delete(&PresentationMemberModel{}).Error
+}

--- a/web/src/app/(auth)/dashboard/page.tsx
+++ b/web/src/app/(auth)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { presentationsApi, type Presentation } from "@shared/api/presentations";
+import { ShareButton } from "@features/dashboard/components/ShareButton";
 
 export default function DashboardPage() {
   const { accessToken } = useAuthStore();
@@ -122,13 +123,16 @@ export default function DashboardPage() {
                     {new Date(p.updatedAt).toLocaleDateString("ja-JP")}
                   </p>
                 </button>
-                <button
-                  onClick={() => handleDelete(p.id)}
-                  className="absolute right-2 top-2 hidden rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-500 group-hover:block"
-                  aria-label="削除"
-                >
-                  ✕
-                </button>
+                <div className="absolute right-2 top-2 hidden gap-1 group-hover:flex">
+                  <ShareButton presentationId={p.id} presentationTitle={p.title} />
+                  <button
+                    onClick={() => handleDelete(p.id)}
+                    className="rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-500"
+                    aria-label="削除"
+                  >
+                    ✕
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { useEditorStore } from "@features/editor/stores/editorStore";
 import { useSlideStore } from "@features/editor/stores/slideStore";
 import { slidesApi } from "@shared/api/slides";
+import { presentationsApi } from "@shared/api/presentations";
+import { ShareButton } from "@features/dashboard/components/ShareButton";
 import { EditorCanvas } from "@features/editor/components/Canvas";
 import { SlidePanel } from "@features/editor/components/SlidePanel";
 import { MenuBar } from "@features/editor/components/MenuBar";
@@ -23,6 +25,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { setPresentationId, setActiveSlide, activeTool } = useEditorStore();
   const { setSlides, slides } = useSlideStore();
   const [aiTab, setAiTab] = useState<AITab>(null);
+  const [title, setTitle] = useState("Untitled");
 
   useEffect(() => {
     if (!accessToken || !id) return;
@@ -32,6 +35,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
       setSlides(slideList);
       if (slideList.length > 0) setActiveSlide(slideList[0].id);
     });
+    presentationsApi.get(accessToken, id).then(p => setTitle(p.title));
   }, [id, accessToken, setPresentationId, setSlides, setActiveSlide]);
 
   return (
@@ -41,6 +45,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
         <span className="text-sm font-bold text-gray-800">PresentsAI</span>
         <span className="text-xs text-gray-400">({slides.length} スライド)</span>
         <div className="flex-1" />
+        <ShareButton presentationId={id} presentationTitle={title} />
         <button
           onClick={() => setAiTab(prev => prev === "ai" ? null : "ai")}
           className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${aiTab === "ai" ? "bg-purple-100 text-purple-700" : "text-gray-600 hover:bg-gray-100"}`}

--- a/web/src/features/dashboard/components/ShareButton.tsx
+++ b/web/src/features/dashboard/components/ShareButton.tsx
@@ -1,50 +1,30 @@
 "use client";
 import { useState } from "react";
+import { ShareModal } from "./ShareModal";
 
-export function ShareButton({ presentationId }: { presentationId: string }) {
-  const [copied, setCopied] = useState(false);
+interface ShareButtonProps {
+  presentationId: string;
+  presentationTitle: string;
+}
+
+export function ShareButton({ presentationId, presentationTitle }: ShareButtonProps) {
   const [open, setOpen] = useState(false);
 
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const viewUrl = `${origin}/view/${presentationId}`;
-  const presentUrl = `${origin}/present/${presentationId}`;
-
-  async function copy(url: string) {
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-
   return (
-    <div className="relative">
-      <button onClick={() => setOpen(!open)}
-        className="rounded-lg border px-3 py-1.5 text-sm hover:bg-gray-50">
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-lg border px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      >
         🔗 共有
       </button>
       {open && (
-        <div className="absolute right-0 top-10 z-10 rounded-xl border bg-white shadow-lg p-4 w-72 space-y-3">
-          <div>
-            <p className="text-xs font-medium text-gray-500 mb-1">閲覧リンク（認証不要）</p>
-            <div className="flex gap-2">
-              <input value={viewUrl} readOnly className="flex-1 rounded border px-2 py-1 text-xs bg-gray-50" />
-              <button onClick={() => copy(viewUrl)}
-                className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700">
-                {copied ? "✓" : "コピー"}
-              </button>
-            </div>
-          </div>
-          <div>
-            <p className="text-xs font-medium text-gray-500 mb-1">プレゼンターリンク</p>
-            <div className="flex gap-2">
-              <input value={presentUrl} readOnly className="flex-1 rounded border px-2 py-1 text-xs bg-gray-50" />
-              <button onClick={() => copy(presentUrl)}
-                className="rounded bg-gray-600 px-2 py-1 text-xs text-white hover:bg-gray-700">
-                {copied ? "✓" : "コピー"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <ShareModal
+          presentationId={presentationId}
+          presentationTitle={presentationTitle}
+          onClose={() => setOpen(false)}
+        />
       )}
-    </div>
+    </>
   );
 }

--- a/web/src/features/dashboard/components/ShareModal.tsx
+++ b/web/src/features/dashboard/components/ShareModal.tsx
@@ -1,0 +1,218 @@
+"use client";
+import { useState, useEffect, useCallback } from "react";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { membersApi, type Member, type MemberRole } from "@shared/api/members";
+
+interface ShareModalProps {
+  presentationId: string;
+  presentationTitle: string;
+  onClose: () => void;
+}
+
+const ROLE_LABELS: Record<MemberRole, string> = {
+  owner: "オーナー",
+  editor: "編集者",
+  viewer: "閲覧者",
+};
+
+const ROLE_BADGE: Record<MemberRole, string> = {
+  owner: "bg-purple-100 text-purple-700",
+  editor: "bg-blue-100 text-blue-700",
+  viewer: "bg-gray-100 text-gray-600",
+};
+
+export function ShareModal({ presentationId, presentationTitle, onClose }: ShareModalProps) {
+  const { accessToken } = useAuthStore();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<MemberRole>("viewer");
+  const [inviting, setInviting] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState<"view" | "present" | null>(null);
+
+  const viewUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/view/${presentationId}`;
+  const presentUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/present/${presentationId}`;
+
+  const loadMembers = useCallback(async () => {
+    if (!accessToken) return;
+    try {
+      const res = await membersApi.list(accessToken, presentationId);
+      setMembers(res.items ?? []);
+    } catch { /* not yet shared — empty list is fine */ }
+    finally { setLoading(false); }
+  }, [accessToken, presentationId]);
+
+  useEffect(() => { loadMembers(); }, [loadMembers]);
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault();
+    if (!accessToken || !email.trim()) return;
+    setInviting(true);
+    setError("");
+    try {
+      const member = await membersApi.invite(accessToken, presentationId, email.trim(), role);
+      setMembers(prev => [...prev, member]);
+      setEmail("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "招待に失敗しました");
+    } finally { setInviting(false); }
+  }
+
+  async function handleRoleChange(member: Member, newRole: MemberRole) {
+    if (!accessToken || newRole === "owner") return;
+    try {
+      await membersApi.updateRole(accessToken, presentationId, member.userId, newRole);
+      setMembers(prev => prev.map(m => m.userId === member.userId ? { ...m, role: newRole } : m));
+    } catch { /* ignore */ }
+  }
+
+  async function handleRemove(member: Member) {
+    if (!accessToken) return;
+    try {
+      await membersApi.remove(accessToken, presentationId, member.userId);
+      setMembers(prev => prev.filter(m => m.userId !== member.userId));
+    } catch { /* ignore */ }
+  }
+
+  async function copyLink(url: string, type: "view" | "present") {
+    await navigator.clipboard.writeText(url);
+    setCopied(type);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  return (
+    // Modal backdrop
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-6 py-4">
+          <div>
+            <h2 className="text-base font-bold text-gray-900">共有設定</h2>
+            <p className="text-xs text-gray-500 mt-0.5 truncate max-w-72">{presentationTitle}</p>
+          </div>
+          <button onClick={onClose} className="rounded-full p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600">✕</button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          {/* Invite form */}
+          <div>
+            <p className="text-sm font-semibold text-gray-700 mb-3">ユーザーを招待</p>
+            <form onSubmit={handleInvite} className="flex gap-2">
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                placeholder="メールアドレスを入力..."
+                className="flex-1 rounded-lg border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                required
+              />
+              <select
+                value={role}
+                onChange={e => setRole(e.target.value as MemberRole)}
+                className="rounded-lg border px-2 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              >
+                <option value="viewer">閲覧者</option>
+                <option value="editor">編集者</option>
+              </select>
+              <button
+                type="submit"
+                disabled={inviting || !email.trim()}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
+              >
+                {inviting ? "招待中..." : "招待"}
+              </button>
+            </form>
+            {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+          </div>
+
+          {/* Members list */}
+          <div>
+            <p className="text-sm font-semibold text-gray-700 mb-3">メンバー ({members.length})</p>
+            {loading ? (
+              <p className="text-xs text-gray-400">読み込み中...</p>
+            ) : members.length === 0 ? (
+              <div className="rounded-xl bg-gray-50 py-6 text-center">
+                <p className="text-sm text-gray-400">まだ共有されていません</p>
+                <p className="text-xs text-gray-400 mt-1">メールアドレスを入力して招待しましょう</p>
+              </div>
+            ) : (
+              <ul className="space-y-2 max-h-52 overflow-y-auto">
+                {members.map(member => (
+                  <li key={member.userId} className="flex items-center gap-3 rounded-xl border p-3 hover:bg-gray-50">
+                    {/* Avatar */}
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700">
+                      {(member.displayName || member.email).charAt(0).toUpperCase()}
+                    </div>
+
+                    {/* Name / email */}
+                    <div className="flex-1 min-w-0">
+                      {member.displayName && (
+                        <p className="text-sm font-medium text-gray-800 truncate">{member.displayName}</p>
+                      )}
+                      <p className="text-xs text-gray-500 truncate">{member.email}</p>
+                    </div>
+
+                    {/* Role */}
+                    {member.role === "owner" ? (
+                      <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${ROLE_BADGE[member.role]}`}>
+                        {ROLE_LABELS[member.role]}
+                      </span>
+                    ) : (
+                      <select
+                        value={member.role}
+                        onChange={e => handleRoleChange(member, e.target.value as MemberRole)}
+                        className="rounded-lg border px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
+                      >
+                        <option value="viewer">閲覧者</option>
+                        <option value="editor">編集者</option>
+                      </select>
+                    )}
+
+                    {/* Remove */}
+                    {member.role !== "owner" && (
+                      <button
+                        onClick={() => handleRemove(member)}
+                        className="rounded-full p-1 text-gray-300 hover:bg-red-50 hover:text-red-500"
+                        title="削除"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Public links */}
+          <div>
+            <p className="text-sm font-semibold text-gray-700 mb-3">公開リンク</p>
+            <div className="space-y-2">
+              {[
+                { label: "閲覧用（認証不要）", url: viewUrl, type: "view" as const, color: "border-gray-200" },
+                { label: "プレゼンター用", url: presentUrl, type: "present" as const, color: "border-gray-200" },
+              ].map(({ label, url, type, color }) => (
+                <div key={type} className={`flex items-center gap-2 rounded-xl border ${color} p-3`}>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium text-gray-600">{label}</p>
+                    <p className="text-xs text-gray-400 truncate mt-0.5">{url}</p>
+                  </div>
+                  <button
+                    onClick={() => copyLink(url, type)}
+                    className="shrink-0 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-200"
+                  >
+                    {copied === type ? "✓ コピー済み" : "コピー"}
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/shared/api/members.ts
+++ b/web/src/shared/api/members.ts
@@ -1,0 +1,39 @@
+import { apiClient } from "./api-client";
+
+export type MemberRole = "owner" | "editor" | "viewer";
+
+export interface Member {
+  id: string;
+  presentationId: string;
+  userId: string;
+  email: string;
+  displayName: string;
+  role: MemberRole;
+  createdAt: string;
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export const membersApi = {
+  list: (token: string, presentationId: string) =>
+    apiClient.get<{ items: Member[] }>(`/presentations/${presentationId}/members`, {
+      headers: authHeaders(token),
+    }),
+
+  invite: (token: string, presentationId: string, email: string, role: MemberRole) =>
+    apiClient.post<Member>(`/presentations/${presentationId}/members`, { email, role }, {
+      headers: authHeaders(token),
+    }),
+
+  updateRole: (token: string, presentationId: string, userId: string, role: MemberRole) =>
+    apiClient.put<void>(`/presentations/${presentationId}/members/${userId}`, { role }, {
+      headers: authHeaders(token),
+    }),
+
+  remove: (token: string, presentationId: string, userId: string) =>
+    apiClient.delete<void>(`/presentations/${presentationId}/members/${userId}`, {
+      headers: authHeaders(token),
+    }),
+};


### PR DESCRIPTION
## Summary

プレゼンテーションの共有・メンバー管理機能を完全実装。

## Backend
| Endpoint | Method | 説明 |
|----------|--------|------|
| /presentations/:id/members | GET | メンバー一覧（users JOIN） |
| /presentations/:id/members | POST | メールで招待（viewer/editor） |
| /presentations/:id/members/:userId | PUT | ロール変更 |
| /presentations/:id/members/:userId | DELETE | メンバー削除 |

## Frontend
- **ShareModal**: メンバー一覧・招待フォーム・ロール変更・削除・公開リンクコピー
- **ShareButton**: ダッシュボードのカードとエディタのヘッダーに配置
- メンバーのアバター（イニシャル）・ロールバッジ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)