### PR TITLE
保存済みトランジション/アニメーションを present・view で再生

### DIFF
--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -3,6 +3,8 @@ import { use, useEffect, useRef, useState, useCallback } from "react";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { createCanvas, loadFromJSON, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+import { playTransition } from "@lib/fabric/animation";
+import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
 import { PresenterSocket } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
@@ -13,6 +15,7 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   const [cur, setCur] = useState(0);
   const [elapsed, setElapsed] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
   const presenterRef = useRef<PresenterSocket | null>(null);
 
   useEffect(() => {
@@ -23,10 +26,21 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   }, [id, accessToken]);
 
   useEffect(() => {
-    if (!canvasRef.current || !slides[cur]) return;
+    const slide = slides[cur];
+    if (!canvasRef.current || !slide) return;
     const c = createCanvas(canvasRef.current, { width: SLIDE_WIDTH / 2, height: SLIDE_HEIGHT / 2 });
-    loadFromJSON(c, slides[cur].content);
-    return () => { c.dispose(); };
+    let cancelled = false;
+    // Play the saved slide-level transition, then the per-element entrance
+    // animations once the content is loaded. Guarded so an unmount mid-play
+    // does not touch a disposed canvas.
+    (async () => {
+      if (stageRef.current) {
+        await playTransition(stageRef.current, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
+      }
+      await loadFromJSON(c, slide.content);
+      if (!cancelled) await playSlideAnimations(c, slide.animations);
+    })();
+    return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);
 
   useEffect(() => {
@@ -66,7 +80,7 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   return (
     <div className="flex h-screen bg-gray-900 text-white">
       <div className="flex flex-1 flex-col items-center justify-center p-8">
-        <div className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
+        <div ref={stageRef} className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
         <div className="mt-4 flex items-center gap-6">
           <button onClick={prev} disabled={cur === 0} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">← 前へ</button>
           <span className="text-sm text-gray-400">{cur + 1} / {slides.length}</span>

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { use, useEffect, useRef, useState, useCallback } from "react";
 import { createCanvas, loadFromJSON, fitToContainer } from "@lib/fabric/canvas";
+import { playTransition } from "@lib/fabric/animation";
+import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
 import type { Slide } from "@shared/types/slide";
 
 export default function ViewPage({ params }: { params: Promise<{ id: string }> }) {
@@ -15,11 +17,20 @@ export default function ViewPage({ params }: { params: Promise<{ id: string }> }
   }, [id]);
 
   useEffect(() => {
-    if (!canvasRef.current||!slides[cur]||!containerRef.current) return;
+    const slide = slides[cur];
+    if (!canvasRef.current||!slide||!containerRef.current) return;
     const c = createCanvas(canvasRef.current);
     fitToContainer(c, containerRef.current.clientWidth);
-    loadFromJSON(c, slides[cur].content);
-    return () => { c.dispose(); };
+    let cancelled = false;
+    // Same playback the presenter sees: slide-level transition first, then the
+    // per-element entrance animations once the content is loaded.
+    (async () => {
+      const stage = c.wrapperEl;
+      if (stage) await playTransition(stage, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
+      await loadFromJSON(c, slide.content);
+      if (!cancelled) await playSlideAnimations(c, slide.animations);
+    })();
+    return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);
 
   const next = useCallback(() => setCur(c=>Math.min(c+1,slides.length-1)), [slides.length]);

--- a/web/src/lib/fabric/slidePlayback.test.ts
+++ b/web/src/lib/fabric/slidePlayback.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Canvas, FabricObject } from "fabric";
+import type { ElementAnimation } from "@shared/types/slide";
+
+// Spy on the entrance primitive so we can assert orchestration without a real
+// fabric canvas (jsdom can't run fabric's rendering pipeline).
+const animateEntranceSpy = vi.fn(() => Promise.resolve());
+vi.mock("./animation", () => ({
+  animateEntrance: (...args: unknown[]) => animateEntranceSpy(...args),
+}));
+
+import {
+  modelTransitionToPreview,
+  modelAnimationToEntrance,
+  hasTransition,
+  playSlideAnimations,
+} from "./slidePlayback";
+
+function makeObj(id: string): FabricObject {
+  return { id } as unknown as FabricObject;
+}
+function makeCanvas(objs: FabricObject[]): Canvas {
+  return { getObjects: () => objs } as unknown as Canvas;
+}
+
+describe("modelTransitionToPreview", () => {
+  it("maps each persisted transition type to its preview type", () => {
+    expect(modelTransitionToPreview("fade")).toBe("fade");
+    expect(modelTransitionToPreview("slide")).toBe("slide-left");
+    expect(modelTransitionToPreview("push")).toBe("slide-right");
+    expect(modelTransitionToPreview("zoom")).toBe("zoom");
+    expect(modelTransitionToPreview("none")).toBe("none");
+    expect(modelTransitionToPreview(undefined)).toBe("none");
+  });
+});
+
+describe("modelAnimationToEntrance", () => {
+  it("maps in/out variants to the matching entrance motion", () => {
+    expect(modelAnimationToEntrance("fadeIn")).toBe("fade-in");
+    expect(modelAnimationToEntrance("fadeOut")).toBe("fade-in");
+    expect(modelAnimationToEntrance("slideIn")).toBe("fly-in-left");
+    expect(modelAnimationToEntrance("slideOut")).toBe("fly-in-left");
+    expect(modelAnimationToEntrance("zoomIn")).toBe("bounce");
+    expect(modelAnimationToEntrance("zoomOut")).toBe("bounce");
+  });
+});
+
+describe("hasTransition", () => {
+  it("is false for none / undefined and true otherwise", () => {
+    expect(hasTransition(undefined)).toBe(false);
+    expect(hasTransition({ type: "none" })).toBe(false);
+    expect(hasTransition({ type: "fade" })).toBe(true);
+  });
+});
+
+describe("playSlideAnimations", () => {
+  beforeEach(() => animateEntranceSpy.mockClear());
+
+  it("no-ops when there are no animations", async () => {
+    await playSlideAnimations(makeCanvas([]), undefined);
+    await playSlideAnimations(makeCanvas([]), []);
+    expect(animateEntranceSpy).not.toHaveBeenCalled();
+  });
+
+  it("plays one entrance per resolvable target", async () => {
+    const a = makeObj("obj-a");
+    const b = makeObj("obj-b");
+    const anims: ElementAnimation[] = [
+      { targetId: "obj-a", type: "fadeIn", order: 0, durationMs: 300 },
+      { targetId: "obj-b", type: "slideIn", order: 1 },
+    ];
+    await playSlideAnimations(makeCanvas([a, b]), anims);
+    expect(animateEntranceSpy).toHaveBeenCalledTimes(2);
+    // duration is forwarded (explicit 300 / default 600).
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), a, "fade-in", 300);
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), b, "fly-in-left", 600);
+  });
+
+  it("skips animations whose target object is missing", async () => {
+    const a = makeObj("obj-a");
+    const anims: ElementAnimation[] = [
+      { targetId: "obj-a", type: "fadeIn", order: 0 },
+      { targetId: "obj-gone", type: "zoomIn", order: 1 },
+    ];
+    await playSlideAnimations(makeCanvas([a]), anims);
+    expect(animateEntranceSpy).toHaveBeenCalledTimes(1);
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), a, "fade-in", 600);
+  });
+});

--- a/web/src/lib/fabric/slidePlayback.ts
+++ b/web/src/lib/fabric/slidePlayback.ts
@@ -1,0 +1,84 @@
+import type { Canvas } from "fabric";
+import { animateEntrance, type EntranceType, type TransitionType } from "./animation";
+import { findObjectById } from "./objectId";
+import type {
+  ElementAnimation,
+  ElementAnimationType,
+  SlideTransition,
+  SlideTransitionType,
+} from "@shared/types/slide";
+
+/**
+ * Bridge between the persisted slide model (transition / animations) and the
+ * preview-level playback primitives in ./animation. The editor stores model
+ * types ("slide", "fadeIn", ...); playback maps them back to the preview types
+ * the animation helpers understand and runs them in order.
+ */
+
+/** Map a persisted slide transition type to a preview transition type. */
+export function modelTransitionToPreview(t: SlideTransitionType | undefined): TransitionType {
+  switch (t) {
+    case "fade": return "fade";
+    case "slide": return "slide-left";
+    case "push": return "slide-right";
+    case "zoom": return "zoom";
+    default: return "none"; // "none" or undefined
+  }
+}
+
+/**
+ * Map a persisted element animation type to a preview entrance type. Playback
+ * always plays an entrance when a slide appears, so the "Out" variants reuse
+ * the matching entrance motion (the editor only ever writes the "In" variants).
+ */
+export function modelAnimationToEntrance(t: ElementAnimationType): EntranceType {
+  switch (t) {
+    case "fadeIn":
+    case "fadeOut":
+      return "fade-in";
+    case "slideIn":
+    case "slideOut":
+      return "fly-in-left";
+    case "zoomIn":
+    case "zoomOut":
+      return "bounce";
+  }
+}
+
+/** True when the slide has a transition that should actually animate. */
+export function hasTransition(transition: SlideTransition | undefined): boolean {
+  return modelTransitionToPreview(transition?.type) !== "none";
+}
+
+const DEFAULT_ENTRANCE_MS = 600;
+
+/**
+ * Play every element animation for a slide on its canvas, in ascending `order`.
+ * Each animation honors its own delayMs before starting. Animations whose
+ * target object is missing (e.g. it was deleted) are skipped. Resolves once all
+ * animations have finished.
+ */
+export async function playSlideAnimations(
+  canvas: Canvas,
+  animations: ElementAnimation[] | undefined,
+): Promise<void> {
+  if (!animations || animations.length === 0) return;
+  const ordered = [...animations].sort((a, b) => a.order - b.order);
+  await Promise.all(
+    ordered.map(async (anim) => {
+      const obj = findObjectById(canvas, anim.targetId);
+      if (!obj) return;
+      if (anim.delayMs && anim.delayMs > 0) await delay(anim.delayMs);
+      await animateEntrance(
+        canvas,
+        obj,
+        modelAnimationToEntrance(anim.type),
+        anim.durationMs ?? DEFAULT_ENTRANCE_MS,
+      );
+    }),
+  );
+}
+
+function delay(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
## 概要
PR-1 で `Slide` に追加し #95 で永続化した `transition` / `animations` を、present（発表者）と view（聴衆）で実際に再生する。これで「編集で設定 → 保存 → 再生」のループが閉じる。

> stacked PR: `feature/stable-object-ids`（#96 安定ID付与）の上に積んでいます。**#96 を先にマージ**してください。マージ後、base を main に切り替えます。

## 変更点
- `web/src/lib/fabric/slidePlayback.ts`（新規）: 永続モデル型 ⇄ プレビュー型の逆マッピング（`slide`→`slide-left`、`fadeIn`→`fade-in` 等）と `playSlideAnimations`。
  - animation の targetId を**安定ID**で解決し、`order` 昇順・`delayMs`/`durationMs` を尊重して再生。
  - ターゲットが見つからない（削除済み等）animation はスキップ。
- `web/src/app/(auth)/present/[id]/page.tsx`: スライド表示時に保存済み `transition` を `playTransition`、ロード後に `animations` を `playSlideAnimations` で再生。
- `web/src/app/view/[id]/page.tsx`: 聴衆側も同じ再生（fabric の `wrapperEl` をトランジション対象に）。
- 設定が無いスライドは従来通り無挙動（`transition: "none"` は no-op）。
- アンマウント時に dispose 済みキャンバスへ触れないよう `cancelled` ガード。

## 設計メモ
- 永続フォーマットの `ElementAnimationType` は Out 系（fadeOut 等）も持つが、エディタは In 系しか書かない。再生はスライド表示時のエントランスなので、Out 系も対応するエントランスモーションに割り当てている（P1 の割り切り）。

## 検証
- `npm run build` green（tsc 通過）
- `npx vitest run` green（79件、slidePlayback.test.ts 6件追加）
- `go build ./...` green（Go 側影響なし）

## 次の見立て
- P1 残り: 聴衆同期（present の slideChange に追従して view が再生）の配線。
- P0 残り: Yjs 導入は ADR 相談が必要。