### PR TITLE
Persist slide transition / animation settings (no playback yet)

### DIFF
--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -100,6 +100,7 @@ func main() {
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}", slideHandler.HandleUpdate).Methods(http.MethodPut)
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}", slideHandler.HandleDelete).Methods(http.MethodDelete)
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}/notes", slideHandler.HandleUpdateNotes).Methods(http.MethodPatch)
+	protected.HandleFunc("/presentations/{id}/slides/{slideId}/meta", slideHandler.HandleUpdateMeta).Methods(http.MethodPatch)
 
 	// Slide versions
 	protected.HandleFunc("/presentations/{id}/slides/{slideId}/versions", versionHandler.HandleList).Methods(http.MethodGet)

--- a/services/api/internal/application/slide/usecase.go
+++ b/services/api/internal/application/slide/usecase.go
@@ -67,6 +67,38 @@ func (uc *UseCase) UpdateContent(ctx context.Context, id, ownerID string, conten
 	return s, uc.repo.Update(ctx, s)
 }
 
+// SlideMeta carries the slide-level presentation metadata that can be updated
+// independently of the canvas content. Nil fields are left unchanged.
+type SlideMeta struct {
+	Transition *domainSlide.Transition
+	Animations []domainSlide.ElementAnimation
+	LayoutRef  *string
+}
+
+// UpdateMeta persists slide-level transition / animations / layoutRef.
+// Only the non-nil fields of meta are applied; the rest are preserved.
+func (uc *UseCase) UpdateMeta(ctx context.Context, id, ownerID string, meta SlideMeta) (*domainSlide.Slide, error) {
+	s, err := uc.Get(ctx, id, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	if meta.Transition != nil {
+		// A transition of type "none" clears the stored transition.
+		if meta.Transition.Type == "" || meta.Transition.Type == "none" {
+			s.Transition = nil
+		} else {
+			s.Transition = meta.Transition
+		}
+	}
+	if meta.Animations != nil {
+		s.Animations = meta.Animations
+	}
+	if meta.LayoutRef != nil {
+		s.LayoutRef = *meta.LayoutRef
+	}
+	return s, uc.repo.Update(ctx, s)
+}
+
 func (uc *UseCase) UpdateNotes(ctx context.Context, id, ownerID, notes string) (*domainSlide.Slide, error) {
 	s, err := uc.Get(ctx, id, ownerID)
 	if err != nil {

--- a/services/api/internal/application/slide/usecase_test.go
+++ b/services/api/internal/application/slide/usecase_test.go
@@ -196,6 +196,90 @@ func TestUpdateContent(t *testing.T) {
 	}
 }
 
+func TestUpdateMeta(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(ownedPres, 0)
+
+	layout := "title"
+	updated, err := uc.UpdateMeta(ctx, string(s.ID), ownerID, SlideMeta{
+		Transition: &domainSlide.Transition{Type: "fade", DurationMs: 300},
+		Animations: []domainSlide.ElementAnimation{{TargetID: "o1", Type: "fadeIn", Order: 0}},
+		LayoutRef:  &layout,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMeta returned error: %v", err)
+	}
+	if updated.Transition == nil || updated.Transition.Type != "fade" || updated.Transition.DurationMs != 300 {
+		t.Fatalf("transition not applied: %+v", updated.Transition)
+	}
+	if len(updated.Animations) != 1 || updated.Animations[0].Type != "fadeIn" {
+		t.Fatalf("animations not applied: %+v", updated.Animations)
+	}
+	if updated.LayoutRef != "title" {
+		t.Fatalf("layoutRef = %q, want title", updated.LayoutRef)
+	}
+	// Persisted to the repo.
+	stored := srepo.byID[s.ID]
+	if stored.Transition == nil || stored.Transition.Type != "fade" {
+		t.Fatal("transition not persisted")
+	}
+}
+
+func TestUpdateMetaPartialPreservesOtherFields(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(ownedPres, 0)
+	s.Transition = &domainSlide.Transition{Type: "zoom", DurationMs: 500}
+	s.LayoutRef = "blank"
+
+	// Update only animations; transition and layoutRef must be preserved.
+	if _, err := uc.UpdateMeta(ctx, string(s.ID), ownerID, SlideMeta{
+		Animations: []domainSlide.ElementAnimation{{TargetID: "x", Type: "zoomIn", Order: 1}},
+	}); err != nil {
+		t.Fatalf("UpdateMeta returned error: %v", err)
+	}
+	stored := srepo.byID[s.ID]
+	if stored.Transition == nil || stored.Transition.Type != "zoom" {
+		t.Fatalf("transition not preserved: %+v", stored.Transition)
+	}
+	if stored.LayoutRef != "blank" {
+		t.Fatalf("layoutRef not preserved: %q", stored.LayoutRef)
+	}
+	if len(stored.Animations) != 1 {
+		t.Fatalf("animations not applied: %+v", stored.Animations)
+	}
+}
+
+func TestUpdateMetaNoneClearsTransition(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(ownedPres, 0)
+	s.Transition = &domainSlide.Transition{Type: "fade", DurationMs: 300}
+
+	if _, err := uc.UpdateMeta(ctx, string(s.ID), ownerID, SlideMeta{
+		Transition: &domainSlide.Transition{Type: "none"},
+	}); err != nil {
+		t.Fatalf("UpdateMeta returned error: %v", err)
+	}
+	if srepo.byID[s.ID].Transition != nil {
+		t.Fatalf("transition not cleared: %+v", srepo.byID[s.ID].Transition)
+	}
+}
+
+func TestUpdateMetaForbiddenOnForeignSlide(t *testing.T) {
+	ctx := context.Background()
+	uc, srepo := newUC()
+	s := srepo.seed(otherPres, 0)
+
+	_, err := uc.UpdateMeta(ctx, string(s.ID), ownerID, SlideMeta{
+		Transition: &domainSlide.Transition{Type: "fade"},
+	})
+	if !errors.Is(err, sharedErr.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
 	uc, srepo := newUC()

--- a/services/api/internal/infrastructure/http/slide_handler.go
+++ b/services/api/internal/infrastructure/http/slide_handler.go
@@ -98,6 +98,31 @@ func (h *SlideHandler) HandleUpdateNotes(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, s)
 }
 
+func (h *SlideHandler) HandleUpdateMeta(w http.ResponseWriter, r *http.Request) {
+	ownerID := r.Context().Value(middleware.UserIDKey).(string)
+	id := mux.Vars(r)["slideId"]
+	// Pointer fields distinguish "absent" (leave unchanged) from "present".
+	var req struct {
+		Transition *domainSlide.Transition        `json:"transition"`
+		Animations []domainSlide.ElementAnimation `json:"animations"`
+		LayoutRef  *string                        `json:"layoutRef"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	s, err := h.uc.UpdateMeta(r.Context(), id, ownerID, appSlide.SlideMeta{
+		Transition: req.Transition,
+		Animations: req.Animations,
+		LayoutRef:  req.LayoutRef,
+	})
+	if err != nil {
+		writeHTTPError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s)
+}
+
 func (h *SlideHandler) HandleReorder(w http.ResponseWriter, r *http.Request) {
 	ownerID := r.Context().Value(middleware.UserIDKey).(string)
 	presentationID := mux.Vars(r)["id"]

--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -2,11 +2,17 @@
 import { useState } from "react";
 import { Square, Sparkles, ArrowRightToLine, ArrowDownToLine, Play } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStore } from "../../stores/slideStore";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { slidesApi } from "@shared/api/slides";
 import { animateEntrance, type EntranceType } from "@lib/fabric/animation";
+import type { ElementAnimation, ElementAnimationType } from "@shared/types/slide";
 
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
 
 type AnimChoice = "none" | EntranceType;
+
+const ANIMATION_DURATION_MS = 600;
 
 const ANIMATIONS: { type: AnimChoice; label: string; icon: React.ReactNode }[] = [
   { type: "none", label: "なし", icon: <Square /> },
@@ -15,15 +21,54 @@ const ANIMATIONS: { type: AnimChoice; label: string; icon: React.ReactNode }[] =
   { type: "bounce", label: "バウンス", icon: <ArrowDownToLine /> },
 ];
 
+// Map the preview-level entrance to the persisted model animation type.
+// "bounce" has no model equivalent yet and stores as the closest entrance.
+export function toModelAnimation(t: EntranceType): ElementAnimationType {
+  switch (t) {
+    case "fade-in": return "fadeIn";
+    case "fly-in-left": return "slideIn";
+    case "bounce": return "zoomIn";
+  }
+}
+
+// Resolve a stable target id for an active object: its index in the canvas
+// object list. Playback (next PR) reads this back from the saved animation.
+function targetIdFor(canvas: NonNullable<ReturnType<typeof useEditorStore.getState>["canvas"]>, obj: object): string | null {
+  const idx = canvas.getObjects().indexOf(obj as never);
+  return idx >= 0 ? String(idx) : null;
+}
+
 export function AnimationTab() {
-  const { canvas } = useEditorStore();
+  const { canvas, activeSlideId, presentationId } = useEditorStore();
+  const { slides, updateSlideMeta } = useSlideStore();
+  const { accessToken } = useAuthStore();
   const [selected, setSelected] = useState<AnimChoice>("none");
 
-  function apply(type: AnimChoice) {
+  async function apply(type: AnimChoice) {
     setSelected(type);
     if (type === "none" || !canvas) return;
     const obj = canvas.getActiveObject();
-    if (obj) void animateEntrance(canvas, obj, type);
+    if (!obj) return;
+    void animateEntrance(canvas, obj, type);
+
+    if (!activeSlideId) return;
+    const targetId = targetIdFor(canvas, obj);
+    if (targetId === null) return;
+
+    // Replace any existing animation for this target, keep order ascending.
+    const existing = slides.find((s) => s.id === activeSlideId)?.animations ?? [];
+    const others = existing.filter((a) => a.targetId !== targetId);
+    const next: ElementAnimation = {
+      targetId,
+      type: toModelAnimation(type),
+      order: others.length,
+      durationMs: ANIMATION_DURATION_MS,
+    };
+    const animations = [...others, next];
+    updateSlideMeta(activeSlideId, { animations });
+    if (accessToken && presentationId) {
+      await slidesApi.updateMeta(accessToken, presentationId, activeSlideId, { animations });
+    }
   }
 
   function preview() {
@@ -42,7 +87,7 @@ export function AnimationTab() {
               icon={a.icon}
               label={a.label}
               active={selected === a.type}
-              onClick={() => apply(a.type)}
+              onClick={() => void apply(a.type)}
               disabled={!canvas}
               title={`${a.label} — 選択中のオブジェクトに適用`}
             />

--- a/web/src/features/editor/components/Ribbon/TransitionTab.tsx
+++ b/web/src/features/editor/components/Ribbon/TransitionTab.tsx
@@ -1,9 +1,15 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Square, Sparkles, ArrowLeftToLine, ArrowRightToLine, ZoomIn, Play } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStore } from "../../stores/slideStore";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { slidesApi } from "@shared/api/slides";
 import { playTransition, type TransitionType } from "@lib/fabric/animation";
+import type { SlideTransitionType } from "@shared/types/slide";
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
+
+const TRANSITION_DURATION_MS = 400;
 
 const TRANSITIONS: { type: TransitionType; label: string; icon: React.ReactNode }[] = [
   { type: "none", label: "なし", icon: <Square /> },
@@ -13,8 +19,51 @@ const TRANSITIONS: { type: TransitionType; label: string; icon: React.ReactNode 
   { type: "zoom", label: "ズーム", icon: <ZoomIn /> },
 ];
 
+// Map the preview-level transition type to the persisted model type.
+// "slide-left" / "slide-right" both store as "slide" / "push" respectively.
+export function toModelTransition(t: TransitionType): SlideTransitionType {
+  switch (t) {
+    case "slide-left": return "slide";
+    case "slide-right": return "push";
+    default: return t;
+  }
+}
+
+// Reverse mapping: restore the UI selection from a persisted model type.
+export function fromModelTransition(t: SlideTransitionType | undefined): TransitionType {
+  switch (t) {
+    case "slide": return "slide-left";
+    case "push": return "slide-right";
+    case undefined: return "none";
+    default: return t;
+  }
+}
+
 export function TransitionTab() {
+  const { activeSlideId, presentationId } = useEditorStore();
+  const { slides, updateSlideMeta } = useSlideStore();
+  const { accessToken } = useAuthStore();
   const [selected, setSelected] = useState<TransitionType>("none");
+
+  const currentSlide = slides.find((s) => s.id === activeSlideId);
+
+  // Reflect the saved transition when the active slide changes.
+  useEffect(() => {
+    setSelected(fromModelTransition(currentSlide?.transition?.type));
+  }, [activeSlideId, currentSlide?.transition?.type]);
+
+  async function select(type: TransitionType) {
+    setSelected(type);
+    if (!activeSlideId) return;
+    const transition =
+      type === "none"
+        ? { type: "none" as SlideTransitionType }
+        : { type: toModelTransition(type), durationMs: TRANSITION_DURATION_MS };
+    updateSlideMeta(activeSlideId, { transition });
+    if (accessToken && presentationId) {
+      await slidesApi.updateMeta(accessToken, presentationId, activeSlideId, { transition });
+    }
+  }
 
   function preview() {
     const el = useEditorStore.getState().canvas?.wrapperEl?.parentElement;
@@ -31,7 +80,7 @@ export function TransitionTab() {
               icon={t.icon}
               label={t.label}
               active={selected === t.type}
-              onClick={() => setSelected(t.type)}
+              onClick={() => void select(t.type)}
             />
           ))}
         </div>

--- a/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
+++ b/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { toModelTransition, fromModelTransition } from "./TransitionTab";
+import { toModelAnimation } from "./AnimationTab";
+
+describe("transition type mapping", () => {
+  it("maps preview transition types to persisted model types", () => {
+    expect(toModelTransition("none")).toBe("none");
+    expect(toModelTransition("fade")).toBe("fade");
+    expect(toModelTransition("zoom")).toBe("zoom");
+    expect(toModelTransition("slide-left")).toBe("slide");
+    expect(toModelTransition("slide-right")).toBe("push");
+  });
+
+  it("restores the UI selection from a persisted model type", () => {
+    expect(fromModelTransition(undefined)).toBe("none");
+    expect(fromModelTransition("none")).toBe("none");
+    expect(fromModelTransition("fade")).toBe("fade");
+    expect(fromModelTransition("zoom")).toBe("zoom");
+    expect(fromModelTransition("slide")).toBe("slide-left");
+    expect(fromModelTransition("push")).toBe("slide-right");
+  });
+
+  it("round-trips slide / push through the model and back", () => {
+    expect(fromModelTransition(toModelTransition("slide-left"))).toBe("slide-left");
+    expect(fromModelTransition(toModelTransition("slide-right"))).toBe("slide-right");
+  });
+});
+
+describe("animation type mapping", () => {
+  it("maps preview entrance types to persisted model animation types", () => {
+    expect(toModelAnimation("fade-in")).toBe("fadeIn");
+    expect(toModelAnimation("fly-in-left")).toBe("slideIn");
+    expect(toModelAnimation("bounce")).toBe("zoomIn");
+  });
+});

--- a/web/src/shared/api/slides.test.ts
+++ b/web/src/shared/api/slides.test.ts
@@ -75,4 +75,17 @@ describe("slidesApi", () => {
       auth
     );
   });
+
+  it("updateMeta calls PATCH /presentations/:pid/slides/:slideId/meta with the meta payload", () => {
+    const meta = {
+      transition: { type: "fade" as const, durationMs: 400 },
+      animations: [{ targetId: "0", type: "fadeIn" as const, order: 0, durationMs: 600 }],
+    };
+    slidesApi.updateMeta(TOKEN, PID, "s-1", meta);
+    expect(patch).toHaveBeenCalledWith(
+      `/presentations/${PID}/slides/s-1/meta`,
+      meta,
+      auth
+    );
+  });
 });

--- a/web/src/shared/api/slides.ts
+++ b/web/src/shared/api/slides.ts
@@ -1,5 +1,12 @@
 import { apiClient } from "./api-client";
-import type { Slide, SlideContent } from "@shared/types/slide";
+import type { Slide, SlideContent, SlideTransition, ElementAnimation } from "@shared/types/slide";
+
+/** Slide-level metadata that can be persisted independently of canvas content. */
+export interface SlideMetaUpdate {
+  transition?: SlideTransition;
+  animations?: ElementAnimation[];
+  layoutRef?: string;
+}
 
 function authHeaders(token: string) {
   return { Authorization: `Bearer ${token}` };
@@ -32,6 +39,10 @@ export const slidesApi = {
     }),
   updateNotes: (token: string, presentationId: string, slideId: string, notes: string) =>
     apiClient.patch<Slide>(`/presentations/${presentationId}/slides/${slideId}/notes`, { notes }, {
+      headers: authHeaders(token),
+    }),
+  updateMeta: (token: string, presentationId: string, slideId: string, meta: SlideMetaUpdate) =>
+    apiClient.patch<Slide>(`/presentations/${presentationId}/slides/${slideId}/meta`, meta, {
       headers: authHeaders(token),
     }),
 };


### PR DESCRIPTION
## 概要 (P1 最初の PR)

トランジション / アニメーションの設定を **永続化** できるようにする。
PR-1 でモデル (`Slide.transition` / `animations` / `layoutRef`) と repository の保存経路は準備済みだったが、API 入口〜application 層の配線と、ribbon タブからの保存パスが未接続だった。本 PR でそこを通す。

**スコープは永続化のみ。present / view での再生 (playback) はこの PR では実装しない (次の PR-5)。**

## 変更点

### Go API
- `application/slide`: `UpdateMeta(ctx, id, ownerID, SlideMeta)` を追加。`SlideMeta` は nil フィールドを「変更なし」として扱い、部分更新を許容。transition の `type` が `"none"`/空なら保存値をクリア。
- `infrastructure/http`: `HandleUpdateMeta` を追加。リクエスト DTO はポインタ型で「未指定 = 既存維持」を表現。
- `cmd/api/main.go`: `PATCH /presentations/{id}/slides/{slideId}/meta` を登録 (notes と同じパターン)。
- repository の `Update` は PR-1 時点で既に新フィールドを保存する実装になっており変更不要。

### フロント
- `slidesApi.updateMeta` を追加 (PATCH `.../meta`)。
- `TransitionTab` / `AnimationTab`: 選択を `updateSlideMeta` でストアに反映し、`slidesApi.updateMeta` でサーバーに永続化。プレビュー機能は従来通り維持。
- UI レベルの型を永続モデル型にマッピング (`slide-left`→`slide` / `slide-right`→`push` / `fade-in`→`fadeIn` 等)。`TransitionTab` は active slide 切替時に保存済みの設定を選択状態へ復元。

## ラウンドトリップ
トランジション/アニメを設定 → `updateSlideMeta` + API PATCH で保存 → 再取得時に `Slide.transition`/`animations` として保持される。

## やらないこと (次 PR)
- present / view でのトランジション・アニメーション **再生 (playback)**。
- animation の `targetId` は現状オブジェクトの index 文字列。playback PR で安定 ID 戦略を再検討する。

## 検証
- `cd web && npm run build` → tsc / Next build green
- `cd web && npx vitest run` → 13 files / 67 tests passed
- `cd services/api && go build ./... && go test ./...` → green (UpdateMeta のテスト 4 ケース追加)
- `npm run lint` → 0 errors (既存 warning のみ、本 PR の対象ファイルには無し)