### PR TITLE
test(e2e): Playwright main-flow E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ web/node_modules/
 
 # Uploads
 uploads/
+
+# E2E
+e2e/node_modules/
+e2e/test-results/
+e2e/playwright-report/
+e2e/.playwright/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,16 @@
+# PresentsAI E2E Tests
+
+Playwright end-to-end tests against the running stack.
+
+## Prerequisites
+The full stack must be running: `make dev` (or docker compose up). Default base URL `http://localhost`.
+
+## Run
+```bash
+cd e2e
+npm install
+npx playwright install --with-deps chromium
+npm test
+```
+
+Override base URL: `E2E_BASE_URL=http://localhost:3000 npm test`

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "presentsai-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "presentsai-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "presentsai-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { registerAndLogin, uniqueEmail, clearAuthState } from "./helpers";
+
+test.describe("Authentication", () => {
+  test("register a new account and land on dashboard", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndLogin(page, email);
+    await expect(page.getByRole("heading", { name: "マイプレゼンテーション" })).toBeVisible();
+  });
+
+  test("login persists across reload (hydration)", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndLogin(page, email);
+    await page.reload();
+    // Must NOT bounce to /login.
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page.getByRole("heading", { name: "マイプレゼンテーション" })).toBeVisible();
+  });
+
+  test("unauthenticated user is redirected to login", async ({ page }) => {
+    await clearAuthState(page);
+    await page.goto("/dashboard");
+    await page.waitForURL("**/login", { timeout: 20_000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+import { registerAndLogin, uniqueEmail } from "./helpers";
+
+test.describe("Editor flow", () => {
+  test("create presentation, add a textbox without crashing, and stay in editor", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndLogin(page, email);
+
+    const pageErrors: string[] = [];
+    page.on("pageerror", (e) => pageErrors.push(e.message));
+
+    // Create new presentation -> navigates to editor.
+    await page.getByRole("button", { name: /新規作成|最初のプレゼン/ }).first().click();
+    await page.waitForURL("**/editor/**", { timeout: 20_000 });
+
+    // Editor toolbar visible.
+    await expect(page.locator('button[title="テキスト (T)"]')).toBeVisible();
+
+    // Add a textbox (this used to trigger "Maximum update depth exceeded").
+    await page.locator('button[title="テキスト (T)"]').click();
+    await page.waitForTimeout(1500);
+    await page.keyboard.press("Escape");
+    await page.locator('button[title="テキスト (T)"]').click();
+    await page.waitForTimeout(1500);
+
+    // No infinite-loop / max-depth errors.
+    const maxDepth = pageErrors.filter((e) => /Maximum update depth/i.test(e));
+    expect(maxDepth, "should not have Maximum update depth errors").toHaveLength(0);
+
+    // Editor stays on the editor route (didn't crash out).
+    await expect(page).toHaveURL(/\/editor\//);
+  });
+
+  test("editor hard-refresh stays authenticated", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndLogin(page, email);
+    await page.getByRole("button", { name: /新規作成|最初のプレゼン/ }).first().click();
+    await page.waitForURL("**/editor/**", { timeout: 20_000 });
+    const url = page.url();
+    await page.reload();
+    await page.waitForTimeout(3000);
+    await expect(page).toHaveURL(url); // Not bounced to /login.
+  });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,0 +1,50 @@
+import { Page } from "@playwright/test";
+
+export function uniqueEmail(): string {
+  // Unique email per run. Randomness is fine in test code.
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `e2e_${rand}@example.com`;
+}
+
+export async function registerAndLogin(
+  page: Page,
+  email: string,
+  password = "password123",
+  displayName = "E2E ユーザー"
+) {
+  await page.goto("/login");
+  // Switch to the register tab.
+  await page.getByRole("button", { name: "新規登録" }).click();
+  // Display-name field only exists on the register tab.
+  await page.getByPlaceholder("田中 太郎").fill(displayName);
+  await page.locator("input[type=email]").fill(email);
+  await page.locator("input[type=password]").fill(password);
+  // Register submit button label is "アカウントを作成".
+  await page.getByRole("button", { name: /アカウントを作成/ }).click();
+  await page.waitForURL("**/dashboard", { timeout: 20_000 });
+}
+
+export async function login(page: Page, email: string, password = "password123") {
+  await page.goto("/login");
+  await page.locator("input[type=email]").fill(email);
+  await page.locator("input[type=password]").fill(password);
+  // Login submit button label is "ログイン" (avoid matching the tab by scoping to a submit button).
+  await page.locator('button[type=submit]').click();
+  await page.waitForURL("**/dashboard", { timeout: 20_000 });
+}
+
+/**
+ * Auth tokens are persisted in localStorage (zustand persist, key "presentsai-auth"),
+ * not cookies. To simulate an unauthenticated visitor we must clear localStorage.
+ */
+export async function clearAuthState(page: Page) {
+  await page.goto("/login");
+  await page.evaluate(() => {
+    try {
+      window.localStorage.clear();
+    } catch {
+      /* ignore */
+    }
+  });
+  await page.context().clearCookies();
+}

--- a/e2e/tests/slides.spec.ts
+++ b/e2e/tests/slides.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { registerAndLogin, uniqueEmail } from "./helpers";
+
+test.describe("Slides", () => {
+  test("add a slide via the slide panel", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndLogin(page, email);
+    await page.getByRole("button", { name: /新規作成|最初のプレゼン/ }).first().click();
+    await page.waitForURL("**/editor/**", { timeout: 20_000 });
+
+    // The slide panel (<aside>) lists slide thumbnails, one per ".group" wrapper.
+    // Each thumbnail wrapper has class "group relative" — count those for slide count.
+    const slidePanel = page.locator("aside").filter({ hasText: "スライド" }).first();
+    const thumbnails = slidePanel.locator("div.group");
+
+    // A new presentation starts with exactly one slide.
+    await expect(thumbnails).toHaveCount(1);
+
+    const addBtn = page.getByRole("button", { name: /スライドを追加/ });
+    await expect(addBtn).toBeVisible();
+    await addBtn.click();
+
+    // After adding, there should be exactly 2 slide thumbnails in the panel.
+    await expect(thumbnails).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
Auth + editor + slides flows. Verifies the textbox infinite-loop fix and hydration fix end-to-end.

## Tests (6, all green against nginx :80)
- **auth**: register → dashboard, hydration persists across reload, unauthenticated redirect guard
- **editor**: create presentation, add textbox without `Maximum update depth` crash, hard-refresh stays authenticated
- **slides**: add slide via panel (thumbnail count 1 → 2)

🤖 Generated with Claude Code