### PR TITLE
P0: AIのブラウザ直叩きを廃止しBFFプロキシ化

### DIFF
--- a/web/src/app/api/ai/chat/route.test.ts
+++ b/web/src/app/api/ai/chat/route.test.ts
@@ -1,0 +1,93 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { POST } from "./route";
+
+function makeReq(body: unknown): Request {
+  return new Request("http://localhost/api/ai/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+describe("POST /api/ai/chat", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("proxies to the gateway with stream:true and the configured model", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }),
+    );
+
+    await POST(makeReq({ messages: [{ role: "user", content: "hi" }] }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1/chat/completions");
+    const sent = JSON.parse(init.body);
+    expect(sent.stream).toBe(true);
+    expect(sent.model).toBe("lfm2-2.6b-f16");
+    expect(sent.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("passes the gateway SSE stream through to the client", async () => {
+    const payload = 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\ndata: [DONE]\n\n';
+    fetchMock.mockResolvedValue(
+      new Response(sseStream([payload]), { status: 200 }),
+    );
+
+    const res = await POST(makeReq({ messages: [{ role: "user", content: "x" }] }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toBe(payload);
+  });
+
+  it("forwards response_format when provided", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }),
+    );
+
+    await POST(
+      makeReq({
+        messages: [{ role: "user", content: "x" }],
+        response_format: { type: "json_object" },
+      }),
+    );
+
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("returns 400 when messages are missing", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the gateway fails", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+    const res = await POST(
+      makeReq({ messages: [{ role: "user", content: "x" }] }),
+    );
+    expect(res.status).toBe(502);
+  });
+});

--- a/web/src/app/api/ai/chat/route.ts
+++ b/web/src/app/api/ai/chat/route.ts
@@ -1,0 +1,63 @@
+// Runs server-side only so the browser never learns the gateway URL.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const GATEWAY_URL = process.env.LLM_GATEWAY_URL ?? "http://localhost:4242";
+
+interface ChatBody {
+  messages: { role: string; content: string }[];
+  max_tokens?: number;
+  temperature?: number;
+  response_format?: { type: string };
+}
+
+const MODEL = "lfm2-2.6b-f16";
+
+export async function POST(req: Request) {
+  let body: ChatBody;
+  try {
+    body = (await req.json()) as ChatBody;
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid_json" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  if (!Array.isArray(body?.messages) || body.messages.length === 0) {
+    return new Response(JSON.stringify({ error: "messages_required" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const upstream = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: body.messages,
+      max_tokens: body.max_tokens ?? 1024,
+      temperature: body.temperature ?? 0.7,
+      ...(body.response_format ? { response_format: body.response_format } : {}),
+      stream: true,
+    }),
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response(
+      JSON.stringify({ error: "gateway_error", status: upstream.status }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  // Pass the SSE stream straight through to the client.
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    },
+  });
+}

--- a/web/src/features/ai/components/AIPanel.tsx
+++ b/web/src/features/ai/components/AIPanel.tsx
@@ -33,7 +33,7 @@ export function AIPanel() {
         setResult(r);
       }
     } catch {
-      setResult("エラー: localhost:4242 が起動していることを確認してください。");
+      setResult("エラー: AI サービスに接続できませんでした。しばらくして再試行してください。");
     } finally { setLoading(false); }
   }
 
