### PR TITLE
test(api): Go unit tests for use cases and JSONB

### DIFF
--- a/services/api/internal/application/member/usecase_test.go
+++ b/services/api/internal/application/member/usecase_test.go
@@ -1,0 +1,259 @@
+package member
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainUser "github.com/ko-tarou/presentsai/services/api/internal/domain/user"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+const (
+	presID     = "pres-1"
+	ownerID    = "owner-1"
+	strangerID = "stranger-1"
+)
+
+// fakeMemberRepo is an in-memory member Repository.
+type fakeMemberRepo struct {
+	members map[string]Member // keyed by presentationID+":"+userID
+}
+
+func newFakeMemberRepo() *fakeMemberRepo {
+	return &fakeMemberRepo{members: map[string]Member{}}
+}
+
+func key(pid, uid string) string { return pid + ":" + uid }
+
+func (r *fakeMemberRepo) AddMember(ctx context.Context, presentationID, userID, role string) error {
+	r.members[key(presentationID, userID)] = Member{
+		PresentationID: presentationID,
+		UserID:         userID,
+		Role:           role,
+	}
+	return nil
+}
+
+func (r *fakeMemberRepo) ListMembers(ctx context.Context, presentationID string) ([]Member, error) {
+	var out []Member
+	for _, m := range r.members {
+		if m.PresentationID == presentationID {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeMemberRepo) GetMember(ctx context.Context, presentationID, userID string) (*Member, error) {
+	if m, ok := r.members[key(presentationID, userID)]; ok {
+		return &m, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+
+func (r *fakeMemberRepo) UpdateRole(ctx context.Context, presentationID, userID, role string) error {
+	k := key(presentationID, userID)
+	m, ok := r.members[k]
+	if !ok {
+		return sharedErr.ErrNotFound
+	}
+	m.Role = role
+	r.members[k] = m
+	return nil
+}
+
+func (r *fakeMemberRepo) RemoveMember(ctx context.Context, presentationID, userID string) error {
+	delete(r.members, key(presentationID, userID))
+	return nil
+}
+
+// fakePresentationRepo returns a single presentation owned by ownerID.
+type fakePresentationRepo struct {
+	pres map[domainPresentation.ID]*domainPresentation.Presentation
+}
+
+func newFakePresentationRepo() *fakePresentationRepo {
+	return &fakePresentationRepo{
+		pres: map[domainPresentation.ID]*domainPresentation.Presentation{
+			domainPresentation.ID(presID): {
+				ID:      domainPresentation.ID(presID),
+				OwnerID: domainUser.ID(ownerID),
+				Title:   "Deck",
+			},
+		},
+	}
+}
+
+func (r *fakePresentationRepo) Create(ctx context.Context, p *domainPresentation.Presentation) error {
+	return nil
+}
+func (r *fakePresentationRepo) FindByID(ctx context.Context, id domainPresentation.ID) (*domainPresentation.Presentation, error) {
+	if p, ok := r.pres[id]; ok {
+		return p, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakePresentationRepo) FindByOwner(ctx context.Context, ownerID string, limit, offset int) ([]*domainPresentation.Presentation, int64, error) {
+	return nil, 0, nil
+}
+func (r *fakePresentationRepo) Update(ctx context.Context, p *domainPresentation.Presentation) error {
+	return nil
+}
+func (r *fakePresentationRepo) Delete(ctx context.Context, id domainPresentation.ID) error {
+	return nil
+}
+
+// fakeUserRepo is an in-memory user Repository keyed by email.
+type fakeUserRepo struct {
+	byEmail map[string]*domainUser.User
+}
+
+func newFakeUserRepo() *fakeUserRepo {
+	return &fakeUserRepo{byEmail: map[string]*domainUser.User{}}
+}
+
+func (r *fakeUserRepo) add(email, id, display string) {
+	r.byEmail[email] = &domainUser.User{ID: domainUser.ID(id), Email: email, DisplayName: display}
+}
+
+func (r *fakeUserRepo) Create(ctx context.Context, u *domainUser.User) error { return nil }
+func (r *fakeUserRepo) FindByID(ctx context.Context, id domainUser.ID) (*domainUser.User, error) {
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakeUserRepo) FindByEmail(ctx context.Context, email string) (*domainUser.User, error) {
+	if u, ok := r.byEmail[email]; ok {
+		return u, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakeUserRepo) Update(ctx context.Context, u *domainUser.User) error { return nil }
+
+func setup() (*UseCase, *fakeMemberRepo, *fakeUserRepo) {
+	mrepo := newFakeMemberRepo()
+	urepo := newFakeUserRepo()
+	uc := NewUseCase(mrepo, newFakePresentationRepo(), urepo)
+	return uc, mrepo, urepo
+}
+
+func TestInviteByEmail(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner with valid role succeeds", func(t *testing.T) {
+		for _, role := range []string{"editor", "viewer"} {
+			uc, mrepo, urepo := setup()
+			urepo.add("invitee@example.com", "u-2", "Invitee")
+
+			m, err := uc.InviteByEmail(ctx, presID, ownerID, "invitee@example.com", role)
+			if err != nil {
+				t.Fatalf("role %q: unexpected error: %v", role, err)
+			}
+			if m.Email != "invitee@example.com" || m.Role != role || m.UserID != "u-2" {
+				t.Fatalf("role %q: unexpected member %+v", role, m)
+			}
+			if _, ok := mrepo.members[key(presID, "u-2")]; !ok {
+				t.Fatalf("role %q: member not persisted", role)
+			}
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, _, urepo := setup()
+		urepo.add("invitee@example.com", "u-2", "Invitee")
+		_, err := uc.InviteByEmail(ctx, presID, strangerID, "invitee@example.com", "editor")
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+
+	t.Run("invalid role returns ErrInvalidInput", func(t *testing.T) {
+		for _, role := range []string{"owner", "admin", ""} {
+			uc, _, urepo := setup()
+			urepo.add("invitee@example.com", "u-2", "Invitee")
+			_, err := uc.InviteByEmail(ctx, presID, ownerID, "invitee@example.com", role)
+			if !errors.Is(err, sharedErr.ErrInvalidInput) {
+				t.Fatalf("role %q: err = %v, want ErrInvalidInput", role, err)
+			}
+		}
+	})
+
+	t.Run("email with no user returns error", func(t *testing.T) {
+		uc, _, _ := setup()
+		_, err := uc.InviteByEmail(ctx, presID, ownerID, "ghost@example.com", "editor")
+		if err == nil {
+			t.Fatal("expected error for unknown user, got nil")
+		}
+	})
+}
+
+func TestUpdateRole(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner succeeds", func(t *testing.T) {
+		uc, mrepo, _ := setup()
+		mrepo.AddMember(ctx, presID, "u-2", "viewer")
+		if err := uc.UpdateRole(ctx, presID, ownerID, "u-2", "editor"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := mrepo.members[key(presID, "u-2")].Role; got != "editor" {
+			t.Fatalf("role = %q, want editor", got)
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, _, _ := setup()
+		err := uc.UpdateRole(ctx, presID, strangerID, "u-2", "editor")
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+
+	t.Run("invalid role returns ErrInvalidInput", func(t *testing.T) {
+		uc, _, _ := setup()
+		err := uc.UpdateRole(ctx, presID, ownerID, "u-2", "owner")
+		if !errors.Is(err, sharedErr.ErrInvalidInput) {
+			t.Fatalf("err = %v, want ErrInvalidInput", err)
+		}
+	})
+}
+
+func TestRemoveMember(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner succeeds", func(t *testing.T) {
+		uc, mrepo, _ := setup()
+		mrepo.AddMember(ctx, presID, "u-2", "viewer")
+		if err := uc.RemoveMember(ctx, presID, ownerID, "u-2"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := mrepo.members[key(presID, "u-2")]; ok {
+			t.Fatal("member was not removed")
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, mrepo, _ := setup()
+		mrepo.AddMember(ctx, presID, "u-2", "viewer")
+		err := uc.RemoveMember(ctx, presID, strangerID, "u-2")
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+}
+
+func TestListMembers(t *testing.T) {
+	ctx := context.Background()
+	uc, mrepo, _ := setup()
+	mrepo.AddMember(ctx, presID, "u-2", "viewer")
+	mrepo.AddMember(ctx, presID, "u-3", "editor")
+
+	// caller is the owner
+	got, err := uc.ListMembers(ctx, presID, ownerID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(got))
+	}
+}

--- a/services/api/internal/application/presentation/usecase_test.go
+++ b/services/api/internal/application/presentation/usecase_test.go
@@ -1,0 +1,212 @@
+package presentation
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainSlide "github.com/ko-tarou/presentsai/services/api/internal/domain/slide"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+// fakePresentationRepo is an in-memory presentation Repository that assigns IDs.
+type fakePresentationRepo struct {
+	byID   map[domainPresentation.ID]*domainPresentation.Presentation
+	nextID int
+}
+
+func newFakePresentationRepo() *fakePresentationRepo {
+	return &fakePresentationRepo{byID: map[domainPresentation.ID]*domainPresentation.Presentation{}}
+}
+
+func (r *fakePresentationRepo) Create(ctx context.Context, p *domainPresentation.Presentation) error {
+	r.nextID++
+	p.ID = domainPresentation.ID("pres-" + strconv.Itoa(r.nextID))
+	r.byID[p.ID] = p
+	return nil
+}
+func (r *fakePresentationRepo) FindByID(ctx context.Context, id domainPresentation.ID) (*domainPresentation.Presentation, error) {
+	if p, ok := r.byID[id]; ok {
+		return p, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakePresentationRepo) FindByOwner(ctx context.Context, ownerID string, limit, offset int) ([]*domainPresentation.Presentation, int64, error) {
+	var out []*domainPresentation.Presentation
+	for _, p := range r.byID {
+		if string(p.OwnerID) == ownerID {
+			out = append(out, p)
+		}
+	}
+	return out, int64(len(out)), nil
+}
+func (r *fakePresentationRepo) Update(ctx context.Context, p *domainPresentation.Presentation) error {
+	r.byID[p.ID] = p
+	return nil
+}
+func (r *fakePresentationRepo) Delete(ctx context.Context, id domainPresentation.ID) error {
+	delete(r.byID, id)
+	return nil
+}
+
+// fakeSlideRepo records Create calls so the auto-first-slide behaviour can be asserted.
+type fakeSlideRepo struct {
+	created []*domainSlide.Slide
+}
+
+func (r *fakeSlideRepo) Create(ctx context.Context, s *domainSlide.Slide) error {
+	r.created = append(r.created, s)
+	return nil
+}
+func (r *fakeSlideRepo) FindByID(ctx context.Context, id domainSlide.ID) (*domainSlide.Slide, error) {
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakeSlideRepo) FindByPresentation(ctx context.Context, presentationID string) ([]*domainSlide.Slide, error) {
+	return nil, nil
+}
+func (r *fakeSlideRepo) Update(ctx context.Context, s *domainSlide.Slide) error { return nil }
+func (r *fakeSlideRepo) Delete(ctx context.Context, id domainSlide.ID) error    { return nil }
+func (r *fakeSlideRepo) ReorderSlides(ctx context.Context, presentationID string, positions map[string]int) error {
+	return nil
+}
+
+const (
+	ownerID    = "owner-1"
+	strangerID = "stranger-1"
+)
+
+func newUC() (*UseCase, *fakePresentationRepo, *fakeSlideRepo) {
+	prepo := newFakePresentationRepo()
+	srepo := &fakeSlideRepo{}
+	return NewUseCase(prepo, srepo), prepo, srepo
+}
+
+func TestCreate(t *testing.T) {
+	ctx := context.Background()
+	uc, _, srepo := newUC()
+
+	p, err := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "My Deck"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if p.ID == "" {
+		t.Fatal("expected presentation to have an ID")
+	}
+	if p.Title != "My Deck" || string(p.OwnerID) != ownerID {
+		t.Fatalf("unexpected presentation %+v", p)
+	}
+
+	// exactly one first slide auto-created for the new presentation
+	if len(srepo.created) != 1 {
+		t.Fatalf("expected 1 auto-created slide, got %d", len(srepo.created))
+	}
+	if srepo.created[0].PresentationID != p.ID {
+		t.Fatalf("first slide presentation id = %q, want %q", srepo.created[0].PresentationID, p.ID)
+	}
+	if srepo.created[0].Position != 0 {
+		t.Fatalf("first slide position = %d, want 0", srepo.created[0].Position)
+	}
+}
+
+func TestGet(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner can get", func(t *testing.T) {
+		uc, _, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "T"})
+		got, err := uc.Get(ctx, string(created.ID), ownerID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ID != created.ID {
+			t.Fatalf("got id %q, want %q", got.ID, created.ID)
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, _, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "T"})
+		_, err := uc.Get(ctx, string(created.ID), strangerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner updates title", func(t *testing.T) {
+		uc, prepo, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "Old"})
+		updated, err := uc.Update(ctx, string(created.ID), ownerID, "New Title")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updated.Title != "New Title" {
+			t.Fatalf("title = %q, want New Title", updated.Title)
+		}
+		if prepo.byID[created.ID].Title != "New Title" {
+			t.Fatal("title not persisted")
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, _, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "Old"})
+		_, err := uc.Update(ctx, string(created.ID), strangerID, "Hacked")
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner deletes", func(t *testing.T) {
+		uc, prepo, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "T"})
+		if err := uc.Delete(ctx, string(created.ID), ownerID); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := prepo.byID[created.ID]; ok {
+			t.Fatal("presentation not deleted")
+		}
+	})
+
+	t.Run("non-owner returns ErrForbidden", func(t *testing.T) {
+		uc, prepo, _ := newUC()
+		created, _ := uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "T"})
+		err := uc.Delete(ctx, string(created.ID), strangerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+		if _, ok := prepo.byID[created.ID]; !ok {
+			t.Fatal("presentation should not have been deleted by non-owner")
+		}
+	})
+}
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	uc, _, _ := newUC()
+	uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "A"})
+	uc.Create(ctx, CreateInput{OwnerID: ownerID, Title: "B"})
+	uc.Create(ctx, CreateInput{OwnerID: strangerID, Title: "C"})
+
+	got, total, err := uc.List(ctx, ownerID, 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 2 || len(got) != 2 {
+		t.Fatalf("expected 2 presentations for owner, got len=%d total=%d", len(got), total)
+	}
+	for _, p := range got {
+		if string(p.OwnerID) != ownerID {
+			t.Fatalf("List returned presentation owned by %q", p.OwnerID)
+		}
+	}
+}

