### PR TITLE
聴衆同期: view が発表者のスライド送りにリアルタイム追従

### DIFF
--- a/services/realtime/cmd/realtime/main_test.go
+++ b/services/realtime/cmd/realtime/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsURL rewrites an httptest http(s) URL to a ws(s) URL with the given path/query.
+func wsURL(base, pathQuery string) string {
+	return "ws" + strings.TrimPrefix(base, "http") + pathQuery
+}
+
+// TestPresenterBroadcastsToViewer verifies the core P1 path: a slide-change
+// sent by the presenter is delivered verbatim to every connected viewer.
+func TestPresenterBroadcastsToViewer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/presenter", handlePresenter)
+	mux.HandleFunc("/viewer", handleViewer)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dialer := websocket.DefaultDialer
+
+	viewer, _, err := dialer.Dial(wsURL(srv.URL, "/viewer?session=room1"), nil)
+	if err != nil {
+		t.Fatalf("viewer dial: %v", err)
+	}
+	defer viewer.Close()
+
+	presenter, _, err := dialer.Dial(wsURL(srv.URL, "/presenter?session=room1"), nil)
+	if err != nil {
+		t.Fatalf("presenter dial: %v", err)
+	}
+	defer presenter.Close()
+
+	// Give the viewer time to be registered in the session before broadcasting.
+	time.Sleep(50 * time.Millisecond)
+
+	payload := []byte(`{"type":"slide-change","slideIndex":4}`)
+	if err := presenter.WriteMessage(websocket.TextMessage, payload); err != nil {
+		t.Fatalf("presenter write: %v", err)
+	}
+
+	viewer.SetReadDeadline(time.Now().Add(time.Second))
+	_, got, err := viewer.ReadMessage()
+	if err != nil {
+		t.Fatalf("viewer read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("viewer got %q, want %q", got, payload)
+	}
+}
+
+// TestViewersAreIsolatedBySession ensures a slide-change in one session does
+// not leak to viewers of a different session.
+func TestViewersAreIsolatedBySession(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/presenter", handlePresenter)
+	mux.HandleFunc("/viewer", handleViewer)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dialer := websocket.DefaultDialer
+
+	otherViewer, _, err := dialer.Dial(wsURL(srv.URL, "/viewer?session=other"), nil)
+	if err != nil {
+		t.Fatalf("other viewer dial: %v", err)
+	}
+	defer otherViewer.Close()
+
+	presenter, _, err := dialer.Dial(wsURL(srv.URL, "/presenter?session=room1"), nil)
+	if err != nil {
+		t.Fatalf("presenter dial: %v", err)
+	}
+	defer presenter.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := presenter.WriteMessage(websocket.TextMessage, []byte(`{"type":"slide-change","slideIndex":1}`)); err != nil {
+		t.Fatalf("presenter write: %v", err)
+	}
+
+	// The unrelated viewer must NOT receive anything.
+	otherViewer.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if _, _, err := otherViewer.ReadMessage(); err == nil {
+		t.Fatalf("viewer in another session unexpectedly received a broadcast")
+	}
+}

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -3,17 +3,38 @@ import { use, useEffect, useRef, useState, useCallback } from "react";
 import { createCanvas, loadFromJSON, fitToContainer } from "@lib/fabric/canvas";
 import { playTransition } from "@lib/fabric/animation";
 import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
+import { ViewerSocket, type ViewerStatus } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
+
+const STATUS_LABEL: Record<ViewerStatus, string> = {
+  connecting: "接続中…",
+  connected: "発表者に同期中",
+  disconnected: "切断 — 手動操作",
+};
 
 export default function ViewPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const [slides, setSlides] = useState<Slide[]>([]);
   const [cur, setCur] = useState(0);
+  const [status, setStatus] = useState<ViewerStatus>("connecting");
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
     fetch(`/api/presentations/${id}/slides`).then(r=>r.json()).then((d:{items:Slide[]})=>setSlides(d.items??[]));
