### PR TITLE
保存済みトランジション/アニメーションを present・view で再生

### DIFF
--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -3,6 +3,8 @@ import { use, useEffect, useRef, useState, useCallback } from "react";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { createCanvas, loadFromJSON, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+import { playTransition } from "@lib/fabric/animation";
+import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
 import { PresenterSocket } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
@@ -13,6 +15,7 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   const [cur, setCur] = useState(0);
   const [elapsed, setElapsed] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
   const presenterRef = useRef<PresenterSocket | null>(null);
 
   useEffect(() => {
@@ -23,10 +26,21 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   }, [id, accessToken]);
 
   useEffect(() => {
-    if (!canvasRef.current || !slides[cur]) return;
+    const slide = slides[cur];
+    if (!canvasRef.current || !slide) return;
     const c = createCanvas(canvasRef.current, { width: SLIDE_WIDTH / 2, height: SLIDE_HEIGHT / 2 });
-    loadFromJSON(c, slides[cur].content);
-    return () => { c.dispose(); };
+    let cancelled = false;
+    // Play the saved slide-level transition, then the per-element entrance
+    // animations once the content is loaded. Guarded so an unmount mid-play
+    // does not touch a disposed canvas.
+    (async () => {
+      if (stageRef.current) {
+        await playTransition(stageRef.current, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
+      }
+      await loadFromJSON(c, slide.content);
+      if (!cancelled) await playSlideAnimations(c, slide.animations);
+    })();
+    return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);
 
   useEffect(() => {
@@ -66,7 +80,7 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   return (
     <div className="flex h-screen bg-gray-900 text-white">
       <div className="flex flex-1 flex-col items-center justify-center p-8">
-        <div className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
+        <div ref={stageRef} className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
         <div className="mt-4 flex items-center gap-6">
           <button onClick={prev} disabled={cur === 0} className="rounded-lg bg-gray-700 px-4 py-2 text-sm disabled:opacity-40">← 前へ</button>
           <span className="text-sm text-gray-400">{cur + 1} / {slides.length}</span>

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { use, useEffect, useRef, useState, useCallback } from "react";
 import { createCanvas, loadFromJSON, fitToContainer } from "@lib/fabric/canvas";
+import { playTransition } from "@lib/fabric/animation";
+import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
 import type { Slide } from "@shared/types/slide";
 
 export default function ViewPage({ params }: { params: Promise<{ id: string }> }) {
@@ -15,11 +17,20 @@ export default function ViewPage({ params }: { params: Promise<{ id: string }> }
   }, [id]);
 
   useEffect(() => {
-    if (!canvasRef.current||!slides[cur]||!containerRef.current) return;
+    const slide = slides[cur];
+    if (!canvasRef.current||!slide||!containerRef.current) return;
     const c = createCanvas(canvasRef.current);
     fitToContainer(c, containerRef.current.clientWidth);
-    loadFromJSON(c, slides[cur].content);
-    return () => { c.dispose(); };
+    let cancelled = false;
+    // Same playback the presenter sees: slide-level transition first, then the
+    // per-element entrance animations once the content is loaded.
+    (async () => {
+      const stage = c.wrapperEl;
+      if (stage) await playTransition(stage, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
+      await loadFromJSON(c, slide.content);
+      if (!cancelled) await playSlideAnimations(c, slide.animations);
+    })();
+    return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);
 
   const next = useCallback(() => setCur(c=>Math.min(c+1,slides.length-1)), [slides.length]);

--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -6,6 +6,7 @@ import { useSlideStore } from "../../stores/slideStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { animateEntrance, type EntranceType } from "@lib/fabric/animation";
+import { ensureObjectId } from "@lib/fabric/objectId";
 import type { ElementAnimation, ElementAnimationType } from "@shared/types/slide";
 
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
@@ -31,11 +32,11 @@ export function toModelAnimation(t: EntranceType): ElementAnimationType {
   }
 }
 
-// Resolve a stable target id for an active object: its index in the canvas
-// object list. Playback (next PR) reads this back from the saved animation.
-function targetIdFor(canvas: NonNullable<ReturnType<typeof useEditorStore.getState>["canvas"]>, obj: object): string | null {
-  const idx = canvas.getObjects().indexOf(obj as never);
-  return idx >= 0 ? String(idx) : null;
+// Resolve a stable target id for an active object. Unlike the object's index
+// (which shifts on add/remove/reorder), this id is persisted with the object
+// and survives save/load, so playback can reliably find the same element.
+function targetIdFor(_canvas: NonNullable<ReturnType<typeof useEditorStore.getState>["canvas"]>, obj: object): string | null {
+  return ensureObjectId(obj as Parameters<typeof ensureObjectId>[0]);
 }
 
 export function AnimationTab() {

--- a/web/src/lib/fabric/canvas.ts
+++ b/web/src/lib/fabric/canvas.ts
@@ -1,5 +1,6 @@
 import { Canvas } from "fabric";
 import { applyControlsToCanvas, applyPowerPointControls } from "./powerpointControls";
+import { ensureObjectIds, CUSTOM_OBJECT_PROPERTIES } from "./objectId";
 
 // Apply PowerPoint-style selection/resize defaults once at module load.
 applyPowerPointControls();
@@ -34,13 +35,21 @@ export function loadFromJSON(canvas: Canvas, json: object): Promise<Canvas> {
     // Re-apply PowerPoint object behaviors to restored objects so saved slides
     // behave like freshly created ones (uniform stroke, no-distort textboxes).
     applyControlsToCanvas(c);
+    // Back-fill stable ids on slides saved before object ids existed, so their
+    // element animations can still resolve their target objects.
+    ensureObjectIds(c);
     c.renderAll();
     return c;
   });
 }
 
 export function toJSON(canvas: Canvas): Record<string, unknown> {
-  return canvas.toJSON() as Record<string, unknown>;
+  // Assign ids to any object lacking one before serializing, then include the
+  // `id` custom property so the stable identity round-trips through save/load.
+  ensureObjectIds(canvas);
+  // toObject threads `propertiesToInclude` down to each object's serializer,
+  // so the custom `id` is emitted. Canvas.toJSON() in fabric v6 takes no args.
+  return canvas.toObject([...CUSTOM_OBJECT_PROPERTIES]) as Record<string, unknown>;
 }
 
 export function fitToContainer(canvas: Canvas, containerWidth: number): number {

--- a/web/src/lib/fabric/objectId.test.ts
+++ b/web/src/lib/fabric/objectId.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { Canvas, FabricObject } from "fabric";
+import {
+  ensureObjectId,
+  ensureObjectIds,
+  findObjectById,
+  CUSTOM_OBJECT_PROPERTIES,
+} from "./objectId";
+
+// Minimal fabric-object stand-in: ensureObjectId only touches `set` and `id`.
+function makeObj(id?: string): FabricObject {
+  const o: Record<string, unknown> = { id };
+  o.set = (k: string, v: unknown) => {
+    o[k] = v;
+    return o;
+  };
+  return o as unknown as FabricObject;
+}
+
+function makeCanvas(objs: FabricObject[]): Canvas {
+  return { getObjects: () => objs } as unknown as Canvas;
+}
+
+describe("objectId", () => {
+  it("includes 'id' in the custom serialized properties", () => {
+    expect(CUSTOM_OBJECT_PROPERTIES).toContain("id");
+  });
+
+  it("assigns a fresh id to an object that has none", () => {
+    const obj = makeObj();
+    const id = ensureObjectId(obj);
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+    expect((obj as unknown as { id: string }).id).toBe(id);
+  });
+
+  it("is idempotent: an existing id is preserved", () => {
+    const obj = makeObj("obj-existing");
+    expect(ensureObjectId(obj)).toBe("obj-existing");
+    expect(ensureObjectId(obj)).toBe("obj-existing");
+  });
+
+  it("assigns unique ids to distinct objects", () => {
+    const a = ensureObjectId(makeObj());
+    const b = ensureObjectId(makeObj());
+    expect(a).not.toBe(b);
+  });
+
+  it("back-fills ids on every object on the canvas", () => {
+    const objs = [makeObj(), makeObj("obj-kept"), makeObj()];
+    ensureObjectIds(makeCanvas(objs));
+    const ids = objs.map((o) => (o as unknown as { id: string }).id);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(ids[1]).toBe("obj-kept");
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("finds an object by its id and returns null when absent", () => {
+    const target = makeObj("obj-target");
+    const canvas = makeCanvas([makeObj("obj-other"), target]);
+    expect(findObjectById(canvas, "obj-target")).toBe(target);
+    expect(findObjectById(canvas, "obj-missing")).toBeNull();
+  });
+});

--- a/web/src/lib/fabric/objectId.ts
+++ b/web/src/lib/fabric/objectId.ts
@@ -1,0 +1,52 @@
+import type { Canvas, FabricObject } from "fabric";
+
+/**
+ * Stable per-object identity for slides.
+ *
+ * Fabric objects have no persistent identity of their own: their index in the
+ * canvas object list shifts whenever objects are added, removed, or reordered.
+ * Element animations reference a target object, so they need an id that:
+ *  - survives serialization (round-trips through toJSON / loadFromJSON), and
+ *  - never changes once assigned.
+ *
+ * We attach a custom `id` property to every object and include it in the
+ * serialized JSON (see `toJSON` in ./canvas). Older slides saved before ids
+ * existed are back-filled on load so they keep working.
+ */
+
+const OBJECT_ID_PREFIX = "obj-";
+
+/** Properties added to fabric's default serialization so ids round-trip. */
+export const CUSTOM_OBJECT_PROPERTIES = ["id"] as const;
+
+function newObjectId(): string {
+  // crypto.randomUUID is available in browsers and Node 19+; fall back to a
+  // timestamp + random suffix for older/jsdom environments used in tests.
+  const rand =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return `${OBJECT_ID_PREFIX}${rand}`;
+}
+
+type WithId = FabricObject & { id?: string };
+
+/** Return the object's stable id, assigning a fresh one if it has none. */
+export function ensureObjectId(obj: FabricObject): string {
+  const o = obj as WithId;
+  if (typeof o.id === "string" && o.id.length > 0) return o.id;
+  const id = newObjectId();
+  o.set?.("id", id);
+  o.id = id;
+  return id;
+}
+
+/** Back-fill stable ids on every object currently on the canvas. */
+export function ensureObjectIds(canvas: Canvas): void {
+  canvas.getObjects().forEach((o) => ensureObjectId(o));
+}
+
+/** Find the object carrying the given stable id, or null if absent. */
+export function findObjectById(canvas: Canvas, id: string): FabricObject | null {
+  return canvas.getObjects().find((o) => (o as WithId).id === id) ?? null;
+}

--- a/web/src/lib/fabric/slidePlayback.test.ts
+++ b/web/src/lib/fabric/slidePlayback.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Canvas, FabricObject } from "fabric";
+import type { ElementAnimation } from "@shared/types/slide";
+
+// Spy on the entrance primitive so we can assert orchestration without a real
+// fabric canvas (jsdom can't run fabric's rendering pipeline).
+const animateEntranceSpy = vi.fn(() => Promise.resolve());
+vi.mock("./animation", () => ({
+  animateEntrance: (...args: unknown[]) => animateEntranceSpy(...args),
+}));
+
+import {
+  modelTransitionToPreview,
+  modelAnimationToEntrance,
+  hasTransition,
+  playSlideAnimations,
+} from "./slidePlayback";
+
+function makeObj(id: string): FabricObject {
+  return { id } as unknown as FabricObject;
+}
+function makeCanvas(objs: FabricObject[]): Canvas {
+  return { getObjects: () => objs } as unknown as Canvas;
+}
+
+describe("modelTransitionToPreview", () => {
+  it("maps each persisted transition type to its preview type", () => {
+    expect(modelTransitionToPreview("fade")).toBe("fade");
+    expect(modelTransitionToPreview("slide")).toBe("slide-left");
+    expect(modelTransitionToPreview("push")).toBe("slide-right");
+    expect(modelTransitionToPreview("zoom")).toBe("zoom");
+    expect(modelTransitionToPreview("none")).toBe("none");
+    expect(modelTransitionToPreview(undefined)).toBe("none");
+  });
+});
+
+describe("modelAnimationToEntrance", () => {
+  it("maps in/out variants to the matching entrance motion", () => {
+    expect(modelAnimationToEntrance("fadeIn")).toBe("fade-in");
+    expect(modelAnimationToEntrance("fadeOut")).toBe("fade-in");
+    expect(modelAnimationToEntrance("slideIn")).toBe("fly-in-left");
+    expect(modelAnimationToEntrance("slideOut")).toBe("fly-in-left");
+    expect(modelAnimationToEntrance("zoomIn")).toBe("bounce");
+    expect(modelAnimationToEntrance("zoomOut")).toBe("bounce");
+  });
+});
+
+describe("hasTransition", () => {
+  it("is false for none / undefined and true otherwise", () => {
+    expect(hasTransition(undefined)).toBe(false);
+    expect(hasTransition({ type: "none" })).toBe(false);
+    expect(hasTransition({ type: "fade" })).toBe(true);
+  });
+});
+
+describe("playSlideAnimations", () => {
+  beforeEach(() => animateEntranceSpy.mockClear());
+
+  it("no-ops when there are no animations", async () => {
+    await playSlideAnimations(makeCanvas([]), undefined);
+    await playSlideAnimations(makeCanvas([]), []);
+    expect(animateEntranceSpy).not.toHaveBeenCalled();
+  });
+
+  it("plays one entrance per resolvable target", async () => {
+    const a = makeObj("obj-a");
+    const b = makeObj("obj-b");
+    const anims: ElementAnimation[] = [
+      { targetId: "obj-a", type: "fadeIn", order: 0, durationMs: 300 },
+      { targetId: "obj-b", type: "slideIn", order: 1 },
+    ];
+    await playSlideAnimations(makeCanvas([a, b]), anims);
+    expect(animateEntranceSpy).toHaveBeenCalledTimes(2);
+    // duration is forwarded (explicit 300 / default 600).
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), a, "fade-in", 300);
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), b, "fly-in-left", 600);
+  });
+
+  it("skips animations whose target object is missing", async () => {
+    const a = makeObj("obj-a");
+    const anims: ElementAnimation[] = [
+      { targetId: "obj-a", type: "fadeIn", order: 0 },
+      { targetId: "obj-gone", type: "zoomIn", order: 1 },
+    ];
+    await playSlideAnimations(makeCanvas([a]), anims);
+    expect(animateEntranceSpy).toHaveBeenCalledTimes(1);
+    expect(animateEntranceSpy).toHaveBeenCalledWith(expect.anything(), a, "fade-in", 600);
+  });
+});

--- a/web/src/lib/fabric/slidePlayback.test.ts
+++ b/web/src/lib/fabric/slidePlayback.test.ts
@@ -4,7 +4,8 @@ import type { ElementAnimation } from "@shared/types/slide";
 
 // Spy on the entrance primitive so we can assert orchestration without a real
 // fabric canvas (jsdom can't run fabric's rendering pipeline).
-const animateEntranceSpy = vi.fn(() => Promise.resolve());
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const animateEntranceSpy = vi.fn((..._args: any[]) => Promise.resolve());
 vi.mock("./animation", () => ({
   animateEntrance: (...args: unknown[]) => animateEntranceSpy(...args),
 }));

--- a/web/src/lib/fabric/slidePlayback.ts
+++ b/web/src/lib/fabric/slidePlayback.ts
@@ -1,0 +1,84 @@
+import type { Canvas } from "fabric";
+import { animateEntrance, type EntranceType, type TransitionType } from "./animation";
+import { findObjectById } from "./objectId";
+import type {
+  ElementAnimation,
+  ElementAnimationType,
+  SlideTransition,
+  SlideTransitionType,
+} from "@shared/types/slide";
+
+/**
+ * Bridge between the persisted slide model (transition / animations) and the
+ * preview-level playback primitives in ./animation. The editor stores model
+ * types ("slide", "fadeIn", ...); playback maps them back to the preview types
+ * the animation helpers understand and runs them in order.
+ */
+
+/** Map a persisted slide transition type to a preview transition type. */
+export function modelTransitionToPreview(t: SlideTransitionType | undefined): TransitionType {
+  switch (t) {
+    case "fade": return "fade";
+    case "slide": return "slide-left";
+    case "push": return "slide-right";
+    case "zoom": return "zoom";
+    default: return "none"; // "none" or undefined
+  }
+}
+
+/**
+ * Map a persisted element animation type to a preview entrance type. Playback
+ * always plays an entrance when a slide appears, so the "Out" variants reuse
+ * the matching entrance motion (the editor only ever writes the "In" variants).
+ */
+export function modelAnimationToEntrance(t: ElementAnimationType): EntranceType {
+  switch (t) {
+    case "fadeIn":
+    case "fadeOut":
+      return "fade-in";
+    case "slideIn":
+    case "slideOut":
+      return "fly-in-left";
+    case "zoomIn":
+    case "zoomOut":
+      return "bounce";
+  }
+}
+
+/** True when the slide has a transition that should actually animate. */
+export function hasTransition(transition: SlideTransition | undefined): boolean {
+  return modelTransitionToPreview(transition?.type) !== "none";
+}
+
+const DEFAULT_ENTRANCE_MS = 600;
+
+/**
+ * Play every element animation for a slide on its canvas, in ascending `order`.
+ * Each animation honors its own delayMs before starting. Animations whose
+ * target object is missing (e.g. it was deleted) are skipped. Resolves once all
+ * animations have finished.
+ */
+export async function playSlideAnimations(
+  canvas: Canvas,
+  animations: ElementAnimation[] | undefined,
+): Promise<void> {
+  if (!animations || animations.length === 0) return;
+  const ordered = [...animations].sort((a, b) => a.order - b.order);
+  await Promise.all(
+    ordered.map(async (anim) => {
+      const obj = findObjectById(canvas, anim.targetId);
+      if (!obj) return;
+      if (anim.delayMs && anim.delayMs > 0) await delay(anim.delayMs);
+      await animateEntrance(
+        canvas,
+        obj,
+        modelAnimationToEntrance(anim.type),
+        anim.durationMs ?? DEFAULT_ENTRANCE_MS,
+      );
+    }),
+  );
+}
+
+function delay(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
## 概要
PR-1 で `Slide` に追加し #95 で永続化した `transition` / `animations` を、present（発表者）と view（聴衆）で実際に再生する。これで「編集で設定 → 保存 → 再生」のループが閉じる。

> #96（安定ID付与）のマージ後、base を main に付け替えて作成した PR です。

## 変更点
- `web/src/lib/fabric/slidePlayback.ts`（新規）: 永続モデル型 ⇄ プレビュー型の逆マッピング（`slide`→`slide-left`、`fadeIn`→`fade-in` 等）と `playSlideAnimations`。
  - animation の targetId を**安定ID**で解決し、`order` 昇順・`delayMs`/`durationMs` を尊重して再生。
  - ターゲットが見つからない（削除済み等）animation はスキップ。
- `web/src/app/(auth)/present/[id]/page.tsx`: スライド表示時に保存済み `transition` を `playTransition`、ロード後に `animations` を `playSlideAnimations` で再生。
- `web/src/app/view/[id]/page.tsx`: 聴衆側も同じ再生（fabric の `wrapperEl` をトランジション対象に）。
- 設定が無いスライドは従来通り無挙動（`transition: \"none\"` は no-op）。
- アンマウント時に dispose 済みキャンバスへ触れないよう `cancelled` ガード。

## 設計メモ
- 永続フォーマットの `ElementAnimationType` は Out 系（fadeOut 等）も持つが、エディタは In 系しか書かない。再生はスライド表示時のエントランスなので、Out 系も対応するエントランスモーションに割り当てている（P1 の割り切り）。

## 検証
- `npm run build` green（tsc 通過）
- `npx vitest run` green（79件、slidePlayback.test.ts 6件追加）
- `go build ./...` green（Go 側影響なし）

## 次の見立て
- P1 残り: 聴衆同期（present の slideChange に追従して view が再生）の配線。
- P0 残り: Yjs 導入は ADR 相談が必要。