### PR TITLE
エクスポートを全スライド対応にする (PDF/PNG/PPTX)

### DIFF
--- a/web/src/features/editor/components/Backstage/Backstage.tsx
+++ b/web/src/features/editor/components/Backstage/Backstage.tsx
@@ -6,11 +6,12 @@ import {
   X, ArrowLeft, FileText, FileImage, FileCode, Presentation,
 } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStore } from "../../stores/slideStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { toJSON } from "@lib/fabric/canvas";
 import { exportToPDF } from "@lib/export/pdf";
-import { exportToPNG, exportToSVG } from "@lib/export/png";
+import { exportAllSlidesToPNG, exportToSVG } from "@lib/export/png";
 import { exportToPPTX } from "@lib/export/pptx";
 import type { SlideContent } from "@shared/types/slide";
 
@@ -34,6 +35,7 @@ export function Backstage({ open, onClose }: BackstageProps) {
   const router = useRouter();
   const [section, setSection] = useState<Section>("new");
   const { canvas, activeSlideId, presentationId } = useEditorStore();
+  const slides = useSlideStore((s) => s.slides);
   const setDirty = useEditorStore((s) => s.setDirty);
   const { accessToken } = useAuthStore();
 
@@ -149,10 +151,10 @@ export function Backstage({ open, onClose }: BackstageProps) {
           <Panel title="エクスポート">
             <div className="grid max-w-2xl grid-cols-2 gap-4">
               {[
-                { l: "PDF", desc: "PDF として保存", Icon: FileText, fn: () => exportToPDF(canvas!) },
-                { l: "PNG", desc: "画像として保存", Icon: FileImage, fn: () => exportToPNG(canvas!) },
+                { l: "PDF", desc: "PDF として保存", Icon: FileText, fn: () => exportToPDF(slides) },
+                { l: "PNG", desc: "画像として保存", Icon: FileImage, fn: () => exportAllSlidesToPNG(slides) },
                 { l: "SVG", desc: "ベクター形式で保存", Icon: FileCode, fn: () => exportToSVG(canvas!) },
-                { l: "PowerPoint", desc: "PPTX として保存", Icon: Presentation, fn: () => exportToPPTX(canvas!) },
+                { l: "PowerPoint", desc: "PPTX として保存", Icon: Presentation, fn: () => exportToPPTX(slides) },
               ].map(({ l, desc, Icon, fn }) => (
                 <button
                   key={l}
@@ -174,7 +176,7 @@ export function Backstage({ open, onClose }: BackstageProps) {
         {section === "print" && (
           <Panel title="印刷">
             <button
-              onClick={() => { if (canvas) exportToPDF(canvas); }}
+              onClick={() => { if (canvas) exportToPDF(slides); }}
               disabled={!canvas}
               className="btn btn-primary gap-2 disabled:opacity-50"
             >

--- a/web/src/features/editor/components/Toolbar/ExportButton.tsx
+++ b/web/src/features/editor/components/Toolbar/ExportButton.tsx
@@ -2,23 +2,25 @@
 import { useState } from "react";
 import { Download, FileText, FileImage, FileCode, Presentation } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStore } from "../../stores/slideStore";
 import { exportToPDF } from "@lib/export/pdf";
-import { exportToPNG, exportToSVG } from "@lib/export/png";
+import { exportAllSlidesToPNG, exportToSVG } from "@lib/export/png";
 import { exportToPPTX } from "@lib/export/pptx";
 import { Popover } from "@shared/components/ui";
 
 export function ExportButton() {
   const { canvas } = useEditorStore();
+  const slides = useSlideStore((s) => s.slides);
   const [busy, setBusy] = useState(false);
   async function run(fn: ()=>Promise<void>|void, close: () => void) {
     if (!canvas) return; setBusy(true); close();
     try { await fn(); } finally { setBusy(false); }
   }
   const OPTIONS = [
-    { l: "PDF として保存", Icon: FileText, fn: () => exportToPDF(canvas!) },
-    { l: "PNG として保存", Icon: FileImage, fn: () => exportToPNG(canvas!) },
+    { l: "PDF として保存", Icon: FileText, fn: () => exportToPDF(slides) },
+    { l: "PNG として保存", Icon: FileImage, fn: () => exportAllSlidesToPNG(slides) },
     { l: "SVG として保存", Icon: FileCode, fn: () => exportToSVG(canvas!) },
-    { l: "PPTX として保存", Icon: Presentation, fn: () => exportToPPTX(canvas!) },
+    { l: "PPTX として保存", Icon: Presentation, fn: () => exportToPPTX(slides) },
   ];
   return (
     <Popover

--- a/web/src/lib/export/pdf.ts
+++ b/web/src/lib/export/pdf.ts
@@ -1,8 +1,25 @@
 import jsPDF from "jspdf";
-import type { Canvas } from "fabric";
-export async function exportToPDF(canvas: Canvas, title="presentation"): Promise<void> {
-  const dataURL = canvas.toDataURL({ format:"png", multiplier:2 });
-  const pdf = new jsPDF({ orientation:"landscape", unit:"px", format:[1280,720] });
-  pdf.addImage(dataURL,"PNG",0,0,1280,720);
+import type { Slide } from "@shared/types/slide";
+import { renderAllSlides } from "./renderSlides";
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+
+/**
+ * Export the whole deck as a multi-page PDF — one slide per page. Each slide is
+ * rasterized on a throwaway offscreen canvas, so the result is independent of
+ * which slide is currently visible in the editor.
+ */
+export async function exportToPDF(slides: Slide[], title = "presentation"): Promise<void> {
+  const urls = await renderAllSlides(slides);
+  if (urls.length === 0) return;
+
+  const pdf = new jsPDF({
+    orientation: "landscape",
+    unit: "px",
+    format: [SLIDE_WIDTH, SLIDE_HEIGHT],
+  });
+  urls.forEach((url, i) => {
+    if (i > 0) pdf.addPage([SLIDE_WIDTH, SLIDE_HEIGHT], "landscape");
+    pdf.addImage(url, "PNG", 0, 0, SLIDE_WIDTH, SLIDE_HEIGHT);
+  });
   pdf.save(`${title}.pdf`);
 }

--- a/web/src/lib/export/png.ts
+++ b/web/src/lib/export/png.ts
@@ -1,11 +1,33 @@
 import type { Canvas } from "fabric";
-export function exportToPNG(canvas: Canvas, filename="slide"): void {
-  const url = canvas.toDataURL({ format:"png", multiplier:2 });
-  const a = document.createElement("a"); a.href=url; a.download=`${filename}.png`; a.click();
+import type { Slide } from "@shared/types/slide";
+import { renderAllSlides } from "./renderSlides";
+
+function downloadDataURL(url: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
 }
-export function exportToSVG(canvas: Canvas, filename="slide"): void {
+
+/**
+ * Export every slide in the deck as a separate PNG, downloaded as a numbered
+ * file group (`slide-1.png`, `slide-2.png`, ...). Each slide is rasterized on
+ * a throwaway offscreen canvas, independent of the currently visible canvas.
+ */
+export async function exportAllSlidesToPNG(slides: Slide[], filename = "slide"): Promise<void> {
+  const urls = await renderAllSlides(slides);
+  urls.forEach((url, i) => downloadDataURL(url, `${filename}-${i + 1}.png`));
+}
+
+/** Export the single visible canvas as PNG (used for ad-hoc single-slide saves). */
+export function exportToPNG(canvas: Canvas, filename = "slide"): void {
+  const url = canvas.toDataURL({ format: "png", multiplier: 2 });
+  downloadDataURL(url, `${filename}.png`);
+}
+
+export function exportToSVG(canvas: Canvas, filename = "slide"): void {
   const svg = canvas.toSVG();
-  const url = URL.createObjectURL(new Blob([svg],{type:"image/svg+xml"}));
-  const a = document.createElement("a"); a.href=url; a.download=`${filename}.svg`; a.click();
+  const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+  downloadDataURL(url, `${filename}.svg`);
   URL.revokeObjectURL(url);
 }

--- a/web/src/lib/export/pptx.ts
+++ b/web/src/lib/export/pptx.ts
@@ -1,11 +1,25 @@
 import pptxgen from "pptxgenjs";
-import type { Canvas } from "fabric";
-export async function exportToPPTX(canvas: Canvas, title="presentation"): Promise<void> {
+import type { Slide } from "@shared/types/slide";
+import { renderAllSlides } from "./renderSlides";
+
+/**
+ * Export the whole deck as a PPTX — one PowerPoint slide per deck slide. Each
+ * slide is rasterized (full-bleed image) on a throwaway offscreen canvas.
+ *
+ * NOTE: slides are embedded as raster images, not native PPTX shapes/text.
+ * Vectorizing into editable shapes is intentionally out of scope (separate PR).
+ */
+export async function exportToPPTX(slides: Slide[], title = "presentation"): Promise<void> {
+  const urls = await renderAllSlides(slides);
+
   const pptx = new pptxgen();
-  pptx.defineLayout({ name:"SLIDE_16x9", width:10, height:5.625 });
-  pptx.layout="SLIDE_16x9";
-  const slide = pptx.addSlide();
-  const dataURL = canvas.toDataURL({ format:"png", multiplier:1 });
-  slide.addImage({ data:dataURL, x:0,y:0, w:"100%",h:"100%" });
-  await pptx.writeFile({ fileName:`${title}.pptx` });
+  pptx.defineLayout({ name: "SLIDE_16x9", width: 10, height: 5.625 });
+  pptx.layout = "SLIDE_16x9";
+
+  for (const url of urls) {
+    const slide = pptx.addSlide();
+    slide.addImage({ data: url, x: 0, y: 0, w: "100%", h: "100%" });
+  }
+
+  await pptx.writeFile({ fileName: `${title}.pptx` });
 }

--- a/web/src/lib/export/renderSlides.test.ts
+++ b/web/src/lib/export/renderSlides.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderAllSlides } from "./renderSlides";
+import type { Slide, SlideContent } from "@shared/types/slide";
+
+function makeSlide(id: string, position: number, label: string): Slide {
+  const content: SlideContent = { version: "6.0.0", objects: [{ label }] };
+  return {
+    id,
+    presentationId: "p1",
+    position,
+    content,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("renderAllSlides", () => {
+  it("returns one data URL per slide (count parity)", async () => {
+    const slides = [
+      makeSlide("a", 0, "A"),
+      makeSlide("b", 1, "B"),
+      makeSlide("c", 2, "C"),
+    ];
+    const render = vi.fn((c: SlideContent) => Promise.resolve(`url:${(c.objects[0] as { label: string }).label}`));
+
+    const urls = await renderAllSlides(slides, render);
+
+    expect(urls).toHaveLength(slides.length);
+    expect(render).toHaveBeenCalledTimes(slides.length);
+  });
+
+  it("walks slides in position order regardless of array order", async () => {
+    const slides = [
+      makeSlide("c", 2, "C"),
+      makeSlide("a", 0, "A"),
+      makeSlide("b", 1, "B"),
+    ];
+    const render = (c: SlideContent) =>
+      Promise.resolve(`url:${(c.objects[0] as { label: string }).label}`);
+
+    const urls = await renderAllSlides(slides, render);
+
+    expect(urls).toEqual(["url:A", "url:B", "url:C"]);
+  });
+
+  it("returns an empty array for an empty deck", async () => {
+    const render = vi.fn(() => Promise.resolve("url"));
+    const urls = await renderAllSlides([], render);
+    expect(urls).toEqual([]);
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it("passes each slide's content through to the renderer", async () => {
+    const slides = [makeSlide("a", 0, "only")];
+    const render = vi.fn((c: SlideContent) => Promise.resolve(JSON.stringify(c)));
+    await renderAllSlides(slides, render);
+    expect(render).toHaveBeenCalledWith(slides[0].content);
+  });
+});

--- a/web/src/lib/export/renderSlides.ts
+++ b/web/src/lib/export/renderSlides.ts
@@ -1,0 +1,52 @@
+import { StaticCanvas } from "fabric";
+import type { Slide, SlideContent } from "@shared/types/slide";
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+
+/** PNG quality multiplier used when rasterizing a slide for export. */
+const EXPORT_MULTIPLIER = 2;
+
+/**
+ * Render a single slide's content to a PNG data URL using a throwaway
+ * offscreen Fabric canvas. The canvas is created detached from the DOM,
+ * loaded from the slide JSON, rasterized, then disposed so no editor state
+ * or visible canvas is touched.
+ */
+export async function renderSlideToDataURL(content: SlideContent): Promise<string> {
+  // A bare <canvas> element kept off the document; StaticCanvas is non-
+  // interactive, which is all we need for rasterizing.
+  const el = document.createElement("canvas");
+  const canvas = new StaticCanvas(el, {
+    width: SLIDE_WIDTH,
+    height: SLIDE_HEIGHT,
+    backgroundColor: content.background ?? "#ffffff",
+  });
+  try {
+    await canvas.loadFromJSON(content as unknown as Record<string, unknown>);
+    canvas.renderAll();
+    return canvas.toDataURL({ format: "png", multiplier: EXPORT_MULTIPLIER });
+  } finally {
+    canvas.dispose();
+  }
+}
+
+/**
+ * Rasterize every slide in `slides` (ordered by `position`) to a PNG data URL.
+ *
+ * The renderer is injectable so the slide-walking logic can be unit-tested
+ * without a real browser/Fabric canvas. Production callers rely on the default
+ * {@link renderSlideToDataURL}.
+ *
+ * @returns one data URL per slide, in slide order. Length always equals
+ *          `slides.length`.
+ */
+export async function renderAllSlides(
+  slides: Slide[],
+  render: (content: SlideContent) => Promise<string> = renderSlideToDataURL,
+): Promise<string[]> {
+  const ordered = [...slides].sort((a, b) => a.position - b.position);
+  const urls: string[] = [];
+  for (const slide of ordered) {
+    urls.push(await render(slide.content));
+  }
+  return urls;
+}


### PR DESCRIPTION
## 概要

エクスポートが「現在表示中の1スライドのみ」しか出力できなかった欠陥を修正し、デッキ全体を出力できるようにする。

- **PDF**: 全スライドを走査し、各スライドを1ページとする複数ページ PDF を生成
- **PNG**: 全スライドをそれぞれ PNG 化し、連番ファイル群 (`slide-1.png`, `slide-2.png`, ...) としてダウンロード
- **PPTX**: 全スライドを走査し、各スライドを1枚の PowerPoint スライドとして持つ pptx を生成

## オフスクリーン全スライド走査の方式

`web/src/lib/export/renderSlides.ts` に `renderAllSlides` を追加。

- 各 `slide.content` (JSON) から **DOM 非接続の `<canvas>` + Fabric `StaticCanvas`** (1280×720) を生成 → `loadFromJSON` → `renderAll` → `toDataURL` → `dispose`、を全スライドぶん回す
- 表示中の canvas に一切依存しない（編集中の状態を汚さない）
- `position` 順にソートして走査
- レンダラを差し替え可能 (injectable) にしてあり、ブラウザなしで走査ロジックを単体テストできる

## スコープ（bounded）

- **このPRでやること**: ラスタ（画像）のまま全スライドを出力する
- **やらないこと（別PR）**: PPTX のネイティブ図形/テキスト化（**ベクター化**）、SVG エクスポートの全スライド対応。PPTX は現状方式（各スライドを画像として貼る）を全スライドに拡張し、まず「全枚数入る」ことを達成する

## 検証

- `npm run build` green（既存の `style.ts` の warning のみ。本PRと無関係）
- `npx vitest run` green: **57 tests passed**（うち新規4件: 2枚以上のデッキでページ数/スライド数が一致 + position順走査を検証）
- `tsc --noEmit` green
- 既存テスト破壊なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)