+  }, [id]);
+
+  // Follow the presenter: a slide-change from realtime(:8082) drives `cur`,
+  // which re-runs the playback effect below (same transition/animations as
+  // present). Handlers are detached on unmount so a presenter switch / route
+  // change cannot push state into a gone component.
+  useEffect(() => {
+    let mounted = true;
+    const sock = new ViewerSocket(id, {
+      onSlideChange: (index) => { if (mounted) setCur(index); },
+      onStatus: (s) => { if (mounted) setStatus(s); },
+    });
+    return () => { mounted = false; sock.destroy(); };
   }, [id]);
 
   useEffect(() => {
@@ -36,14 +57,21 @@ export default function ViewPage({ params }: { params: Promise<{ id: string }> }
   const next = useCallback(() => setCur(c=>Math.min(c+1,slides.length-1)), [slides.length]);
   const prev = useCallback(() => setCur(c=>Math.max(c-1,0)), []);
 
+  // Manual navigation stays available as a fallback when disconnected.
   useEffect(() => {
     const h = (e: KeyboardEvent) => { if (e.key==="ArrowRight"||e.key===" ") next(); if (e.key==="ArrowLeft") prev(); };
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);
   }, [next, prev]);
 
+  const dot = status === "connected" ? "bg-green-400" : status === "connecting" ? "bg-yellow-400" : "bg-red-400";
+
   return (
     <div ref={containerRef} className="flex h-screen flex-col items-center justify-center bg-black gap-4">
+      <div className="flex items-center gap-2 text-xs text-gray-400">
+        <span className={`inline-block h-2 w-2 rounded-full ${dot}`} />
+        <span>{STATUS_LABEL[status]}</span>
+      </div>
       <canvas ref={canvasRef} className="shadow-2xl rounded"/>
       <div className="flex items-center gap-4">
         <button onClick={prev} disabled={cur===0} className="rounded bg-gray-800 px-4 py-2 text-white text-sm disabled:opacity-30">← 前</button>

--- a/web/src/lib/realtime/presenter.test.ts
+++ b/web/src/lib/realtime/presenter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseSlideChange, ViewerSocket, type ViewerStatus } from "./presenter";
+
+describe("parseSlideChange", () => {
+  it("returns the index for a well-formed slide-change frame", () => {
+    expect(parseSlideChange(JSON.stringify({ type: "slide-change", slideIndex: 3 }))).toBe(3);
+    expect(parseSlideChange(JSON.stringify({ type: "slide-change", slideIndex: 0 }))).toBe(0);
+  });
+
+  it("rejects unrelated, malformed, or non-string frames", () => {
+    expect(parseSlideChange(JSON.stringify({ type: "ping" }))).toBeNull();
+    expect(parseSlideChange(JSON.stringify({ type: "slide-change" }))).toBeNull();
+    expect(parseSlideChange(JSON.stringify({ type: "slide-change", slideIndex: "2" }))).toBeNull();
+    expect(parseSlideChange("not json")).toBeNull();
+    expect(parseSlideChange(42)).toBeNull();
+    expect(parseSlideChange(null)).toBeNull();
+  });
+});
+
+// Minimal WebSocket stand-in so we can drive lifecycle + messages without a server.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  readyState = 0;
+  closed = false;
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  close() { this.closed = true; }
+}
+
+describe("ViewerSocket", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("reports connecting immediately, then connected on open", () => {
+    const statuses: ViewerStatus[] = [];
+    new ViewerSocket("sess-1", { onSlideChange: () => {}, onStatus: (s) => statuses.push(s) });
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toContain("/viewer?session=sess-1");
+    expect(statuses).toEqual(["connecting"]);
+    ws.onopen?.();
+    expect(statuses).toEqual(["connecting", "connected"]);
+  });
+
+  it("invokes onSlideChange for slide-change frames and ignores others", () => {
+    const seen: number[] = [];
+    new ViewerSocket("s", { onSlideChange: (i) => seen.push(i) });
+    const ws = FakeWebSocket.instances[0];
+    ws.onmessage?.({ data: JSON.stringify({ type: "slide-change", slideIndex: 5 }) });
+    ws.onmessage?.({ data: JSON.stringify({ type: "noise" }) });
+    ws.onmessage?.({ data: "garbage" });
+    expect(seen).toEqual([5]);
+  });
+
+  it("reports disconnected on close and error", () => {
+    const statuses: ViewerStatus[] = [];
+    new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) });
+    const ws = FakeWebSocket.instances[0];
+    ws.onclose?.();
+    ws.onerror?.();
+    expect(statuses).toEqual(["connecting", "disconnected", "disconnected"]);
+  });
+
+  it("detaches handlers and closes the socket on destroy", () => {
+    const statuses: ViewerStatus[] = [];
+    const sock = new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) });
+    const ws = FakeWebSocket.instances[0];
+    sock.destroy();
+    expect(ws.closed).toBe(true);
+    expect(ws.onclose).toBeNull();
+    expect(ws.onmessage).toBeNull();
+    // a stray close after destroy must not push another status update
+    expect(statuses).toEqual(["connecting"]);
+  });
+});

