### PR TITLE
Add Slide data model fields: transition / animations / layoutRef

### DIFF
--- a/services/api/internal/domain/slide/entity.go
+++ b/services/api/internal/domain/slide/entity.go
@@ -12,15 +12,34 @@ type ID string
 // Content is the Fabric.js canvas JSON stored as JSONB in PostgreSQL.
 type Content map[string]interface{}
 
+// Transition is a slide-level transition played when the slide appears.
+// Type "none" (the zero value) means no transition.
+type Transition struct {
+	Type       string `json:"type"`
+	DurationMs int    `json:"durationMs,omitempty"`
+}
+
+// ElementAnimation is an animation applied to a single canvas element.
+type ElementAnimation struct {
+	TargetID   string `json:"targetId"`
+	Type       string `json:"type"`
+	Order      int    `json:"order"`
+	DurationMs int    `json:"durationMs,omitempty"`
+	DelayMs    int    `json:"delayMs,omitempty"`
+}
+
 type Slide struct {
-	ID             ID              `json:"id"`
-	PresentationID presentation.ID `json:"presentationId"`
-	Position       int             `json:"position"`
-	ThumbnailURL   string          `json:"thumbnailUrl"`
-	Notes          string          `json:"notes"`
-	Content        Content         `json:"content"`
-	CreatedAt      time.Time       `json:"createdAt"`
-	UpdatedAt      time.Time       `json:"updatedAt"`
+	ID             ID                 `json:"id"`
+	PresentationID presentation.ID    `json:"presentationId"`
+	Position       int                `json:"position"`
+	ThumbnailURL   string             `json:"thumbnailUrl"`
+	Notes          string             `json:"notes"`
+	Content        Content            `json:"content"`
+	Transition     *Transition        `json:"transition,omitempty"`
+	Animations     []ElementAnimation `json:"animations,omitempty"`
+	LayoutRef      string             `json:"layoutRef,omitempty"`
+	CreatedAt      time.Time          `json:"createdAt"`
+	UpdatedAt      time.Time          `json:"updatedAt"`
 }
 
 func New(presentationID presentation.ID, position int) *Slide {

--- a/services/api/internal/domain/slide/entity_test.go
+++ b/services/api/internal/domain/slide/entity_test.go
@@ -1,0 +1,72 @@
+package slide
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSlideJSONRoundTrip verifies the additive transition/animations/layoutRef
+// fields survive a JSON marshal -> unmarshal round trip (the API wire format).
+func TestSlideJSONRoundTrip(t *testing.T) {
+	in := Slide{
+		ID:             "s1",
+		PresentationID: "p1",
+		Position:       2,
+		Notes:          "note",
+		Content:        Content{"version": "6.0.0", "objects": []interface{}{}},
+		Transition:     &Transition{Type: "fade", DurationMs: 300},
+		Animations: []ElementAnimation{
+			{TargetID: "obj-1", Type: "fadeIn", Order: 0, DurationMs: 200, DelayMs: 50},
+			{TargetID: "obj-2", Type: "slideIn", Order: 1},
+		},
+		LayoutRef: "title",
+	}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out Slide
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if out.Transition == nil || out.Transition.Type != "fade" || out.Transition.DurationMs != 300 {
+		t.Errorf("transition not preserved: %+v", out.Transition)
+	}
+	if len(out.Animations) != 2 {
+		t.Fatalf("animations length = %d, want 2", len(out.Animations))
+	}
+	if out.Animations[0].TargetID != "obj-1" || out.Animations[0].Type != "fadeIn" ||
+		out.Animations[0].Order != 0 || out.Animations[0].DurationMs != 200 || out.Animations[0].DelayMs != 50 {
+		t.Errorf("animation[0] not preserved: %+v", out.Animations[0])
+	}
+	if out.Animations[1].TargetID != "obj-2" || out.Animations[1].Order != 1 {
+		t.Errorf("animation[1] not preserved: %+v", out.Animations[1])
+	}
+	if out.LayoutRef != "title" {
+		t.Errorf("layoutRef = %q, want %q", out.LayoutRef, "title")
+	}
+}
+
+// TestSlideJSONOmitsEmptyOptionalFields ensures a slide without the new fields
+// does not emit them, so existing slides round-trip unchanged.
+func TestSlideJSONOmitsEmptyOptionalFields(t *testing.T) {
+	in := Slide{ID: "s1", Content: Content{"version": "6.0.0"}}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"transition", "animations", "layoutRef"} {
+		if _, ok := raw[k]; ok {
+			t.Errorf("expected %q to be omitted when empty", k)
+		}
+	}
+}

