### PR TITLE
feat(design): Lucide toolbar icons + auth hydration fix

### DIFF
--- a/web/src/app/(auth)/layout.tsx
+++ b/web/src/app/(auth)/layout.tsx
@@ -2,7 +2,14 @@
 import { useRequireAuth } from "@shared/hooks/useAuth";
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useRequireAuth();
+  const { isAuthenticated, isReady } = useRequireAuth();
+  if (!isReady) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-subtle">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary-500 border-t-transparent" />
+      </div>
+    );
+  }
   if (!isAuthenticated) return null;
   return <>{children}</>;
 }

--- a/web/src/features/ai/components/AIPanel.tsx
+++ b/web/src/features/ai/components/AIPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Bot } from "lucide-react";
 import { useEditorStore } from "@features/editor/stores/editorStore";
 import { generateText, generateJSON } from "@lib/ai/client";
 import { Textbox } from "fabric";
@@ -38,22 +39,24 @@ export function AIPanel() {
 
   return (
     <div className="flex flex-col h-full p-4 gap-3">
-      <h2 className="text-sm font-semibold text-gray-700">🤖 AI アシスタント</h2>
-      <p className="text-xs text-gray-400">LFM2-2.6B ローカル</p>
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-content-primary">
+        <Bot className="h-4 w-4 text-primary-600" /> AI アシスタント
+      </h2>
+      <p className="text-xs text-content-tertiary">LFM2-2.6B ローカル</p>
       <div className="flex gap-1">
         {(["improve","generate","outline"] as const).map(m=>(
-          <button key={m} onClick={()=>setMode(m)} className={`flex-1 rounded py-1 text-xs font-medium ${mode===m?"bg-blue-600 text-white":"bg-gray-100 text-gray-600"}`}>
+          <button key={m} onClick={()=>setMode(m)} className={`flex-1 rounded-lg py-1 text-xs font-medium transition-colors ${mode===m?"bg-primary-600 text-white":"bg-surface-muted text-content-secondary hover:bg-surface-subtle"}`}>
             {m==="improve"?"改善":m==="generate"?"生成":"アウトライン"}
           </button>
         ))}
       </div>
       <textarea value={prompt} onChange={e=>setPrompt(e.target.value)} rows={4}
         placeholder={mode==="outline"?"テーマを入力...":"テキストを入力..."}
-        className="flex-1 rounded-lg border p-3 text-sm resize-none focus:border-blue-500 focus:outline-none"/>
-      <button onClick={run} disabled={loading||!prompt.trim()} className="rounded-lg bg-blue-600 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+        className="input flex-1 resize-none p-3 text-sm"/>
+      <button onClick={run} disabled={loading||!prompt.trim()} className="btn btn-primary w-full disabled:opacity-50">
         {loading?"生成中...":"実行"}
       </button>
-      {result && <div className="rounded-lg bg-gray-50 p-3 text-xs text-gray-700 max-h-40 overflow-y-auto whitespace-pre-wrap">{result}</div>}
+      {result && <div className="max-h-40 overflow-y-auto whitespace-pre-wrap rounded-lg bg-surface-muted p-3 text-xs text-content-secondary">{result}</div>}
     </div>
   );
 }