--- a/web/src/lib/realtime/presenter.ts
+++ b/web/src/lib/realtime/presenter.ts
@@ -12,19 +12,57 @@ export class PresenterSocket {
   destroy() { this.ws?.close(); }
 }
 
+/** Connection lifecycle reported to the viewer UI. */
+export type ViewerStatus = "connecting" | "connected" | "disconnected";
+
+export interface ViewerSocketHandlers {
+  onSlideChange: (index: number) => void;
+  onStatus?: (status: ViewerStatus) => void;
+}
+
+/**
+ * Parse a raw realtime message and return the slide index the viewer should
+ * follow, or null if the message is not a usable slide-change. Pure so the
+ * follow logic can be unit-tested without a live socket.
+ */
+export function parseSlideChange(data: unknown): number | null {
+  if (typeof data !== "string") return null;
+  try {
+    const msg = JSON.parse(data) as { type?: string; slideIndex?: number };
+    if (msg.type === "slide-change" && typeof msg.slideIndex === "number" && Number.isFinite(msg.slideIndex)) {
+      return msg.slideIndex;
+    }
+  } catch {
+    /* ignore malformed frames */
+  }
+  return null;
+}
+
 export class ViewerSocket {
   private ws: WebSocket | null = null;
-  constructor(sessionId: string, onSlideChange: (index: number) => void) {
+  constructor(sessionId: string, handlers: ViewerSocketHandlers | ((index: number) => void)) {
+    // Backwards-compatible: a bare callback is treated as onSlideChange.
+    const h: ViewerSocketHandlers = typeof handlers === "function" ? { onSlideChange: handlers } : handlers;
     const url = `${process.env.NEXT_PUBLIC_REALTIME_URL ?? "ws://localhost:8082"}/viewer?session=${sessionId}`;
+    h.onStatus?.("connecting");
     this.ws = new WebSocket(url);
+    this.ws.onopen = () => h.onStatus?.("connected");
+    this.ws.onclose = () => h.onStatus?.("disconnected");
+    this.ws.onerror = () => h.onStatus?.("disconnected");
     this.ws.onmessage = (e) => {
-      try {
-        const msg = JSON.parse(e.data as string) as { type: string; slideIndex?: number };
-        if (msg.type === "slide-change" && msg.slideIndex !== undefined) {
-          onSlideChange(msg.slideIndex);
-        }
-      } catch { /* ignore */ }
+      const index = parseSlideChange(e.data);
+      if (index !== null) h.onSlideChange(index);
     };
   }
-  destroy() { this.ws?.close(); }
+  destroy() {
+    // Drop handlers before closing so an unmount-triggered close does not
+    // bubble a "disconnected" status into a component that is going away.
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      this.ws.close();
+    }
+  }
 }


### PR DESCRIPTION
## 概要
PresentsAI P1 の仕上げ。`view/[id]`（聴衆）が発表者のスライド送りにリアルタイム追従するよう配線した。これまで realtime サービスは presenter→viewer のブロードキャストを実装済みだったが、viewer 側が受信していなかった（監査で「聴衆同期 実質未配線」と指摘）。

## 配線の実装点
1. **viewer 受信**: `view/[id]/page.tsx` が `ViewerSocket` を購読し、発表者の `slide-change`（presenter → realtime :8082 → viewer）で `cur` を更新。
2. **再生適用**: `cur` 変化で既存の playback effect が再実行され、present と同じ `playTransition` / `playSlideAnimations`（#98）が追従時にも再生される。
3. **接続状態 UI + クリーンアップ**: 接続中／同期中／切断 のインジケータを追加。`ViewerSocket` に status コールバックを追加し、`destroy()` でハンドラを切り離してから close（unmount / 発表者切替時に gone なコンポーネントへ state を push しないガード）。手動ナビは切断時のフォールバックとして維持。
4. **realtime 中継**: presenter→viewer のブロードキャストは既存実装で疎通済み。Yjs/CRDT には踏み込まず、slide index ブロードキャストに限定。

## テスト
- `web`: `npx vitest run` → 85 passed（新規 `presenter.test.ts` 6 件: parseSlideChange / ViewerSocket の status・message・destroy）。
- `web`: `npm run build`（tsc green）。
- `services/realtime`: `go build ./... && go test ./...` green（新規 `main_test.go`: presenter→viewer ブロードキャスト疎通 / セッション分離）。

## スコープ
- 本体（非テスト）約74行、テスト約173行。