--- a/services/api/internal/infrastructure/postgres/jsonb_test.go
+++ b/services/api/internal/infrastructure/postgres/jsonb_test.go
@@ -77,3 +77,48 @@ func TestJSONBRoundTrip(t *testing.T) {
 		t.Fatalf("round-trip mismatch:\n got = %#v\nwant = %#v", got, orig)
 	}
 }
+
+func TestJSONBRawValueAndScan(t *testing.T) {
+	t.Run("empty value is SQL NULL", func(t *testing.T) {
+		var j JSONBRaw
+		v, err := j.Value()
+		if err != nil {
+			t.Fatalf("Value returned error: %v", err)
+		}
+		if v != nil {
+			t.Fatalf("Value = %v, want nil for empty JSONBRaw", v)
+		}
+	})
+
+	t.Run("nil scan yields nil", func(t *testing.T) {
+		j := JSONBRaw(`{"a":1}`)
+		if err := j.Scan(nil); err != nil {
+			t.Fatalf("Scan(nil) returned error: %v", err)
+		}
+		if j != nil {
+			t.Fatalf("after Scan(nil), JSONBRaw = %v, want nil", j)
+		}
+	})
+
+	t.Run("array round-trips", func(t *testing.T) {
+		orig := JSONBRaw(`[{"targetId":"o1","type":"fadeIn","order":0}]`)
+		v, err := orig.Value()
+		if err != nil {
+			t.Fatalf("Value returned error: %v", err)
+		}
+		var got JSONBRaw
+		if err := got.Scan(v.([]byte)); err != nil {
+			t.Fatalf("Scan returned error: %v", err)
+		}
+		if string(got) != string(orig) {
+			t.Fatalf("round-trip mismatch: got %s, want %s", got, orig)
+		}
+	})
+
+	t.Run("non-[]byte value returns error", func(t *testing.T) {
+		var j JSONBRaw
+		if err := j.Scan("not bytes"); err == nil {
+			t.Fatal("expected error for non-[]byte value, got nil")
+		}
+	})
+}

--- a/services/api/internal/infrastructure/postgres/models.go
+++ b/services/api/internal/infrastructure/postgres/models.go
@@ -22,6 +22,30 @@ func (j *JSONB) Scan(value interface{}) error {
 	return json.Unmarshal(b, j)
 }
 