--- a/services/api/internal/application/slide/usecase_test.go
+++ b/services/api/internal/application/slide/usecase_test.go
@@ -1,0 +1,245 @@
+package slide
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	domainPresentation "github.com/ko-tarou/presentsai/services/api/internal/domain/presentation"
+	domainSlide "github.com/ko-tarou/presentsai/services/api/internal/domain/slide"
+	domainUser "github.com/ko-tarou/presentsai/services/api/internal/domain/user"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+const (
+	ownerID    = "owner-1"
+	strangerID = "stranger-1"
+	ownedPres  = "pres-owned"
+	otherPres  = "pres-other"
+)
+
+// fakePresentationRepo serves two presentations: one owned by ownerID, one by stranger.
+type fakePresentationRepo struct {
+	pres map[domainPresentation.ID]*domainPresentation.Presentation
+}
+
+func newFakePresentationRepo() *fakePresentationRepo {
+	return &fakePresentationRepo{
+		pres: map[domainPresentation.ID]*domainPresentation.Presentation{
+			domainPresentation.ID(ownedPres): {ID: domainPresentation.ID(ownedPres), OwnerID: domainUser.ID(ownerID)},
+			domainPresentation.ID(otherPres): {ID: domainPresentation.ID(otherPres), OwnerID: domainUser.ID(strangerID)},
+		},
+	}
+}
+
+func (r *fakePresentationRepo) Create(ctx context.Context, p *domainPresentation.Presentation) error {
+	return nil
+}
+func (r *fakePresentationRepo) FindByID(ctx context.Context, id domainPresentation.ID) (*domainPresentation.Presentation, error) {
+	if p, ok := r.pres[id]; ok {
+		return p, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakePresentationRepo) FindByOwner(ctx context.Context, ownerID string, limit, offset int) ([]*domainPresentation.Presentation, int64, error) {
+	return nil, 0, nil
+}
+func (r *fakePresentationRepo) Update(ctx context.Context, p *domainPresentation.Presentation) error {
+	return nil
+}
+func (r *fakePresentationRepo) Delete(ctx context.Context, id domainPresentation.ID) error {
+	return nil
+}
+
+// fakeSlideRepo is an in-memory slide Repository.
+type fakeSlideRepo struct {
+	byID            map[domainSlide.ID]*domainSlide.Slide
+	nextID          int
+	reorderCalls    int
+	lastReorderPres string
+	lastPositions   map[string]int
+}
+
+func newFakeSlideRepo() *fakeSlideRepo {
+	return &fakeSlideRepo{byID: map[domainSlide.ID]*domainSlide.Slide{}}
+}
+
+func (r *fakeSlideRepo) Create(ctx context.Context, s *domainSlide.Slide) error {
+	r.nextID++
+	s.ID = domainSlide.ID("slide-" + strconv.Itoa(r.nextID))
+	r.byID[s.ID] = s
+	return nil
+}
+func (r *fakeSlideRepo) FindByID(ctx context.Context, id domainSlide.ID) (*domainSlide.Slide, error) {
+	if s, ok := r.byID[id]; ok {
+		return s, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+func (r *fakeSlideRepo) FindByPresentation(ctx context.Context, presentationID string) ([]*domainSlide.Slide, error) {
+	var out []*domainSlide.Slide
+	for _, s := range r.byID {
+		if string(s.PresentationID) == presentationID {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+func (r *fakeSlideRepo) Update(ctx context.Context, s *domainSlide.Slide) error {
+	r.byID[s.ID] = s
+	return nil
+}
+func (r *fakeSlideRepo) Delete(ctx context.Context, id domainSlide.ID) error {
+	delete(r.byID, id)
+	return nil
+}
+func (r *fakeSlideRepo) ReorderSlides(ctx context.Context, presentationID string, positions map[string]int) error {
+	r.reorderCalls++
+	r.lastReorderPres = presentationID
+	r.lastPositions = positions
+	return nil
+}
+
+// seed inserts a slide directly into the repo for the given presentation.
+func (r *fakeSlideRepo) seed(presID string, position int) *domainSlide.Slide {
+	r.nextID++
+	s := &domainSlide.Slide{
+		ID:             domainSlide.ID("slide-" + strconv.Itoa(r.nextID)),
+		PresentationID: domainPresentation.ID(presID),
+		Position:       position,
+	}
+	r.byID[s.ID] = s
+	return s
+}
+
+func newUC() (*UseCase, *fakeSlideRepo) {
+	srepo := newFakeSlideRepo()
+	return NewUseCase(srepo, newFakePresentationRepo()), srepo
+}
+
+func TestOwnershipGuard(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	// a slide belonging to a presentation owned by stranger
+	s := srepo.seed(otherPres, 0)
+
+	t.Run("Get on foreign slide", func(t *testing.T) {
+		_, err := uc.Get(ctx, string(s.ID), ownerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+	t.Run("List on foreign presentation", func(t *testing.T) {
+		_, err := uc.List(ctx, otherPres, ownerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+	t.Run("Create on foreign presentation", func(t *testing.T) {
+		_, err := uc.Create(ctx, otherPres, ownerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+	t.Run("Delete on foreign slide", func(t *testing.T) {
+		err := uc.Delete(ctx, string(s.ID), ownerID)
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+	t.Run("Reorder on foreign presentation", func(t *testing.T) {
+		err := uc.Reorder(ctx, otherPres, ownerID, map[string]int{})
+		if !errors.Is(err, sharedErr.ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+}
+
+func TestCreate(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	// pre-existing slides at positions 0 and 1
+	srepo.seed(ownedPres, 0)
+	srepo.seed(ownedPres, 1)
+
+	s, err := uc.Create(ctx, ownedPres, ownerID)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if s.Position != 2 {
+		t.Fatalf("new slide position = %d, want 2 (len of existing)", s.Position)
+	}
+	if string(s.PresentationID) != ownedPres {
+		t.Fatalf("presentation id = %q, want %q", s.PresentationID, ownedPres)
+	}
+	if _, ok := srepo.byID[s.ID]; !ok {
+		t.Fatal("slide not persisted")
+	}
+}
+
+func TestUpdateContent(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(ownedPres, 0)
+
+	newContent := domainSlide.Content{"version": "6.0.0", "objects": []interface{}{"rect"}}
+	updated, err := uc.UpdateContent(ctx, string(s.ID), ownerID, newContent)
+	if err != nil {
+		t.Fatalf("UpdateContent returned error: %v", err)
+	}
+	if updated.Content["objects"] == nil {
+		t.Fatal("content not updated")
+	}
+	if srepo.byID[s.ID].Content["version"] != "6.0.0" {
+		t.Fatal("content not persisted")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(ownedPres, 0)
+
+	if err := uc.Delete(ctx, string(s.ID), ownerID); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if _, ok := srepo.byID[s.ID]; ok {
+		t.Fatal("slide not deleted")
+	}
+}
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	srepo.seed(ownedPres, 0)
+	srepo.seed(ownedPres, 1)
+	srepo.seed(otherPres, 0) // different presentation, must not appear
+
+	got, err := uc.List(ctx, ownedPres, ownerID)
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 slides, got %d", len(got))
+	}
+}
+
+func TestReorder(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	positions := map[string]int{"slide-a": 1, "slide-b": 0}
+
+	if err := uc.Reorder(ctx, ownedPres, ownerID, positions); err != nil {
+		t.Fatalf("Reorder returned error: %v", err)
+	}
+	if srepo.reorderCalls != 1 {
+		t.Fatalf("expected 1 ReorderSlides call, got %d", srepo.reorderCalls)
+	}
+	if srepo.lastReorderPres != ownedPres {
+		t.Fatalf("reorder presentation = %q, want %q", srepo.lastReorderPres, ownedPres)
+	}
+	if len(srepo.lastPositions) != 2 {
+		t.Fatalf("expected 2 positions forwarded, got %d", len(srepo.lastPositions))
+	}
+}

--- a/services/api/internal/application/user/auth_service.go
+++ b/services/api/internal/application/user/auth_service.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -112,10 +113,15 @@ func (s *AuthService) issueTokenPair(ctx context.Context, userID string) (*Token
 		return nil, err
 	}
 
+	jti, err := randomJTI()
+	if err != nil {
+		return nil, err
+	}
 	refreshToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub": userID,
 		"iat": now.Unix(),
 		"exp": now.Add(refreshTokenTTL).Unix(),
+		"jti": jti,
 	}).SignedString([]byte(s.refreshSec))
 	if err != nil {
 		return nil, err
@@ -136,4 +142,15 @@ func (s *AuthService) issueTokenPair(ctx context.Context, userID string) (*Token
 func hashToken(token string) string {
 	h := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(h[:])
+}
+
+// randomJTI returns a random token identifier so that two refresh tokens
+// issued for the same user within the same second are never identical
+// (which would otherwise collide on their hash and break rotation).
+func randomJTI() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/services/api/internal/application/user/auth_service_test.go
+++ b/services/api/internal/application/user/auth_service_test.go
@@ -1,0 +1,372 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+
+	domainUser "github.com/ko-tarou/presentsai/services/api/internal/domain/user"
+	sharedErr "github.com/ko-tarou/presentsai/services/api/internal/shared/errors"
+)
+
+// fakeUserRepo is an in-memory implementation of domainUser.Repository.
+type fakeUserRepo struct {
+	mu     sync.Mutex
+	byID   map[domainUser.ID]*domainUser.User
+	nextID int
+}
+
+func newFakeUserRepo() *fakeUserRepo {
+	return &fakeUserRepo{byID: map[domainUser.ID]*domainUser.User{}}
+}
+
+func (r *fakeUserRepo) Create(ctx context.Context, u *domainUser.User) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nextID++
+	u.ID = domainUser.ID("user-" + strconv.Itoa(r.nextID))
+	// store a copy to avoid aliasing surprises
+	cp := *u
+	r.byID[u.ID] = &cp
+	return nil
+}
+
+func (r *fakeUserRepo) FindByID(ctx context.Context, id domainUser.ID) (*domainUser.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if u, ok := r.byID[id]; ok {
+		cp := *u
+		return &cp, nil
+	}
+	return nil, sharedErr.ErrNotFound
+}
+
+func (r *fakeUserRepo) FindByEmail(ctx context.Context, email string) (*domainUser.User, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, u := range r.byID {
+		if u.Email == email {
+			cp := *u
+			return &cp, nil
+		}
+	}
+	return nil, sharedErr.ErrNotFound
+}
+
+func (r *fakeUserRepo) Update(ctx context.Context, u *domainUser.User) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.byID[u.ID]; !ok {
+		return sharedErr.ErrNotFound
+	}
+	cp := *u
+	r.byID[u.ID] = &cp
+	return nil
+}
+
+// storedUser returns the stored user with the given email (for white-box assertions).
+func (r *fakeUserRepo) storedUser(email string) *domainUser.User {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, u := range r.byID {
+		if u.Email == email {
+			return u
+		}
+	}
+	return nil
+}
+
+// fakeRefreshRepo is an in-memory RefreshTokenRepository.
+type fakeRefreshRepo struct {
+	mu     sync.Mutex
+	tokens map[string]refreshEntry // keyed by tokenHash
+}
+
+type refreshEntry struct {
+	userID    string
+	expiresAt time.Time
+}
+
+func newFakeRefreshRepo() *fakeRefreshRepo {
+	return &fakeRefreshRepo{tokens: map[string]refreshEntry{}}
+}
+
+func (r *fakeRefreshRepo) Store(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tokens[tokenHash] = refreshEntry{userID: userID, expiresAt: expiresAt}
+	return nil
+}
+
+func (r *fakeRefreshRepo) Find(ctx context.Context, tokenHash string) (string, time.Time, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.tokens[tokenHash]; ok {
+		return e.userID, e.expiresAt, nil
+	}
+	return "", time.Time{}, sharedErr.ErrNotFound
+}
+
+func (r *fakeRefreshRepo) Delete(ctx context.Context, tokenHash string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tokens, tokenHash)
+	return nil
+}
+
+func (r *fakeRefreshRepo) DeleteAllForUser(ctx context.Context, userID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for hash, e := range r.tokens {
+		if e.userID == userID {
+			delete(r.tokens, hash)
+		}
+	}
+	return nil
+}
+
+func (r *fakeRefreshRepo) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.tokens)
+}
+
+// has reports whether a token with the given hash is stored.
+func (r *fakeRefreshRepo) has(tokenHash string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.tokens[tokenHash]
+	return ok
+}
+
+// setExpiry forcibly overrides the stored expiry for a token hash (test helper).
+func (r *fakeRefreshRepo) setExpiry(tokenHash string, t time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.tokens[tokenHash]; ok {
+		e.expiresAt = t
+		r.tokens[tokenHash] = e
+	}
+}
+
+// setSecrets sets the JWT env vars and must be called before NewAuthService,
+// because NewAuthService reads the secrets from the environment at construction.
+func setSecrets(t *testing.T) {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-access-secret")
+	t.Setenv("JWT_REFRESH_SECRET", "test-refresh-secret")
+}
+
+// subFromToken parses a HS256 JWT signed with secret and returns its "sub" claim.
+func subFromToken(t *testing.T, token, secret string) string {
+	t.Helper()
+	parsed, err := jwt.Parse(token, func(*jwt.Token) (interface{}, error) {
+		return []byte(secret), nil
+	})
+	if err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatalf("unexpected claims type %T", parsed.Claims)
+	}
+	sub, _ := claims["sub"].(string)
+	return sub
+}
+
+func TestRegister(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("new email returns token pair with valid claims", func(t *testing.T) {
+		setSecrets(t)
+		users := newFakeUserRepo()
+		refresh := newFakeRefreshRepo()
+		svc := NewAuthService(users, refresh)
+
+		pair, err := svc.Register(ctx, "alice@example.com", "s3cret-pass", "Alice")
+		if err != nil {
+			t.Fatalf("Register returned error: %v", err)
+		}
+		if pair.AccessToken == "" || pair.RefreshToken == "" {
+			t.Fatalf("expected non-empty tokens, got access=%q refresh=%q", pair.AccessToken, pair.RefreshToken)
+		}
+
+		stored := users.storedUser("alice@example.com")
+		if stored == nil {
+			t.Fatal("user was not stored")
+		}
+		// access token sub must decode to the created user's id
+		sub := subFromToken(t, pair.AccessToken, "test-access-secret")
+		if sub != string(stored.ID) {
+			t.Fatalf("sub claim = %q, want %q", sub, string(stored.ID))
+		}
+		// password must be bcrypt-hashed, not plaintext
+		if stored.PasswordHash == "s3cret-pass" {
+			t.Fatal("password stored in plaintext")
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(stored.PasswordHash), []byte("s3cret-pass")); err != nil {
+			t.Fatalf("stored hash does not verify against plaintext: %v", err)
+		}
+		// a refresh token must have been persisted
+		if refresh.count() != 1 {
+			t.Fatalf("expected 1 stored refresh token, got %d", refresh.count())
+		}
+	})
+
+	t.Run("existing email returns ErrAlreadyExists", func(t *testing.T) {
+		setSecrets(t)
+		users := newFakeUserRepo()
+		svc := NewAuthService(users, newFakeRefreshRepo())
+
+		if _, err := svc.Register(ctx, "dup@example.com", "pw1", "First"); err != nil {
+			t.Fatalf("first register failed: %v", err)
+		}
+		_, err := svc.Register(ctx, "dup@example.com", "pw2", "Second")
+		if !errors.Is(err, sharedErr.ErrAlreadyExists) {
+			t.Fatalf("err = %v, want ErrAlreadyExists", err)
+		}
+	})
+}
+
+func TestLogin(t *testing.T) {
+	ctx := context.Background()
+
+	register := func(t *testing.T) (*AuthService, *fakeUserRepo) {
+		setSecrets(t)
+		users := newFakeUserRepo()
+		svc := NewAuthService(users, newFakeRefreshRepo())
+		if _, err := svc.Register(ctx, "bob@example.com", "correct-horse", "Bob"); err != nil {
+			t.Fatalf("setup register failed: %v", err)
+		}
+		return svc, users
+	}
+
+	t.Run("correct password returns token pair", func(t *testing.T) {
+		svc, users := register(t)
+		pair, err := svc.Login(ctx, "bob@example.com", "correct-horse")
+		if err != nil {
+			t.Fatalf("Login returned error: %v", err)
+		}
+		if pair.AccessToken == "" || pair.RefreshToken == "" {
+			t.Fatal("expected non-empty tokens")
+		}
+		sub := subFromToken(t, pair.AccessToken, "test-access-secret")
+		if sub != string(users.storedUser("bob@example.com").ID) {
+			t.Fatal("sub claim does not match user id")
+		}
+	})
+
+	t.Run("wrong password returns ErrUnauthorized", func(t *testing.T) {
+		svc, _ := register(t)
+		_, err := svc.Login(ctx, "bob@example.com", "wrong")
+		if !errors.Is(err, sharedErr.ErrUnauthorized) {
+			t.Fatalf("err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("unknown email returns ErrUnauthorized", func(t *testing.T) {
+		svc, _ := register(t)
+		_, err := svc.Login(ctx, "nobody@example.com", "whatever")
+		if !errors.Is(err, sharedErr.ErrUnauthorized) {
+			t.Fatalf("err = %v, want ErrUnauthorized", err)
+		}
+	})
+}
+
+func TestRefresh(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid token rotates and returns new pair", func(t *testing.T) {
+		setSecrets(t)
+		refresh := newFakeRefreshRepo()
+		svc := NewAuthService(newFakeUserRepo(), refresh)
+
+		pair, err := svc.Register(ctx, "carol@example.com", "pw", "Carol")
+		if err != nil {
+			t.Fatalf("register failed: %v", err)
+		}
+		oldHash := hashToken(pair.RefreshToken)
+		if !refresh.has(oldHash) {
+			t.Fatal("refresh token not stored after register")
+		}
+
+		newPair, err := svc.Refresh(ctx, pair.RefreshToken)
+		if err != nil {
+			t.Fatalf("Refresh returned error: %v", err)
+		}
+		if newPair.AccessToken == "" || newPair.RefreshToken == "" {
+			t.Fatal("expected non-empty rotated tokens")
+		}
+		// old token must be rotated out
+		if refresh.has(oldHash) {
+			t.Fatal("old refresh token was not deleted (rotation failed)")
+		}
+		// new token must be stored
+		if !refresh.has(hashToken(newPair.RefreshToken)) {
+			t.Fatal("new refresh token not stored")
+		}
+		if refresh.count() != 1 {
+			t.Fatalf("expected exactly 1 stored token after rotation, got %d", refresh.count())
+		}
+	})
+
+	t.Run("unknown token returns ErrUnauthorized", func(t *testing.T) {
+		setSecrets(t)
+		svc := NewAuthService(newFakeUserRepo(), newFakeRefreshRepo())
+		_, err := svc.Refresh(ctx, "not-a-real-token")
+		if !errors.Is(err, sharedErr.ErrUnauthorized) {
+			t.Fatalf("err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("expired token returns ErrUnauthorized", func(t *testing.T) {
+		setSecrets(t)
+		refresh := newFakeRefreshRepo()
+		svc := NewAuthService(newFakeUserRepo(), refresh)
+		pair, err := svc.Register(ctx, "dan@example.com", "pw", "Dan")
+		if err != nil {
+			t.Fatalf("register failed: %v", err)
+		}
+		refresh.setExpiry(hashToken(pair.RefreshToken), time.Now().Add(-time.Hour))
+		_, err = svc.Refresh(ctx, pair.RefreshToken)
+		if !errors.Is(err, sharedErr.ErrUnauthorized) {
+			t.Fatalf("err = %v, want ErrUnauthorized", err)
+		}
+	})
+}
+
+func TestLogout(t *testing.T) {
+	ctx := context.Background()
+	setSecrets(t)
+	refresh := newFakeRefreshRepo()
+	svc := NewAuthService(newFakeUserRepo(), refresh)
+
+	pair, err := svc.Register(ctx, "erin@example.com", "pw", "Erin")
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	userID, _, err := refresh.Find(ctx, hashToken(pair.RefreshToken))
+	if err != nil {
+		t.Fatalf("could not look up stored token: %v", err)
+	}
+	// issue a second token for the same user to ensure all are removed
+	if _, err := svc.issueTokenPair(ctx, userID); err != nil {
+		t.Fatalf("issueTokenPair failed: %v", err)
+	}
+	if refresh.count() != 2 {
+		t.Fatalf("expected 2 stored tokens before logout, got %d", refresh.count())
+	}
+
+	if err := svc.Logout(ctx, userID); err != nil {
+		t.Fatalf("Logout returned error: %v", err)
+	}
+	if refresh.count() != 0 {
+		t.Fatalf("expected 0 stored tokens after logout, got %d", refresh.count())
+	}
+}

--- a/services/api/internal/infrastructure/postgres/jsonb_test.go
+++ b/services/api/internal/infrastructure/postgres/jsonb_test.go
@@ -1,0 +1,79 @@
+package postgres
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestJSONBValue(t *testing.T) {
+	j := JSONB{"version": "6.0.0", "count": float64(3)}
+
+	v, err := j.Value()
+	if err != nil {
+		t.Fatalf("Value returned error: %v", err)
+	}
+	b, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("Value returned %T, want []byte", v)
+	}
+
+	// the bytes must be the JSON marshaling of the map
+	want, _ := json.Marshal(map[string]interface{}(j))
+	if string(b) != string(want) {
+		t.Fatalf("Value = %s, want %s", b, want)
+	}
+}
+
+func TestJSONBScan(t *testing.T) {
+	t.Run("scans a JSON object from []byte", func(t *testing.T) {
+		var j JSONB
+		raw := []byte(`{"version":"6.0.0","objects":["rect"]}`)
+		if err := j.Scan(raw); err != nil {
+			t.Fatalf("Scan returned error: %v", err)
+		}
+		if j["version"] != "6.0.0" {
+			t.Fatalf("version = %v, want 6.0.0", j["version"])
+		}
+		objs, ok := j["objects"].([]interface{})
+		if !ok || len(objs) != 1 || objs[0] != "rect" {
+			t.Fatalf("objects = %v, want [rect]", j["objects"])
+		}
+	})
+
+	t.Run("non-[]byte value returns error", func(t *testing.T) {
+		var j JSONB
+		if err := j.Scan("a string, not bytes"); err == nil {
+			t.Fatal("expected error for non-[]byte value, got nil")
+		}
+		if err := j.Scan(42); err == nil {
+			t.Fatal("expected error for int value, got nil")
+		}
+		if err := j.Scan(nil); err == nil {
+			t.Fatal("expected error for nil value, got nil")
+		}
+	})
+}
+
+func TestJSONBRoundTrip(t *testing.T) {
+	orig := JSONB{
+		"version": "6.0.0",
+		"objects": []interface{}{"a", "b"},
+		"nested":  map[string]interface{}{"x": float64(1)},
+	}
+
+	v, err := orig.Value()
+	if err != nil {
+		t.Fatalf("Value returned error: %v", err)
+	}
+	b := v.([]byte)
+
+	var got JSONB
+	if err := got.Scan(b); err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(map[string]interface{}(got), map[string]interface{}(orig)) {
+		t.Fatalf("round-trip mismatch:\n got = %#v\nwant = %#v", got, orig)
+	}
+}


### PR DESCRIPTION
Table-driven tests with in-memory fakes covering auth, members, presentations, slides, JSONB. No DB required.

Also fixes a refresh-token collision bug found by the tests: refresh tokens issued in the same second for the same user were byte-identical and collided on hash, breaking rotation. Added a random `jti` claim.

🤖 Generated with Claude Code