--- a/web/src/features/ai/components/PresentationReport.tsx
+++ b/web/src/features/ai/components/PresentationReport.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { BarChart3, CheckCircle2, TrendingUp } from "lucide-react";
 import { generateJSON } from "@lib/ai/client";
 
 interface Report {
@@ -29,30 +30,32 @@ export function PresentationReport({ transcript }: { transcript: string }) {
 
   return (
     <div className="p-4 space-y-4">
-      <h2 className="text-sm font-semibold text-gray-700">📊 発表後レポート</h2>
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-content-primary">
+        <BarChart3 className="h-4 w-4 text-primary-600" /> 発表後レポート
+      </h2>
       <button onClick={generate} disabled={loading || !transcript.trim()}
-        className="w-full rounded-lg bg-blue-600 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+        className="btn btn-primary w-full disabled:opacity-50">
         {loading ? "分析中..." : "レポートを生成"}
       </button>
       {report && (
         <div className="space-y-3">
-          <div className="rounded-xl bg-blue-50 p-3">
+          <div className="rounded-xl bg-primary-50 p-3">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs font-medium text-blue-700">総合スコア</span>
-              <span className="text-2xl font-bold text-blue-700">{report.score}</span>
+              <span className="text-xs font-medium text-primary-700">総合スコア</span>
+              <span className="text-2xl font-bold text-primary-700">{report.score}</span>
             </div>
-            <p className="text-xs text-blue-600">{report.summary}</p>
+            <p className="text-xs text-primary-600">{report.summary}</p>
           </div>
           {report.strengths.length > 0 && (
             <div>
-              <p className="text-xs font-medium text-green-700 mb-1">✅ 良かった点</p>
-              {report.strengths.map((s,i)=><p key={i} className="text-xs text-gray-600">• {s}</p>)}
+              <p className="mb-1 flex items-center gap-1.5 text-xs font-medium text-success-dark"><CheckCircle2 className="h-3.5 w-3.5" /> 良かった点</p>
+              {report.strengths.map((s,i)=><p key={i} className="text-xs text-content-secondary">• {s}</p>)}
             </div>
           )}
           {report.improvements.length > 0 && (
             <div>
-              <p className="text-xs font-medium text-orange-700 mb-1">📈 改善点</p>
-              {report.improvements.map((s,i)=><p key={i} className="text-xs text-gray-600">• {s}</p>)}
+              <p className="mb-1 flex items-center gap-1.5 text-xs font-medium text-warning-dark"><TrendingUp className="h-3.5 w-3.5" /> 改善点</p>
+              {report.improvements.map((s,i)=><p key={i} className="text-xs text-content-secondary">• {s}</p>)}
             </div>
           )}
         </div>

--- a/web/src/features/ai/components/RealtimeCoach.tsx
+++ b/web/src/features/ai/components/RealtimeCoach.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useRef, useCallback, useEffect } from "react";
+import { Mic, Play, Square, Type, Gauge, Lightbulb } from "lucide-react";
 import { generateText } from "@lib/ai/client";
 
 interface CoachingHint { text: string; type: "speed" | "filler" | "tip"; }
@@ -110,38 +111,40 @@ export function RealtimeCoach() {
 
   return (
     <div className="flex flex-col gap-3 p-4 h-full">
-      <h2 className="text-sm font-semibold text-gray-700">🎙️ リアルタイム AI コーチ</h2>
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-content-primary">
+        <Mic className="h-4 w-4 text-primary-600" /> リアルタイム AI コーチ
+      </h2>
 
-      <div className="flex items-center justify-between rounded-xl bg-gray-100 p-3">
+      <div className="flex items-center justify-between rounded-xl bg-surface-muted p-3">
         <div>
-          <p className="text-xs text-gray-500">経過時間</p>
-          <p className="font-mono text-lg font-bold text-gray-800">{fmt(elapsed)}</p>
+          <p className="text-xs text-content-tertiary">経過時間</p>
+          <p className="font-mono text-lg font-bold text-content-primary">{fmt(elapsed)}</p>
         </div>
         <button
           onClick={active ? stopCoaching : startCoaching}
-          className={`rounded-full px-4 py-2 text-sm font-semibold text-white ${active ? "bg-red-500 hover:bg-red-600" : "bg-green-500 hover:bg-green-600"}`}
+          className={`flex items-center gap-1.5 rounded-full px-4 py-2 text-sm font-semibold text-white transition-colors ${active ? "bg-error hover:bg-error-dark" : "bg-success hover:bg-success-dark"}`}
         >
-          {active ? "⏹ 停止" : "▶ 開始"}
+          {active ? <><Square className="h-4 w-4" /> 停止</> : <><Play className="h-4 w-4" /> 開始</>}
         </button>
       </div>
 
       {transcript && (
-        <div className="rounded-lg bg-blue-50 p-2 text-xs text-blue-700 italic">
+        <div className="rounded-lg bg-primary-50 p-2 text-xs italic text-primary-700">
           "{transcript}"
         </div>
       )}
 
       <div className="flex-1 space-y-2 overflow-y-auto">
         {hints.length === 0 ? (
-          <p className="text-xs text-gray-400">コーチングを開始すると、ここにリアルタイムアドバイスが表示されます</p>
+          <p className="text-xs text-content-tertiary">コーチングを開始すると、ここにリアルタイムアドバイスが表示されます</p>
         ) : (
           hints.map((h, i) => (
-            <div key={i} className={`rounded-lg p-2 text-xs ${
-              h.type==="filler" ? "bg-yellow-50 text-yellow-700 border border-yellow-200" :
-              h.type==="speed" ? "bg-orange-50 text-orange-700 border border-orange-200" :
-              "bg-green-50 text-green-700 border border-green-200"
+            <div key={i} className={`flex items-center gap-1.5 rounded-lg border p-2 text-xs ${
+              h.type==="filler" ? "border-warning-light bg-warning-light text-warning-dark" :
+              h.type==="speed" ? "border-warning-light bg-warning-light text-warning-dark" :
+              "border-success-light bg-success-light text-success-dark"
             }`}>
-              {h.type==="filler"?"🔤":h.type==="speed"?"⚡":"💡"} {h.text}
+              {h.type==="filler"?<Type className="h-3.5 w-3.5 shrink-0" />:h.type==="speed"?<Gauge className="h-3.5 w-3.5 shrink-0" />:<Lightbulb className="h-3.5 w-3.5 shrink-0" />} {h.text}
             </div>
           ))
         )}

--- a/web/src/features/dashboard/stores/authStore.ts
+++ b/web/src/features/dashboard/stores/authStore.ts
@@ -5,8 +5,10 @@ interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
   userId: string | null;
+  hasHydrated: boolean;
   setTokens: (access: string, refresh: string) => void;
   clearTokens: () => void;
+  setHasHydrated: (v: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -15,6 +17,7 @@ export const useAuthStore = create<AuthState>()(
       accessToken: null,
       refreshToken: null,
       userId: null,
+      hasHydrated: false,
       setTokens: (access, refresh) => {
         try {
           const payload = JSON.parse(atob(access.split(".")[1]));
@@ -25,7 +28,13 @@ export const useAuthStore = create<AuthState>()(
       },
       clearTokens: () =>
         set({ accessToken: null, refreshToken: null, userId: null }),
+      setHasHydrated: (v) => set({ hasHydrated: v }),
     }),
-    { name: "presentsai-auth" }
+    {
+      name: "presentsai-auth",
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    }
   )
 );

--- a/web/src/features/editor/components/Toolbar/AutoLayoutButton.tsx
+++ b/web/src/features/editor/components/Toolbar/AutoLayoutButton.tsx
@@ -1,28 +1,29 @@
 "use client";
+import { AlignHorizontalSpaceAround, AlignVerticalSpaceAround, AlignHorizontalDistributeCenter } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { applyAutoLayout, distributeObjects } from "@lib/fabric/tools/autoLayout";
 
 export function AutoLayoutButton() {
   const { canvas } = useEditorStore();
   return (
-    <div className="flex items-center gap-1 border-l pl-2">
+    <div className="flex items-center gap-1 border-l border-border pl-2">
       <button
         onClick={() => canvas && applyAutoLayout(canvas, { direction: "horizontal", gap: 12, padding: 0, align: "center" })}
         title="水平等間隔配置"
-        className="rounded px-2 py-1.5 text-xs hover:bg-gray-100">
-        ⇔
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <AlignHorizontalSpaceAround className="h-4 w-4" />
       </button>
       <button
         onClick={() => canvas && applyAutoLayout(canvas, { direction: "vertical", gap: 12, padding: 0, align: "center" })}
         title="垂直等間隔配置"
-        className="rounded px-2 py-1.5 text-xs hover:bg-gray-100">
-        ⇕
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <AlignVerticalSpaceAround className="h-4 w-4" />
       </button>
       <button
         onClick={() => canvas && distributeObjects(canvas, "horizontal")}
         title="水平均等分布"
-        className="rounded px-2 py-1.5 text-xs hover:bg-gray-100">
-        ||
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <AlignHorizontalDistributeCenter className="h-4 w-4" />
       </button>
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/BooleanToolbar.tsx
+++ b/web/src/features/editor/components/Toolbar/BooleanToolbar.tsx
@@ -1,25 +1,26 @@
 "use client";
+import { Combine, SquareMinus, Diamond, SquareDashed } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { performBoolean } from "@lib/fabric/tools/boolean";
 
-type BooleanOpLabel = { op: "union" | "subtract" | "intersect" | "exclude"; label: string; emoji: string };
+type BooleanOpLabel = { op: "union" | "subtract" | "intersect" | "exclude"; label: string; Icon: typeof Combine };
 
 const OPS: BooleanOpLabel[] = [
-  { op: "union", label: "合体", emoji: "🔵" },
-  { op: "subtract", label: "差分", emoji: "🔘" },
-  { op: "intersect", label: "交差", emoji: "⚫" },
-  { op: "exclude", label: "除外", emoji: "⭕" },
+  { op: "union", label: "合体", Icon: Combine },
+  { op: "subtract", label: "差分", Icon: SquareMinus },
+  { op: "intersect", label: "交差", Icon: Diamond },
+  { op: "exclude", label: "除外", Icon: SquareDashed },
 ];
 
 export function BooleanToolbar() {
   const { canvas } = useEditorStore();
   return (
-    <div className="flex items-center gap-1 px-2 py-1 border-b">
-      {OPS.map(({ op, label, emoji }) => (
+    <div className="flex items-center gap-1 border-b border-border px-2 py-1">
+      {OPS.map(({ op, label, Icon }) => (
         <button key={op} onClick={() => canvas && performBoolean(canvas, op)}
           title={label}
-          className="flex h-8 items-center gap-1 rounded px-2 text-xs hover:bg-gray-100">
-          {emoji} {label}
+          className="flex h-8 items-center gap-1.5 rounded-lg px-2 text-xs text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+          <Icon className="h-4 w-4" /> {label}
         </button>
       ))}
     </div>

--- a/web/src/features/editor/components/Toolbar/ChartButton.tsx
+++ b/web/src/features/editor/components/Toolbar/ChartButton.tsx
@@ -1,8 +1,16 @@
 "use client";
 import { useState } from "react";
+import { BarChart3, LineChart, PieChart } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { addChart, type ChartType } from "@lib/fabric/tools/chart";
 const SAMPLE = { labels: ["Q1","Q2","Q3","Q4"], values: [30,50,40,70] };
+
+const OPTIONS: { type: ChartType; label: string; Icon: typeof BarChart3 }[] = [
+  { type: "bar", label: "棒グラフ", Icon: BarChart3 },
+  { type: "line", label: "折れ線", Icon: LineChart },
+  { type: "pie", label: "円グラフ", Icon: PieChart },
+  { type: "donut", label: "ドーナツ", Icon: PieChart },
+];
 
 export function ChartButton() {
   const { canvas } = useEditorStore();
@@ -13,15 +21,22 @@ export function ChartButton() {
   }
   return (
     <div className="relative">
-      <button onClick={()=>setOpen(!open)} className="flex h-10 w-10 items-center justify-center rounded-lg text-lg hover:bg-blue-50" title="グラフ">📊</button>
+      <button onClick={()=>setOpen(!open)} title="グラフ"
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <BarChart3 className="h-4 w-4" />
+      </button>
       {open && (
-        <div className="absolute left-0 top-12 z-10 rounded-xl border bg-white shadow-lg p-2 w-32">
-          {(["bar","line","pie","donut"] as ChartType[]).map(t=>(
-            <button key={t} onClick={()=>insert(t)} className="w-full rounded px-3 py-2 text-left text-sm hover:bg-gray-50">
-              {t==="bar"?"棒グラフ":t==="line"?"折れ線":t==="pie"?"円グラフ":"ドーナツ"}
-            </button>
-          ))}
-        </div>
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-10 z-20 w-36 rounded-xl border border-border bg-surface p-1 shadow-modal">
+            {OPTIONS.map(({ type, label, Icon })=>(
+              <button key={type} onClick={()=>insert(type)}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-content-secondary hover:bg-primary-50 hover:text-primary-600 transition-colors">
+                <Icon className="h-4 w-4" /> {label}
+              </button>
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/ComponentPanel.tsx
+++ b/web/src/features/editor/components/Toolbar/ComponentPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Puzzle } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { globalComponentLibrary, createComponentFromSelection } from "@lib/fabric/components";
 
@@ -24,33 +25,35 @@ export function ComponentPanel() {
 
   return (
     <div className="relative">
-      <button onClick={() => setOpen(!open)}
-        className="flex h-10 items-center gap-1 rounded-lg px-3 text-sm hover:bg-blue-50"
-        title="コンポーネント">
-        🧩<span className="text-xs">コンポ</span>
+      <button onClick={() => setOpen(!open)} title="コンポーネント"
+        className="flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <Puzzle className="h-4 w-4" /><span className="text-xs">コンポ</span>
       </button>
       {open && (
-        <div className="absolute left-0 top-12 z-10 rounded-xl border bg-white shadow-lg p-3 w-56 space-y-3">
-          <div>
-            <p className="text-xs font-medium text-gray-500 mb-1">選択中をコンポーネントとして保存</p>
-            <div className="flex gap-1">
-              <input value={name} onChange={e => setName(e.target.value)} placeholder="名前"
-                className="flex-1 rounded border px-2 py-1 text-xs focus:outline-none" />
-              <button onClick={saveAsComponent} className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700">保存</button>
-            </div>
-          </div>
-          {components.length > 0 && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-10 z-20 w-56 space-y-3 rounded-xl border border-border bg-surface p-3 shadow-modal">
             <div>
-              <p className="text-xs font-medium text-gray-500 mb-1">コンポーネント一覧</p>
-              {components.map(c => (
-                <button key={c.id} onClick={() => instantiate(c.id)}
-                  className="w-full rounded px-3 py-2 text-left text-xs hover:bg-gray-50">
-                  🧩 {c.name}
-                </button>
-              ))}
+              <p className="mb-1 text-xs font-medium text-content-secondary">選択中をコンポーネントとして保存</p>
+              <div className="flex gap-1">
+                <input value={name} onChange={e => setName(e.target.value)} placeholder="名前"
+                  className="input flex-1 px-2 py-1 text-xs" />
+                <button onClick={saveAsComponent} className="btn btn-primary btn-sm">保存</button>
+              </div>
             </div>
-          )}
-        </div>
+            {components.length > 0 && (
+              <div>
+                <p className="mb-1 text-xs font-medium text-content-secondary">コンポーネント一覧</p>
+                {components.map(c => (
+                  <button key={c.id} onClick={() => instantiate(c.id)}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-content-secondary hover:bg-primary-50 hover:text-primary-600 transition-colors">
+                    <Puzzle className="h-3.5 w-3.5" /> {c.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/ExportButton.tsx
+++ b/web/src/features/editor/components/Toolbar/ExportButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Download, FileText, FileImage, FileCode, Presentation } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { exportToPDF } from "@lib/export/pdf";
 import { exportToPNG, exportToSVG } from "@lib/export/png";
@@ -13,22 +14,30 @@ export function ExportButton() {
     if (!canvas) return; setBusy(true); setOpen(false);
     try { await fn(); } finally { setBusy(false); }
   }
+  const OPTIONS = [
+    { l: "PDF として保存", Icon: FileText, fn: () => exportToPDF(canvas!) },
+    { l: "PNG として保存", Icon: FileImage, fn: () => exportToPNG(canvas!) },
+    { l: "SVG として保存", Icon: FileCode, fn: () => exportToSVG(canvas!) },
+    { l: "PPTX として保存", Icon: Presentation, fn: () => exportToPPTX(canvas!) },
+  ];
   return (
     <div className="relative">
-      <button onClick={()=>setOpen(!open)} disabled={busy} className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-50">
-        {busy?"出力中...":"⬇ エクスポート"}
+      <button onClick={()=>setOpen(!open)} disabled={busy}
+        className="btn btn-secondary btn-sm gap-1.5 disabled:opacity-50">
+        <Download className="h-4 w-4" />{busy?"出力中...":"エクスポート"}
       </button>
       {open && (
-        <div className="absolute right-0 top-10 z-10 rounded-xl border bg-white shadow-lg w-44">
-          {[
-            {l:"PDF として保存", fn:()=>exportToPDF(canvas!)},
-            {l:"PNG として保存", fn:()=>exportToPNG(canvas!)},
-            {l:"SVG として保存", fn:()=>exportToSVG(canvas!)},
-            {l:"PPTX として保存", fn:()=>exportToPPTX(canvas!)},
-          ].map(({l,fn})=>(
-            <button key={l} onClick={()=>run(fn)} className="block w-full px-4 py-2.5 text-left text-sm hover:bg-gray-50 first:rounded-t-xl last:rounded-b-xl">{l}</button>
-          ))}
-        </div>
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-10 z-20 w-44 rounded-xl border border-border bg-surface p-1 shadow-modal">
+            {OPTIONS.map(({l,Icon,fn})=>(
+              <button key={l} onClick={()=>run(fn)}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-content-secondary hover:bg-primary-50 hover:text-primary-600 transition-colors">
+                <Icon className="h-4 w-4" />{l}
+              </button>
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/ImageUploadButton.tsx
+++ b/web/src/features/editor/components/Toolbar/ImageUploadButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useRef } from "react";
+import { Image as ImageIcon } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { uploadAndAddImage } from "@lib/fabric/tools/image";
 
@@ -23,10 +24,10 @@ export function ImageUploadButton() {
       <input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={handleFile} />
       <button
         onClick={() => inputRef.current?.click()}
-        className="flex h-10 w-10 items-center justify-center rounded-lg text-xl hover:bg-blue-50 hover:ring-1 hover:ring-blue-300"
         title="画像を追加"
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors"
       >
-        🖼️
+        <ImageIcon className="h-4 w-4" />
       </button>
     </>
   );

--- a/web/src/features/editor/components/Toolbar/ShapeToolbar.tsx
+++ b/web/src/features/editor/components/Toolbar/ShapeToolbar.tsx
@@ -1,32 +1,41 @@
 "use client";
+import { useState } from "react";
+import { Shapes, Square, Circle, Triangle, Minus, ArrowRight, Star, Diamond } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { addShape, type ShapeType } from "@lib/fabric/tools/shapes";
 
-const SHAPES: { type: ShapeType; label: string; emoji: string }[] = [
-  { type: "rect", label: "矩形", emoji: "⬜" },
-  { type: "circle", label: "円", emoji: "⭕" },
-  { type: "triangle", label: "三角形", emoji: "🔺" },
-  { type: "line", label: "直線", emoji: "➖" },
-  { type: "arrow", label: "矢印", emoji: "➡️" },
-  { type: "star", label: "星", emoji: "⭐" },
-  { type: "diamond", label: "菱形", emoji: "🔷" },
+const SHAPES: { type: ShapeType; label: string; Icon: typeof Square }[] = [
+  { type: "rect", label: "矩形", Icon: Square },
+  { type: "circle", label: "円", Icon: Circle },
+  { type: "triangle", label: "三角形", Icon: Triangle },
+  { type: "line", label: "直線", Icon: Minus },
+  { type: "arrow", label: "矢印", Icon: ArrowRight },
+  { type: "star", label: "星", Icon: Star },
+  { type: "diamond", label: "菱形", Icon: Diamond },
 ];
 
 export function ShapeToolbar() {
   const { canvas } = useEditorStore();
-
+  const [open, setOpen] = useState(false);
   return (
-    <div className="flex flex-wrap gap-1 p-2">
-      {SHAPES.map(({ type, label, emoji }) => (
-        <button
-          key={type}
-          onClick={() => canvas && addShape(canvas, type)}
-          title={label}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-lg hover:bg-blue-50 hover:ring-1 hover:ring-blue-300"
-        >
-          {emoji}
-        </button>
-      ))}
+    <div className="relative">
+      <button onClick={() => setOpen(!open)} title="図形"
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <Shapes className="h-4 w-4" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-10 z-20 grid grid-cols-4 gap-1 rounded-xl border border-border bg-surface p-2 shadow-modal">
+            {SHAPES.map(({ type, label, Icon }) => (
+              <button key={type} onClick={() => { canvas && addShape(canvas, type); setOpen(false); }} title={label}
+                className="flex h-9 w-9 items-center justify-center rounded-lg text-content-secondary hover:bg-primary-50 hover:text-primary-600 transition-colors">
+                <Icon className="h-4 w-4" />
+              </button>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/features/editor/components/Toolbar/TableButton.tsx
+++ b/web/src/features/editor/components/Toolbar/TableButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Table } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { addTable } from "@lib/fabric/tools/table";
 
@@ -11,13 +12,19 @@ export function TableButton() {
   function insert() { if (!canvas) return; addTable(canvas, { rows, cols }); setOpen(false); }
   return (
     <div className="relative">
-      <button onClick={()=>setOpen(!open)} className="flex h-10 w-10 items-center justify-center rounded-lg text-lg hover:bg-blue-50" title="テーブル">🏓</button>
+      <button onClick={()=>setOpen(!open)} title="テーブル"
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <Table className="h-4 w-4" />
+      </button>
       {open && (
-        <div className="absolute left-0 top-12 z-10 rounded-xl border bg-white shadow-lg p-3 w-44 space-y-2">
-          <label className="flex items-center justify-between text-xs text-gray-600">行数 <input type="number" min="1" max="20" value={rows} onChange={e=>setRows(Number(e.target.value))} className="w-16 rounded border px-2 py-1 text-xs"/></label>
-          <label className="flex items-center justify-between text-xs text-gray-600">列数 <input type="number" min="1" max="10" value={cols} onChange={e=>setCols(Number(e.target.value))} className="w-16 rounded border px-2 py-1 text-xs"/></label>
-          <button onClick={insert} className="w-full rounded bg-blue-600 py-1.5 text-xs text-white font-semibold hover:bg-blue-700">挿入</button>
-        </div>
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-10 z-20 w-44 space-y-2 rounded-xl border border-border bg-surface p-3 shadow-modal">
+            <label className="flex items-center justify-between text-xs text-content-secondary">行数 <input type="number" min="1" max="20" value={rows} onChange={e=>setRows(Number(e.target.value))} className="input w-16 px-2 py-1 text-xs"/></label>
+            <label className="flex items-center justify-between text-xs text-content-secondary">列数 <input type="number" min="1" max="10" value={cols} onChange={e=>setCols(Number(e.target.value))} className="input w-16 px-2 py-1 text-xs"/></label>
+            <button onClick={insert} className="btn btn-primary btn-sm w-full">挿入</button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/TemplatePanel.tsx
+++ b/web/src/features/editor/components/Toolbar/TemplatePanel.tsx
@@ -1,9 +1,17 @@
 "use client";
 import { useState } from "react";
+import { LayoutTemplate, Square, Heading, Columns2, Moon } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useSlideStore } from "../../stores/slideStore";
 import { BUILT_IN_TEMPLATES } from "@lib/fabric/templates";
 import type { SlideContent } from "@shared/types/slide";
+
+const TEMPLATE_ICONS: Record<string, typeof Square> = {
+  blank: Square,
+  title: Heading,
+  "two-col": Columns2,
+  dark: Moon,
+};
 
 export function TemplatePanel() {
   const { canvas, activeSlideId } = useEditorStore();
@@ -16,16 +24,26 @@ export function TemplatePanel() {
   }
   return (
     <div className="relative">
-      <button onClick={()=>setOpen(!open)} className="flex h-10 items-center gap-1 rounded-lg px-3 text-sm hover:bg-blue-50" title="テンプレート">📑<span className="text-xs">テンプレ</span></button>
+      <button onClick={()=>setOpen(!open)} title="テンプレート"
+        className="flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-content-secondary hover:bg-surface-muted hover:text-content-primary transition-colors">
+        <LayoutTemplate className="h-4 w-4" /><span className="text-xs">テンプレ</span>
+      </button>
       {open && (
-        <div className="absolute left-0 top-12 z-10 grid grid-cols-2 gap-2 rounded-xl border bg-white shadow-lg p-3 w-60">
-          {BUILT_IN_TEMPLATES.map(t=>(
-            <button key={t.id} onClick={()=>apply(t.content)} className="flex flex-col items-center gap-1 rounded-lg border p-3 text-xs hover:bg-blue-50 hover:border-blue-300">
-              <span className="text-2xl">{t.thumbnail}</span>
-              <span className="text-gray-600">{t.name}</span>
-            </button>
-          ))}
-        </div>
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-10 z-20 grid w-60 grid-cols-2 gap-2 rounded-xl border border-border bg-surface p-3 shadow-modal">
+            {BUILT_IN_TEMPLATES.map(t=>{
+              const Icon = TEMPLATE_ICONS[t.id] ?? Square;
+              return (
+                <button key={t.id} onClick={()=>apply(t.content)}
+                  className="flex flex-col items-center gap-1.5 rounded-lg border border-border p-3 text-xs text-content-secondary hover:bg-primary-50 hover:border-primary-300 hover:text-primary-600 transition-colors">
+                  <Icon className="h-6 w-6" />
+                  <span>{t.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/src/features/editor/components/Toolbar/ViewOptions.tsx
+++ b/web/src/features/editor/components/Toolbar/ViewOptions.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Grid3x3, Magnet } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { toggleGrid, enableSnap } from "@lib/fabric/grid";
 
@@ -17,9 +18,9 @@ export function ViewOptions() {
     if (next) enableSnap(canvas);
   }
   return (
-    <div className="flex items-center gap-3 px-3 py-1 text-xs text-gray-600 border-b">
-      <label className="flex items-center gap-1 cursor-pointer"><input type="checkbox" checked={showGrid} onChange={handleGrid} className="rounded" />グリッド</label>
-      <label className="flex items-center gap-1 cursor-pointer"><input type="checkbox" checked={snapEnabled} onChange={handleSnap} className="rounded" />スナップ</label>
+    <div className="flex items-center gap-3 border-b border-border px-3 py-1 text-xs text-content-secondary">
+      <label className="flex cursor-pointer items-center gap-1.5"><input type="checkbox" checked={showGrid} onChange={handleGrid} className="rounded" /><Grid3x3 className="h-3.5 w-3.5" />グリッド</label>
+      <label className="flex cursor-pointer items-center gap-1.5"><input type="checkbox" checked={snapEnabled} onChange={handleSnap} className="rounded" /><Magnet className="h-3.5 w-3.5" />スナップ</label>
     </div>
   );
 }

--- a/web/src/shared/hooks/useAuth.ts
+++ b/web/src/shared/hooks/useAuth.ts
@@ -4,14 +4,14 @@ import { useRouter } from "next/navigation";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 
 export function useRequireAuth() {
-  const { accessToken } = useAuthStore();
+  const { accessToken, hasHydrated } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
-    if (!accessToken) {
+    if (hasHydrated && !accessToken) {
       router.replace("/login");
     }
-  }, [accessToken, router]);
+  }, [accessToken, hasHydrated, router]);
 
-  return { isAuthenticated: !!accessToken };
+  return { isAuthenticated: !!accessToken, isReady: hasHydrated };
 }


### PR DESCRIPTION
Converts all remaining emoji toolbar/AI components to Lucide icons. Fixes protected-route hydration race that bounced authed users to /login on refresh.

🤖 Generated with Claude Code