+// JSONBRaw is a nullable jsonb column holding arbitrary JSON (objects or
+// arrays). It is used for additive slide fields (transition, animations).
+type JSONBRaw json.RawMessage
+
+func (j JSONBRaw) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
+	return []byte(j), nil
+}
+
+func (j *JSONBRaw) Scan(value interface{}) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+	b, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("JSONBRaw: expected []byte, got %T", value)
+	}
+	*j = append((*j)[:0], b...)
+	return nil
+}
+
 type UserModel struct {
 	ID           string    `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	Email        string    `gorm:"uniqueIndex;not null"`
@@ -52,6 +76,9 @@ type SlideModel struct {
 	ThumbnailURL   string    `gorm:"default:''"`
 	Notes          string    `gorm:"not null;default:''"`
 	Content        JSONB     `gorm:"type:jsonb;not null;default:'{}'"`
+	Transition     JSONBRaw  `gorm:"type:jsonb"`
+	Animations     JSONBRaw  `gorm:"type:jsonb"`
+	LayoutRef      string    `gorm:"not null;default:''"`
 	CreatedAt      time.Time `gorm:"autoCreateTime"`
 	UpdatedAt      time.Time `gorm:"autoUpdateTime"`
 }

--- a/services/api/internal/infrastructure/postgres/slide_repository.go
+++ b/services/api/internal/infrastructure/postgres/slide_repository.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 
 	"gorm.io/gorm"
 
@@ -24,6 +25,9 @@ func (r *slideRepository) Create(ctx context.Context, s *domainSlide.Slide) erro
 		Position:       s.Position,
 		ThumbnailURL:   s.ThumbnailURL,
 		Content:        JSONB(s.Content),
+		Transition:     marshalRaw(s.Transition),
+		Animations:     marshalRaw(s.Animations),
+		LayoutRef:      s.LayoutRef,
 	}
 	if err := r.db.WithContext(ctx).Create(m).Error; err != nil {
 		return err
@@ -70,6 +74,9 @@ func (r *slideRepository) Update(ctx context.Context, s *domainSlide.Slide) erro
 			"content":       JSONB(s.Content),
 			"thumbnail_url": s.ThumbnailURL,
 			"notes":         s.Notes,
+			"transition":    marshalRaw(s.Transition),
+			"animations":    marshalRaw(s.Animations),
+			"layout_ref":    s.LayoutRef,
 		}).Error
 }
 
@@ -91,14 +98,45 @@ func (r *slideRepository) ReorderSlides(ctx context.Context, presentationID stri
 }
 
 func modelToSlide(m *SlideModel) *domainSlide.Slide {
-	return &domainSlide.Slide{
+	s := &domainSlide.Slide{
 		ID:             domainSlide.ID(m.ID),
 		PresentationID: domainPresentation.ID(m.PresentationID),
 		Position:       m.Position,
 		ThumbnailURL:   m.ThumbnailURL,
 		Notes:          m.Notes,
 		Content:        domainSlide.Content(m.Content),
+		LayoutRef:      m.LayoutRef,
 		CreatedAt:      m.CreatedAt,
 		UpdatedAt:      m.UpdatedAt,
 	}
+	if len(m.Transition) > 0 {
+		var t domainSlide.Transition
+		if json.Unmarshal(m.Transition, &t) == nil {
+			s.Transition = &t
+		}
+	}
+	if len(m.Animations) > 0 {
+		_ = json.Unmarshal(m.Animations, &s.Animations)
+	}
+	return s
+}
+
+// marshalRaw serializes a value to a jsonb column. A nil pointer / empty slice
+// yields a nil column (SQL NULL), keeping the field optional and additive.
+func marshalRaw(v interface{}) JSONBRaw {
+	switch val := v.(type) {
+	case *domainSlide.Transition:
+		if val == nil {
+			return nil
+		}
+	case []domainSlide.ElementAnimation:
+		if len(val) == 0 {
+			return nil
+		}
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return JSONBRaw(b)
 }

--- a/web/src/features/editor/stores/slideStore.test.ts
+++ b/web/src/features/editor/stores/slideStore.test.ts
@@ -57,4 +57,33 @@ describe("useSlideStore", () => {
     useSlideStore.getState().setCurrentIndex(2);
     expect(useSlideStore.getState().currentIndex).toBe(2);
   });
+
+  it("setSlides preserves transition/animations/layoutRef fields", () => {
+    const s = slide("a", {
+      transition: { type: "fade", durationMs: 300 },
+      animations: [{ targetId: "o1", type: "fadeIn", order: 0 }],
+      layoutRef: "title",
+    });
+    useSlideStore.getState().setSlides([s]);
+    const got = useSlideStore.getState().slides[0];
+    expect(got.transition).toEqual({ type: "fade", durationMs: 300 });
+    expect(got.animations).toEqual([{ targetId: "o1", type: "fadeIn", order: 0 }]);
+    expect(got.layoutRef).toBe("title");
+  });
+
+  it("updateSlideMeta updates slide-level fields on the matching slide only", () => {
+    useSlideStore.getState().setSlides([slide("a"), slide("b")]);
+    useSlideStore.getState().updateSlideMeta("a", {
+      transition: { type: "slide", durationMs: 500 },
+      animations: [{ targetId: "x", type: "zoomIn", order: 1, delayMs: 100 }],
+      layoutRef: "blank",
+    });
+    const [a, b] = useSlideStore.getState().slides;
+    expect(a.transition).toEqual({ type: "slide", durationMs: 500 });
+    expect(a.animations).toEqual([{ targetId: "x", type: "zoomIn", order: 1, delayMs: 100 }]);
+    expect(a.layoutRef).toBe("blank");
+    // content untouched, sibling untouched
+    expect(a.content.version).toBe("6.0.0");
+    expect(b.transition).toBeUndefined();
+  });
 });

--- a/web/src/features/editor/stores/slideStore.ts
+++ b/web/src/features/editor/stores/slideStore.ts
@@ -8,6 +8,11 @@ interface SlideState {
   setSlides: (slides: Slide[]) => void;
   addSlide: (slide: Slide) => void;
   updateSlide: (id: string, content: Record<string, unknown>) => void;
+  /** Update slide-level metadata (transition / animations / layoutRef / notes). */
+  updateSlideMeta: (
+    id: string,
+    meta: Partial<Pick<Slide, "transition" | "animations" | "layoutRef" | "notes">>,
+  ) => void;
   deleteSlide: (id: string) => void;
   setCurrentIndex: (index: number) => void;
 }
@@ -24,6 +29,10 @@ export const useSlideStore = create<SlideState>()((set) => ({
       slides: state.slides.map((s) =>
         s.id === id ? { ...s, content: { ...s.content, ...content } } : s
       ),
+    })),
+  updateSlideMeta: (id, meta) =>
+    set((state) => ({
+      slides: state.slides.map((s) => (s.id === id ? { ...s, ...meta } : s)),
     })),
   deleteSlide: (id) =>
     set((state) => ({

--- a/web/src/shared/types/slide.ts
+++ b/web/src/shared/types/slide.ts
@@ -14,6 +14,12 @@ export interface Slide {
   thumbnailUrl?: string;
   notes?: string;
   content: SlideContent;
+  /** Slide-level entrance/exit transition played when the slide appears. */
+  transition?: SlideTransition;
+  /** Per-element animations played within the slide. */
+  animations?: ElementAnimation[];
+  /** Reference to the layout template this slide was created from. */
+  layoutRef?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -23,6 +29,41 @@ export interface SlideContent {
   objects: FabricObject[];
   background?: string;
 }
+
+/** Slide-level transition. `type` "none" means no transition (default). */
+export interface SlideTransition {
+  type: SlideTransitionType;
+  /** Duration in milliseconds. */
+  durationMs?: number;
+}
+
+export type SlideTransitionType =
+  | "none"
+  | "fade"
+  | "slide"
+  | "push"
+  | "zoom";
+
+/** Animation applied to a single canvas element, identified by its object id. */
+export interface ElementAnimation {
+  /** Fabric object id (or custom element id) this animation targets. */
+  targetId: string;
+  type: ElementAnimationType;
+  /** Play order within the slide (ascending). */
+  order: number;
+  /** Duration in milliseconds. */
+  durationMs?: number;
+  /** Delay before the animation starts, in milliseconds. */
+  delayMs?: number;
+}
+
+export type ElementAnimationType =
+  | "fadeIn"
+  | "fadeOut"
+  | "slideIn"
+  | "slideOut"
+  | "zoomIn"
+  | "zoomOut";
 
 export type FabricObject = Record<string, unknown>;
 


### PR DESCRIPTION
## 概要 (Summary)
大規模リファクタの最初のPR。後発機能（アニメ・トランジション・レイアウト）が依存する **Slide データモデルの土台** を確定する。型/スキーマの **additive・非破壊** 拡張のみで、挙動は一切変えない（「保存できる箱」を作るだけ）。

## スコープ (Scope) — 土台のみ・挙動不変
- **TS** `Slide` 型に optional フィールドを追加:
  - `transition?: SlideTransition`（`type` + `durationMs`）
  - `animations?: ElementAnimation[]`（`targetId` / `type` / `order` / `durationMs` / `delayMs`）
  - `layoutRef?: string`（レイアウトテンプレート参照）
  - Zustand store に `updateSlideMeta` アクションを追加（slide レベルのメタ更新）。`setSlides`/`addSlide` は top-level フィールドをそのまま保持。
- **Go** domain `Slide` エンティティと GORM `SlideModel` に同等フィールドを追加:
  - `Transition *Transition` / `Animations []ElementAnimation` を jsonb 列、`LayoutRef string` を text 列として保存。
  - repository の Create / Update / modelToSlide を配線。nullable な jsonb 用に `JSONBRaw` 型を追加。
- **マイグレーション不要**: スキーマは GORM `AutoMigrate` 管理。AutoMigrate は列を追加するのみ（破壊なし）なので additive。デフォルト値で既存スライドは壊れない（空のときは JSON から省略 / SQL NULL）。
- **このPRでやらないこと**: 再生・UI 配線（P1 で実施）。

## テスト結果 (Verification)
すべて green:
- `cd web && npx tsc --noEmit` → exit 0
- `cd web && npx vitest run` → **53 passed**（既存 51 + 新規 2: setSlides がメタ保持 / updateSlideMeta）
- `cd web && npx next build` → 成功（全ルート生成）
- `cd services/api && go build ./...` → exit 0
- `cd services/api && go test ./...` → 全パッケージ **ok**（新規: domain/slide の JSON round-trip 2件、postgres の JSONBRaw Value/Scan/round-trip 4件）

既存テストの破壊なし。