@@ -42,7 +42,7 @@ export function AIPanel() {
       <h2 className="flex items-center gap-2 text-sm font-semibold text-content-primary">
         <Bot className="h-4 w-4 text-primary-600" /> AI アシスタント
       </h2>
-      <p className="text-xs text-content-tertiary">LFM2-2.6B ローカル</p>
+      <p className="text-xs text-content-tertiary">AI アシスタント</p>
       <div className="flex gap-1">
         {(["improve","generate","outline"] as const).map(m=>(
           <button key={m} onClick={()=>setMode(m)} className={`flex-1 rounded-lg py-1 text-xs font-medium transition-colors ${mode===m?"bg-primary-600 text-white":"bg-surface-muted text-content-secondary hover:bg-surface-subtle"}`}>

--- a/web/src/features/ai/components/PresentationReport.tsx
+++ b/web/src/features/ai/components/PresentationReport.tsx
@@ -24,7 +24,7 @@ export function PresentationReport({ transcript }: { transcript: string }) {
       );
       setReport(r);
     } catch {
-      setReport({ summary:"LFM Gateway が必要です", strengths:[], improvements:[], score:0 });
+      setReport({ summary:"AI サービスに接続できませんでした", strengths:[], improvements:[], score:0 });
     } finally { setLoading(false); }
   }
 

--- a/web/src/lib/ai/client.ts
+++ b/web/src/lib/ai/client.ts
@@ -1,22 +1,90 @@
-import OpenAI from "openai";
-const client = new OpenAI({
-  baseURL: typeof window !== "undefined"
-    ? (process.env.NEXT_PUBLIC_LLM_GATEWAY_URL ?? "http://localhost:4242/v1")
-    : "http://localhost:4242/v1",
-  apiKey: "local",
-  dangerouslyAllowBrowser: true,
-});
-export async function generateText(prompt: string, system?: string): Promise<string> {
-  const msgs: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-  if (system) msgs.push({ role:"system", content:system });
-  msgs.push({ role:"user", content:prompt });
-  const res = await client.chat.completions.create({ model:"lfm2-2.6b-f16", messages:msgs, max_tokens:1024, temperature:0.7 });
-  return res.choices[0]?.message?.content ?? "";
+// Browser-side AI client. Calls the in-app BFF (/api/ai/chat) which proxies
+// to the LFM Gateway server-side. The browser never sees the gateway URL.
+
+interface Message {
+  role: "system" | "user" | "assistant";
+  content: string;
 }
+
+interface ChatRequest {
+  messages: Message[];
+  max_tokens?: number;
+  temperature?: number;
+  response_format?: { type: string };
+}
+
+/**
+ * POSTs to the BFF and consumes the SSE stream, invoking onToken for each
+ * incremental delta. Returns the fully aggregated text.
+ */
+async function streamChat(
+  req: ChatRequest,
+  onToken?: (delta: string) => void,
+): Promise<string> {
+  const res = await fetch("/api/ai/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(req),
+  });
+
+  if (!res.ok || !res.body) {
+    throw new Error(`AI request failed: ${res.status}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let full = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    // SSE events are separated by double newlines; each line is "data: ...".
+    let nl: number;
+    while ((nl = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (!line.startsWith("data:")) continue;
+      const data = line.slice(5).trim();
+      if (data === "" || data === "[DONE]") continue;
+      try {
+        const json = JSON.parse(data);
+        const delta: string = json.choices?.[0]?.delta?.content ?? "";
+        if (delta) {
+          full += delta;
+          onToken?.(delta);
+        }
+      } catch {
+        // Ignore non-JSON keep-alive lines.
+      }
+    }
+  }
+
+  return full;
+}
+
+export async function generateText(
+  prompt: string,
+  system?: string,
+  onToken?: (delta: string) => void,
+): Promise<string> {
+  const messages: Message[] = [];
+  if (system) messages.push({ role: "system", content: system });
+  messages.push({ role: "user", content: prompt });
+  return streamChat({ messages, max_tokens: 1024, temperature: 0.7 }, onToken);
+}
+
 export async function generateJSON<T>(prompt: string, system?: string): Promise<T> {
-  const msgs: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-  if (system) msgs.push({ role:"system", content:system });
-  msgs.push({ role:"user", content:prompt });
-  const res = await client.chat.completions.create({ model:"lfm2-2.6b-f16", messages:msgs, max_tokens:2048, temperature:0.3, response_format:{type:"json_object"} });
-  return JSON.parse(res.choices[0]?.message?.content ?? "{}") as T;
+  const messages: Message[] = [];
+  if (system) messages.push({ role: "system", content: system });
+  messages.push({ role: "user", content: prompt });
+  const text = await streamChat({
+    messages,
+    max_tokens: 2048,
+    temperature: 0.3,
+    response_format: { type: "json_object" },
+  });
+  return JSON.parse(text || "{}") as T;
 }


### PR DESCRIPTION
## 概要

AI 呼び出しを **ブラウザ直叩きから廃止**し、**サーバー側 BFF (Next.js Route Handler) 経由**に変更する P0 リファクタ。経路のみ差し替え、AI 機能の挙動・UX は不変。

### 背景（監査）
- 旧 `web/src/lib/ai/client.ts` が `dangerouslyAllowBrowser:true` で LFM Gateway (`localhost:4242`) を **ブラウザから直接** 呼んでいた。CORS / 認証 / 秘匿 / レート制限の観点で本番不可。

### 変更内容
1. **BFF ルート新設**: `web/src/app/api/ai/chat/route.ts`（`runtime="nodejs"`）。サーバー環境変数 `LLM_GATEWAY_URL`（デフォルト `http://localhost:4242`）へ `/v1/chat/completions` をプロキシし、`stream:true` で取得した **SSE をそのままパススルー**（`Response(upstream.body)` で `text/event-stream` をストリーム転送）。
2. **クライアント改修**: `lib/ai/client.ts` を `/api/ai/chat` を叩く実装に書き換え。`fetch` で SSE を読み取り delta を集約。**OpenAI SDK / `dangerouslyAllowBrowser` / 直 Gateway URL をブラウザ側から完全除去**。`generateText` / `generateJSON` のシグネチャは維持。
3. **呼び出し側**: `AIPanel` / `RealtimeCoach` / `PresentationReport` は同シグネチャのため挙動不変。Gateway URL を漏らしていたエラーメッセージ表記のみ修正。

### アーキ選択
- BFF は **Next.js Route Handler（web アプリ内）** に配置。AI 呼び出しはフロント起点であり、最小変更で秘匿化できるため。Go api サービスに置く強い理由は現状なし。

### ストリーミング方式
- **ReadableStream パススルー**: Gateway の SSE (`text/event-stream`) を `Response(upstream.body)` でそのままクライアントへ中継。クライアントは `getReader()` で逐次パースし体感のストリーミング性を維持。

## 検証
- `npm run build`: green（`/api/ai/chat` は dynamic server route として出力）
- `npx vitest run`: **62 passed**（うち BFF ルートの新規テスト 5: proxy / stream passthrough / response_format 転送 / 400 / 502）
- 既存テスト破壊なし。クライアントバンドルに `4242` / `dangerouslyAllowBrowser` が含まれないことを確認済み。