### PR TITLE
スライドオブジェクトに保存/復元で保たれる安定IDを付与

### DIFF
--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -6,6 +6,7 @@ import { useSlideStore } from "../../stores/slideStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { animateEntrance, type EntranceType } from "@lib/fabric/animation";
+import { ensureObjectId } from "@lib/fabric/objectId";
 import type { ElementAnimation, ElementAnimationType } from "@shared/types/slide";
 
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
@@ -31,11 +32,11 @@ export function toModelAnimation(t: EntranceType): ElementAnimationType {
   }
 }
 
-// Resolve a stable target id for an active object: its index in the canvas
-// object list. Playback (next PR) reads this back from the saved animation.
-function targetIdFor(canvas: NonNullable<ReturnType<typeof useEditorStore.getState>["canvas"]>, obj: object): string | null {
-  const idx = canvas.getObjects().indexOf(obj as never);
-  return idx >= 0 ? String(idx) : null;
+// Resolve a stable target id for an active object. Unlike the object's index
+// (which shifts on add/remove/reorder), this id is persisted with the object
+// and survives save/load, so playback can reliably find the same element.
+function targetIdFor(_canvas: NonNullable<ReturnType<typeof useEditorStore.getState>["canvas"]>, obj: object): string | null {
+  return ensureObjectId(obj as Parameters<typeof ensureObjectId>[0]);
 }
 
 export function AnimationTab() {

--- a/web/src/lib/fabric/canvas.ts
+++ b/web/src/lib/fabric/canvas.ts
@@ -1,5 +1,6 @@
 import { Canvas } from "fabric";
 import { applyControlsToCanvas, applyPowerPointControls } from "./powerpointControls";
+import { ensureObjectIds, CUSTOM_OBJECT_PROPERTIES } from "./objectId";
 
 // Apply PowerPoint-style selection/resize defaults once at module load.
 applyPowerPointControls();
@@ -34,13 +35,21 @@ export function loadFromJSON(canvas: Canvas, json: object): Promise<Canvas> {
     // Re-apply PowerPoint object behaviors to restored objects so saved slides
     // behave like freshly created ones (uniform stroke, no-distort textboxes).
     applyControlsToCanvas(c);
+    // Back-fill stable ids on slides saved before object ids existed, so their
+    // element animations can still resolve their target objects.
+    ensureObjectIds(c);
     c.renderAll();
     return c;
   });
 }
 
 export function toJSON(canvas: Canvas): Record<string, unknown> {
-  return canvas.toJSON() as Record<string, unknown>;
+  // Assign ids to any object lacking one before serializing, then include the
+  // `id` custom property so the stable identity round-trips through save/load.
+  ensureObjectIds(canvas);
+  // toObject threads `propertiesToInclude` down to each object's serializer,
+  // so the custom `id` is emitted. Canvas.toJSON() in fabric v6 takes no args.
+  return canvas.toObject([...CUSTOM_OBJECT_PROPERTIES]) as Record<string, unknown>;
 }
 
 export function fitToContainer(canvas: Canvas, containerWidth: number): number {

--- a/web/src/lib/fabric/objectId.test.ts
+++ b/web/src/lib/fabric/objectId.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { Canvas, FabricObject } from "fabric";
+import {
+  ensureObjectId,
+  ensureObjectIds,
+  findObjectById,
+  CUSTOM_OBJECT_PROPERTIES,
+} from "./objectId";
+
+// Minimal fabric-object stand-in: ensureObjectId only touches `set` and `id`.
+function makeObj(id?: string): FabricObject {
+  const o: Record<string, unknown> = { id };
+  o.set = (k: string, v: unknown) => {
+    o[k] = v;
+    return o;
+  };
+  return o as unknown as FabricObject;
+}
+
+function makeCanvas(objs: FabricObject[]): Canvas {
+  return { getObjects: () => objs } as unknown as Canvas;
+}
+
+describe("objectId", () => {
+  it("includes 'id' in the custom serialized properties", () => {
+    expect(CUSTOM_OBJECT_PROPERTIES).toContain("id");
+  });
+
+  it("assigns a fresh id to an object that has none", () => {
+    const obj = makeObj();
+    const id = ensureObjectId(obj);
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+    expect((obj as unknown as { id: string }).id).toBe(id);
+  });
+
+  it("is idempotent: an existing id is preserved", () => {
+    const obj = makeObj("obj-existing");
+    expect(ensureObjectId(obj)).toBe("obj-existing");
+    expect(ensureObjectId(obj)).toBe("obj-existing");
+  });
+
+  it("assigns unique ids to distinct objects", () => {
+    const a = ensureObjectId(makeObj());
+    const b = ensureObjectId(makeObj());
+    expect(a).not.toBe(b);
+  });
+
+  it("back-fills ids on every object on the canvas", () => {
+    const objs = [makeObj(), makeObj("obj-kept"), makeObj()];
+    ensureObjectIds(makeCanvas(objs));
+    const ids = objs.map((o) => (o as unknown as { id: string }).id);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(ids[1]).toBe("obj-kept");
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("finds an object by its id and returns null when absent", () => {
+    const target = makeObj("obj-target");
+    const canvas = makeCanvas([makeObj("obj-other"), target]);
+    expect(findObjectById(canvas, "obj-target")).toBe(target);
+    expect(findObjectById(canvas, "obj-missing")).toBeNull();
+  });
+});

--- a/web/src/lib/fabric/objectId.ts
+++ b/web/src/lib/fabric/objectId.ts
@@ -1,0 +1,52 @@
+import type { Canvas, FabricObject } from "fabric";
+
+/**
+ * Stable per-object identity for slides.
+ *
+ * Fabric objects have no persistent identity of their own: their index in the
+ * canvas object list shifts whenever objects are added, removed, or reordered.
+ * Element animations reference a target object, so they need an id that:
+ *  - survives serialization (round-trips through toJSON / loadFromJSON), and
+ *  - never changes once assigned.
+ *
+ * We attach a custom `id` property to every object and include it in the
+ * serialized JSON (see `toJSON` in ./canvas). Older slides saved before ids
+ * existed are back-filled on load so they keep working.
+ */
+
+const OBJECT_ID_PREFIX = "obj-";
+
+/** Properties added to fabric's default serialization so ids round-trip. */
+export const CUSTOM_OBJECT_PROPERTIES = ["id"] as const;
+
+function newObjectId(): string {
+  // crypto.randomUUID is available in browsers and Node 19+; fall back to a
+  // timestamp + random suffix for older/jsdom environments used in tests.
+  const rand =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return `${OBJECT_ID_PREFIX}${rand}`;
+}
+
+type WithId = FabricObject & { id?: string };
+
+/** Return the object's stable id, assigning a fresh one if it has none. */
+export function ensureObjectId(obj: FabricObject): string {
+  const o = obj as WithId;
+  if (typeof o.id === "string" && o.id.length > 0) return o.id;
+  const id = newObjectId();
+  o.set?.("id", id);
+  o.id = id;
+  return id;
+}
+
+/** Back-fill stable ids on every object currently on the canvas. */
+export function ensureObjectIds(canvas: Canvas): void {
+  canvas.getObjects().forEach((o) => ensureObjectId(o));
+}
+
+/** Find the object carrying the given stable id, or null if absent. */
+export function findObjectById(canvas: Canvas, id: string): FabricObject | null {
+  return canvas.getObjects().find((o) => (o as WithId).id === id) ?? null;
+}


### PR DESCRIPTION
## 概要
Fabric オブジェクトには永続的な同一性がなく、要素アニメーションのターゲットを「キャンバス内 index 文字列」で参照していたため、オブジェクトの追加・削除・並べ替えで参照がズレる問題があった。custom prop `id` を導入し、保存/復元（toJSON / loadFromJSON）でも保たれる安定 ID を全オブジェクトに付与する。

これは再生配線 PR（#後続）が animation の targetId を確実に解決するための土台。

## 変更点
- `web/src/lib/fabric/objectId.ts`（新規）: `ensureObjectId` / `ensureObjectIds` / `findObjectById`。`crypto.randomUUID` が無い環境（jsdom 等）はフォールバック。
- `web/src/lib/fabric/canvas.ts`: `toJSON` が `toObject(["id"])` で `id` をシリアライズし、`loadFromJSON` が ID 未付与の旧スライドに ID を後付け（後方互換）。永続フォーマット（`targetId: string`）は不変。
- `web/src/features/editor/components/Ribbon/AnimationTab.tsx`: `targetIdFor` が index ではなく安定 ID を返す。

## 検証
- `npm run build` green（tsc 通過）
- `npx vitest run` green（73 → objectId.test.ts 6件追加）
- `go build ./...` green（content は opaque JSONB のため Go 側影響なし）

## 注意
後続 PR `feature/playback-transition-animation` はこの PR に依存（stack）。本 PR を先にマージしてください。