### PR TITLE
共同編集(PR2): collabサーバを y-websocket 互換の Yjs リレーに

### DIFF
--- a/services/collab/cmd/collab/main.go
+++ b/services/collab/cmd/collab/main.go
@@ -1,3 +1,12 @@
+// Command collab is a y-websocket compatible relay server for PresentsAI.
+//
+// It speaks the y-protocol message framing (sync / awareness) and relays
+// opaque Yjs updates between clients in the same room. It does NOT interpret
+// CRDT contents; the authoritative merge happens in each client's Yjs doc
+// (ADR-0010/0011). Persistence is currently in-memory only (PR4 adds Postgres).
+//
+// y-websocket connects to `ws://host:port/{roomname}`, so the room id is the
+// URL path segment.
 package main
 
 import (
@@ -5,60 +14,108 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
+	"strings"
 
 	"github.com/gorilla/websocket"
 	"github.com/joho/godotenv"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/hub"
 )
 
 var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 
-type Room struct {
-	mu      sync.RWMutex
-	clients map[*websocket.Conn]bool
-	state   []byte
+// wsClient adapts a websocket connection to hub.Client. Outbound frames are
+// queued on a buffered channel and written by a single writer goroutine, so
+// the hub never blocks on slow sockets and gorilla's one-writer rule holds.
+type wsClient struct {
+	conn *websocket.Conn
+	send chan []byte
 }
 
-var rooms = make(map[string]*Room)
-var roomsMu sync.RWMutex
-
-func getRoom(id string) *Room {
-	roomsMu.Lock(); defer roomsMu.Unlock()
-	if r, ok := rooms[id]; ok { return r }
-	r := &Room{clients: make(map[*websocket.Conn]bool)}
-	rooms[id] = r; return r
+func newWSClient(conn *websocket.Conn) *wsClient {
+	return &wsClient{conn: conn, send: make(chan []byte, 256)}
 }
 
-func handleWS(w http.ResponseWriter, r *http.Request) {
-	roomID := r.URL.Query().Get("room")
-	if roomID == "" { http.Error(w, "room required", 400); return }
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil { return }
-	room := getRoom(roomID)
-	room.mu.Lock()
-	room.clients[conn] = true
-	if len(room.state) > 0 { conn.WriteMessage(websocket.BinaryMessage, room.state) }
-	room.mu.Unlock()
-	defer func() { room.mu.Lock(); delete(room.clients, conn); room.mu.Unlock(); conn.Close() }()
-	for {
-		mt, msg, err := conn.ReadMessage()
-		if err != nil { break }
-		room.mu.Lock()
-		room.state = msg
-		for c := range room.clients { if c != conn { c.WriteMessage(mt, msg) } }
-		room.mu.Unlock()
+// Send queues a frame for delivery. If the buffer is full the client is
+// considered too slow; the frame is dropped (Yjs re-syncs on reconnect).
+func (c *wsClient) Send(data []byte) {
+	select {
+	case c.send <- data:
+	default:
+		log.Printf("collab: dropping frame for slow client")
+	}
+}
+
+// writePump drains the send channel to the socket. It exits when the channel
+// is closed, then closes the connection.
+func (c *wsClient) writePump() {
+	defer c.conn.Close()
+	for data := range c.send {
+		if err := c.conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+			return
+		}
+	}
+}
+
+// roomID extracts the room name from the request path. y-websocket uses
+// `ws://host/{roomname}`; we also accept a legacy `?room=` query param.
+func roomID(r *http.Request) string {
+	if q := r.URL.Query().Get("room"); q != "" {
+		return q
+	}
+	return strings.Trim(r.URL.Path, "/")
+}
+
+func makeHandler(h *hub.Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := roomID(r)
+		if id == "" {
+			http.Error(w, "room required", http.StatusBadRequest)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		room := h.Room(id)
+		client := newWSClient(conn)
+		room.Join(client)
+		go client.writePump()
+
+		defer func() {
+			room.Leave(client)
+			close(client.send) // stops writePump, which closes the conn
+		}()
+
+		for {
+			mt, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.BinaryMessage {
+				continue // y-protocol frames are always binary
+			}
+			room.HandleMessage(client, msg)
+		}
 	}
 }
 
 func main() {
 	godotenv.Load()
+	h := hub.New()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type","application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status":"ok","service":"presentsai-collab"})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "presentsai-collab"})
 	})
-	mux.HandleFunc("/ws", handleWS)
-	port := os.Getenv("PORT"); if port == "" { port = "8081" }
+	// y-websocket connects to /{roomname}; "/" catches every room path.
+	mux.HandleFunc("/", makeHandler(h))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8081"
+	}
 	log.Printf("collab service starting on :%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, mux))
 }

--- a/services/collab/cmd/collab/main_test.go
+++ b/services/collab/cmd/collab/main_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/hub"
+	"github.com/ko-tarou/presentsai/services/collab/internal/yproto"
+)
+
+// Real Yjs fixtures captured from a y-protocols client (see internal/hub tests).
+const (
+	syncStep1Empty = "00000100"
+	updateFrame    = "00021f0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00"
+	rawUpdate      = "0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// dial opens a websocket to the test server's room path (y-websocket style).
+func dial(t *testing.T, srv *httptest.Server, room string) *websocket.Conn {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(srv.URL, "http") + "/" + room
+	c, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	return c
+}
+
+func readBinary(t *testing.T, c *websocket.Conn) []byte {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	mt, msg, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("expected binary frame, got type %d", mt)
+	}
+	return msg
+}
+
+// TestE2ESyncStep1OverWebsocket: a client connecting to a populated room over a
+// real websocket receives the snapshot replay followed by the server SyncStep1.
+func TestE2ESyncStep1OverWebsocket(t *testing.T) {
+	h := hub.New()
+	srv := httptest.NewServer(makeHandler(h))
+	defer srv.Close()
+
+	// Seeder pushes one update into the room.
+	seed := dial(t, srv, "deck-e2e")
+	defer seed.Close()
+	if err := seed.WriteMessage(websocket.BinaryMessage, mustHex(t, updateFrame)); err != nil {
+		t.Fatal(err)
+	}
+	// Wait for the server to store it.
+	deadline := time.Now().Add(2 * time.Second)
+	for h.Room("deck-e2e").UpdateCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if h.Room("deck-e2e").UpdateCount() != 1 {
+		t.Fatalf("seed update not stored")
+	}
+
+	// Joiner connects and sends SyncStep1; should get the stored update + SyncStep1.
+	join := dial(t, srv, "deck-e2e")
+	defer join.Close()
+	if err := join.WriteMessage(websocket.BinaryMessage, mustHex(t, syncStep1Empty)); err != nil {
+		t.Fatal(err)
+	}
+
+	first := readBinary(t, join)
+	wantUpdate := yproto.EncodeSyncUpdate(mustHex(t, rawUpdate))
+	if hex.EncodeToString(first) != hex.EncodeToString(wantUpdate) {
+		t.Fatalf("first frame: got %x want %x", first, wantUpdate)
+	}
+	second := readBinary(t, join)
+	wantStep1 := yproto.EncodeSyncStep1(yproto.EmptyStateVector)
+	if hex.EncodeToString(second) != hex.EncodeToString(wantStep1) {
+		t.Fatalf("second frame: got %x want %x", second, wantStep1)
+	}
+}
+
+// TestE2EBroadcastBetweenTwoClients: an update from one client is relayed to a
+// second client in the same room over real websockets.
+func TestE2EBroadcastBetweenTwoClients(t *testing.T) {
+	h := hub.New()
+	srv := httptest.NewServer(makeHandler(h))
+	defer srv.Close()
+
+	a := dial(t, srv, "deck-bcast")
+	defer a.Close()
+	b := dial(t, srv, "deck-bcast")
+	defer b.Close()
+
+	if err := a.WriteMessage(websocket.BinaryMessage, mustHex(t, updateFrame)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readBinary(t, b)
+	want := yproto.EncodeSyncUpdate(mustHex(t, rawUpdate))
+	if hex.EncodeToString(got) != hex.EncodeToString(want) {
+		t.Fatalf("broadcast: got %x want %x", got, want)
+	}
+}
+
+// TestE2EHealth: the /health endpoint stays a plain JSON probe, not a room.
+func TestE2EHealth(t *testing.T) {
+	h := hub.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.HandleFunc("/", makeHandler(h))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("health status %d", resp.StatusCode)
+	}
+}

--- a/services/collab/internal/hub/hub.go
+++ b/services/collab/internal/hub/hub.go
@@ -1,0 +1,193 @@
+// Package hub implements the transport-agnostic relay core for the collab
+// server. It manages rooms (one per presentation), stores the opaque Yjs
+// update log for each room, and computes the outbound messages for every
+// inbound y-protocol message.
+//
+// The relay is deliberately CRDT-agnostic (ADR-0010/0011): the authoritative
+// merge happens in each client's Yjs instance. The server only stores and
+// forwards opaque update bytes. The convergence strategy is:
+//
+//   - On SyncStep1 from a client: reply with every stored update (as Update
+//     messages) so the newcomer catches up, then send our own SyncStep1 with
+//     an empty state vector so the client pushes us its full state.
+//   - On SyncStep2 / Update: append the opaque update to the room log and
+//     broadcast it to every other client as an Update message.
+//   - On awareness / queryAwareness: relay to other clients without storing
+//     (awareness is ephemeral presence state).
+//
+// This strategy is validated to converge against real Yjs clients (see tests).
+package hub
+
+import (
+	"sync"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/yproto"
+)
+
+// Client is anything the hub can push outbound binary frames to. The
+// websocket transport implements this; tests use an in-memory fake.
+type Client interface {
+	// Send delivers one binary websocket frame to the client. It must be
+	// safe to call from the hub's goroutine and should not block
+	// indefinitely (implementations typically buffer or drop on a full
+	// queue).
+	Send(data []byte)
+}
+
+// Room holds the connected clients and the accumulated opaque update log
+// for a single presentation.
+type Room struct {
+	mu      sync.RWMutex
+	clients map[Client]struct{}
+	// updates is the append-only log of opaque Yjs updates seen in this
+	// room. Order is not significant for correctness (Yjs merges are
+	// commutative & idempotent) but is preserved for determinism.
+	updates [][]byte
+}
+
+func newRoom() *Room {
+	return &Room{clients: make(map[Client]struct{})}
+}
+
+// Hub manages all rooms.
+type Hub struct {
+	mu    sync.Mutex
+	rooms map[string]*Room
+}
+
+// New returns an empty Hub.
+func New() *Hub { return &Hub{rooms: make(map[string]*Room)} }
+
+// Room returns the room with the given id, creating it on first use.
+func (h *Hub) Room(id string) *Room {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r, ok := h.rooms[id]
+	if !ok {
+		r = newRoom()
+		h.rooms[id] = r
+	}
+	return r
+}
+
+// RoomCount reports how many rooms currently exist (test/observability).
+func (h *Hub) RoomCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.rooms)
+}
+
+// Join registers c as a member of the room.
+func (r *Room) Join(c Client) {
+	r.mu.Lock()
+	r.clients[c] = struct{}{}
+	r.mu.Unlock()
+}
+
+// Leave removes c from the room.
+func (r *Room) Leave(c Client) {
+	r.mu.Lock()
+	delete(r.clients, c)
+	r.mu.Unlock()
+}
+
+// ClientCount reports the number of connected clients (test/observability).
+func (r *Room) ClientCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.clients)
+}
+
+// UpdateCount reports the number of stored opaque updates (test/observability).
+func (r *Room) UpdateCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.updates)
+}
+
+// HandleMessage processes one inbound y-protocol frame from sender. It mutates
+// the room state (appending updates) and pushes outbound frames directly to
+// the relevant clients via their Send method:
+//
+//   - replies (catch-up snapshot, our SyncStep1) go to sender,
+//   - broadcasts (relayed updates / awareness) go to every other client.
+//
+// Unknown or malformed messages are ignored (best-effort relay).
+func (r *Room) HandleMessage(sender Client, msg []byte) {
+	dec := yproto.NewDecoder(msg)
+	mtype, err := dec.ReadVarUint()
+	if err != nil {
+		return
+	}
+
+	switch int(mtype) {
+	case yproto.MessageSync:
+		r.handleSync(sender, dec, msg)
+	case yproto.MessageAwareness, yproto.MessageQueryAwareness:
+		// Awareness is ephemeral: relay the original frame verbatim to
+		// other clients and never store it.
+		r.broadcast(sender, msg)
+	default:
+		// Unknown message type: ignore.
+	}
+}
+
+func (r *Room) handleSync(sender Client, dec *yproto.Decoder, original []byte) {
+	step, err := dec.ReadVarUint()
+	if err != nil {
+		return
+	}
+	switch int(step) {
+	case yproto.SyncStep1:
+		// The peer announced its state vector. As an opaque relay we
+		// cannot diff against it, so we (a) send every stored update so
+		// the peer catches up, then (b) send our own SyncStep1 with an
+		// empty state vector so the peer replies with its full state.
+		r.replaySnapshot(sender)
+		sender.Send(yproto.EncodeSyncStep1(yproto.EmptyStateVector))
+
+	case yproto.SyncStep2, yproto.SyncUpdate:
+		// Both carry an opaque update payload. Store it, then broadcast
+		// to the other clients as a normalized Update message.
+		update, err := dec.ReadVarUint8Array()
+		if err != nil {
+			return
+		}
+		stored := append([]byte(nil), update...) // copy: msg buffer is reused
+		r.mu.Lock()
+		r.updates = append(r.updates, stored)
+		r.mu.Unlock()
+		r.broadcast(sender, yproto.EncodeSyncUpdate(stored))
+
+	default:
+		// Unknown sync step: ignore.
+	}
+}
+
+// replaySnapshot sends every stored update to c as individual Update messages.
+// Yjs applies them idempotently regardless of order, reconstructing the room
+// state in the newcomer's document.
+func (r *Room) replaySnapshot(c Client) {
+	r.mu.RLock()
+	snapshot := make([][]byte, len(r.updates))
+	copy(snapshot, r.updates)
+	r.mu.RUnlock()
+	for _, u := range snapshot {
+		c.Send(yproto.EncodeSyncUpdate(u))
+	}
+}
+
+// broadcast sends data to every client in the room except the sender.
+func (r *Room) broadcast(sender Client, data []byte) {
+	r.mu.RLock()
+	targets := make([]Client, 0, len(r.clients))
+	for c := range r.clients {
+		if c != sender {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.RUnlock()
+	for _, c := range targets {
+		c.Send(data)
+	}
+}

--- a/services/collab/internal/hub/hub_test.go
+++ b/services/collab/internal/hub/hub_test.go
@@ -1,0 +1,207 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/yproto"
+)
+
+// fakeClient records every frame the hub sends to it.
+type fakeClient struct {
+	id   string
+	recv [][]byte
+}
+
+func (c *fakeClient) Send(data []byte) {
+	c.recv = append(c.recv, append([]byte(nil), data...))
+}
+
+// hexMust decodes a hex string in a test fixture.
+func hexMust(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// Real Yjs fixtures (captured from a y-protocols client).
+const (
+	syncStep1Empty = "00000100" // messageSync, SyncStep1, empty state vector
+	updateFrame    = "00021f0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00"
+	rawUpdate      = "0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00"
+	awarenessFrame = "010401020304" // messageAwareness with opaque payload
+)
+
+// TestUpdateStoredAndBroadcast: an Update frame is appended to the room log and
+// relayed to the *other* client (not echoed back to the sender).
+func TestUpdateStoredAndBroadcast(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	b := &fakeClient{id: "b"}
+	room.Join(a)
+	room.Join(b)
+
+	room.HandleMessage(a, hexMust(t, updateFrame))
+
+	if room.UpdateCount() != 1 {
+		t.Fatalf("expected 1 stored update, got %d", room.UpdateCount())
+	}
+	if len(a.recv) != 0 {
+		t.Fatalf("sender should not receive its own update, got %d frames", len(a.recv))
+	}
+	if len(b.recv) != 1 {
+		t.Fatalf("peer should receive 1 relayed update, got %d", len(b.recv))
+	}
+	// Relayed frame should carry the exact opaque update payload.
+	want := yproto.EncodeSyncUpdate(hexMust(t, rawUpdate))
+	if !bytes.Equal(b.recv[0], want) {
+		t.Fatalf("relayed frame: got %x want %x", b.recv[0], want)
+	}
+}
+
+// TestSyncStep1ReplaysSnapshot: a newcomer sending SyncStep1 receives every
+// stored update followed by the server's own SyncStep1 (empty state vector).
+func TestSyncStep1ReplaysSnapshot(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+
+	// Seed the room with two stored updates via an existing client.
+	seeder := &fakeClient{id: "seed"}
+	room.Join(seeder)
+	room.HandleMessage(seeder, hexMust(t, updateFrame))
+	room.HandleMessage(seeder, hexMust(t, updateFrame))
+	if room.UpdateCount() != 2 {
+		t.Fatalf("expected 2 stored updates, got %d", room.UpdateCount())
+	}
+
+	// Newcomer connects and announces its (empty) state vector.
+	joiner := &fakeClient{id: "join"}
+	room.Join(joiner)
+	room.HandleMessage(joiner, hexMust(t, syncStep1Empty))
+
+	// Expect: 2 replayed updates + 1 server SyncStep1.
+	if len(joiner.recv) != 3 {
+		t.Fatalf("expected 3 frames (2 updates + SyncStep1), got %d", len(joiner.recv))
+	}
+	wantUpdate := yproto.EncodeSyncUpdate(hexMust(t, rawUpdate))
+	if !bytes.Equal(joiner.recv[0], wantUpdate) || !bytes.Equal(joiner.recv[1], wantUpdate) {
+		t.Fatalf("snapshot frames not the stored updates")
+	}
+	wantStep1 := yproto.EncodeSyncStep1(yproto.EmptyStateVector)
+	if !bytes.Equal(joiner.recv[2], wantStep1) {
+		t.Fatalf("final frame: got %x want server SyncStep1 %x", joiner.recv[2], wantStep1)
+	}
+}
+
+// TestSyncStep2Stored: a SyncStep2 (full-state reply) is stored and broadcast
+// just like an Update.
+func TestSyncStep2Stored(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	b := &fakeClient{id: "b"}
+	room.Join(a)
+	room.Join(b)
+
+	step2 := yproto.EncodeSyncStep2(hexMust(t, rawUpdate))
+	room.HandleMessage(a, step2)
+
+	if room.UpdateCount() != 1 {
+		t.Fatalf("SyncStep2 should be stored, count=%d", room.UpdateCount())
+	}
+	if len(b.recv) != 1 {
+		t.Fatalf("SyncStep2 should be broadcast as Update, got %d", len(b.recv))
+	}
+	// Broadcast is normalized to an Update message.
+	want := yproto.EncodeSyncUpdate(hexMust(t, rawUpdate))
+	if !bytes.Equal(b.recv[0], want) {
+		t.Fatalf("broadcast frame: got %x want %x", b.recv[0], want)
+	}
+}
+
+// TestAwarenessRelayedNotStored: awareness is relayed verbatim and not stored.
+func TestAwarenessRelayedNotStored(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	b := &fakeClient{id: "b"}
+	room.Join(a)
+	room.Join(b)
+
+	frame := hexMust(t, awarenessFrame)
+	room.HandleMessage(a, frame)
+
+	if room.UpdateCount() != 0 {
+		t.Fatalf("awareness must not be stored, count=%d", room.UpdateCount())
+	}
+	if len(b.recv) != 1 || !bytes.Equal(b.recv[0], frame) {
+		t.Fatalf("awareness should be relayed verbatim to peer")
+	}
+	if len(a.recv) != 0 {
+		t.Fatalf("awareness should not echo back to sender")
+	}
+}
+
+// TestRoomSeparation: updates in one room never leak into another.
+func TestRoomSeparation(t *testing.T) {
+	h := New()
+	r1 := h.Room("deck-1")
+	r2 := h.Room("deck-2")
+	a := &fakeClient{id: "a"} // in deck-1
+	b := &fakeClient{id: "b"} // in deck-2
+	r1.Join(a)
+	r2.Join(b)
+
+	r1.HandleMessage(a, hexMust(t, updateFrame))
+
+	if r1.UpdateCount() != 1 {
+		t.Fatalf("deck-1 should have 1 update, got %d", r1.UpdateCount())
+	}
+	if r2.UpdateCount() != 0 {
+		t.Fatalf("deck-2 must stay empty, got %d", r2.UpdateCount())
+	}
+	if len(b.recv) != 0 {
+		t.Fatalf("client in deck-2 must not receive deck-1 traffic, got %d", len(b.recv))
+	}
+	if h.RoomCount() != 2 {
+		t.Fatalf("expected 2 rooms, got %d", h.RoomCount())
+	}
+}
+
+// TestLeaveStopsBroadcast: a client that left no longer receives broadcasts.
+func TestLeaveStopsBroadcast(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	b := &fakeClient{id: "b"}
+	room.Join(a)
+	room.Join(b)
+	room.Leave(b)
+
+	room.HandleMessage(a, hexMust(t, updateFrame))
+	if len(b.recv) != 0 {
+		t.Fatalf("left client should receive nothing, got %d", len(b.recv))
+	}
+}
+
+// TestMalformedIgnored: garbage frames are ignored without panicking or storing.
+func TestMalformedIgnored(t *testing.T) {
+	h := New()
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	room.Join(a)
+
+	room.HandleMessage(a, []byte{})           // empty
+	room.HandleMessage(a, []byte{0x00})       // sync, but no step
+	room.HandleMessage(a, []byte{0x00, 0x02}) // update, but no payload
+	room.HandleMessage(a, []byte{0xff, 0xff}) // unknown message type
+
+	if room.UpdateCount() != 0 {
+		t.Fatalf("malformed frames must not be stored, count=%d", room.UpdateCount())
+	}
+}

--- a/services/collab/internal/yproto/yproto.go
+++ b/services/collab/internal/yproto/yproto.go
@@ -1,0 +1,150 @@
+// Package yproto implements the minimal subset of the y-protocol message
+// framing needed to act as a y-websocket compatible relay.
+//
+// The server NEVER interprets CRDT contents: Yjs updates and awareness
+// payloads are handled as opaque byte slices. We only need to parse the
+// outer framing (message type + lib0 var-uint length prefixes) so we can
+// route messages correctly.
+//
+// Wire format (all binary websocket frames):
+//
+//	[varUint messageType] [payload...]
+//
+// messageType:
+//
+//	0 = sync           payload: [varUint syncStep] [...]
+//	1 = awareness      payload: [varUint8Array awarenessUpdate]
+//	3 = queryAwareness payload: (empty)
+//
+// sync step:
+//
+//	0 = SyncStep1      payload: [varUint8Array stateVector]
+//	1 = SyncStep2      payload: [varUint8Array update]
+//	2 = Update         payload: [varUint8Array update]
+//
+// var-uint / var-uint8array follow the lib0 encoding used by y-protocols.
+package yproto
+
+import "errors"
+
+// Message types (must match y-websocket constants).
+const (
+	MessageSync           = 0
+	MessageAwareness      = 1
+	MessageQueryAwareness = 3
+)
+
+// Sync sub-message steps (must match y-protocols/sync constants).
+const (
+	SyncStep1  = 0
+	SyncStep2  = 1
+	SyncUpdate = 2
+)
+
+// ErrTruncated is returned when a buffer ends before a value is fully read.
+var ErrTruncated = errors.New("yproto: truncated message")
+
+// EmptyStateVector is the lib0 encoding of an empty Yjs state vector
+// (a var-uint map length of 0). Sending SyncStep1 with this state vector
+// asks the peer to reply with its *entire* document state, which lets an
+// opaque relay request a full snapshot without understanding CRDT internals.
+var EmptyStateVector = []byte{0}
+
+// Decoder reads lib0-encoded values from a byte slice.
+type Decoder struct {
+	buf []byte
+	pos int
+}
+
+// NewDecoder wraps b for reading.
+func NewDecoder(b []byte) *Decoder { return &Decoder{buf: b} }
+
+// ReadVarUint reads an unsigned lib0 variable-length integer.
+func (d *Decoder) ReadVarUint() (uint64, error) {
+	var num uint64
+	var shift uint
+	for {
+		if d.pos >= len(d.buf) {
+			return 0, ErrTruncated
+		}
+		b := d.buf[d.pos]
+		d.pos++
+		num |= uint64(b&0x7f) << shift
+		if b&0x80 == 0 {
+			return num, nil
+		}
+		shift += 7
+		if shift > 63 {
+			return 0, errors.New("yproto: var-uint overflow")
+		}
+	}
+}
+
+// ReadVarUint8Array reads a length-prefixed byte slice. The returned slice
+// aliases the underlying buffer; copy it if it must outlive the buffer.
+func (d *Decoder) ReadVarUint8Array() ([]byte, error) {
+	n, err := d.ReadVarUint()
+	if err != nil {
+		return nil, err
+	}
+	if d.pos+int(n) > len(d.buf) {
+		return nil, ErrTruncated
+	}
+	out := d.buf[d.pos : d.pos+int(n)]
+	d.pos += int(n)
+	return out, nil
+}
+
+// Encoder writes lib0-encoded values to an internal buffer.
+type Encoder struct {
+	buf []byte
+}
+
+// NewEncoder returns an empty encoder.
+func NewEncoder() *Encoder { return &Encoder{} }
+
+// WriteVarUint appends an unsigned lib0 variable-length integer.
+func (e *Encoder) WriteVarUint(num uint64) {
+	for num > 0x7f {
+		e.buf = append(e.buf, byte(0x80|(num&0x7f)))
+		num >>= 7
+	}
+	e.buf = append(e.buf, byte(num&0x7f))
+}
+
+// WriteVarUint8Array appends a length-prefixed byte slice.
+func (e *Encoder) WriteVarUint8Array(b []byte) {
+	e.WriteVarUint(uint64(len(b)))
+	e.buf = append(e.buf, b...)
+}
+
+// Bytes returns the accumulated buffer.
+func (e *Encoder) Bytes() []byte { return e.buf }
+
+// EncodeSyncUpdate frames an opaque Yjs update as a sync/Update message,
+// the canonical way to relay a single update to other clients.
+func EncodeSyncUpdate(update []byte) []byte {
+	e := NewEncoder()
+	e.WriteVarUint(MessageSync)
+	e.WriteVarUint(SyncUpdate)
+	e.WriteVarUint8Array(update)
+	return e.Bytes()
+}
+
+// EncodeSyncStep1 frames a SyncStep1 carrying the given state vector.
+func EncodeSyncStep1(stateVector []byte) []byte {
+	e := NewEncoder()
+	e.WriteVarUint(MessageSync)
+	e.WriteVarUint(SyncStep1)
+	e.WriteVarUint8Array(stateVector)
+	return e.Bytes()
+}
+
+// EncodeSyncStep2 frames a SyncStep2 carrying an opaque update.
+func EncodeSyncStep2(update []byte) []byte {
+	e := NewEncoder()
+	e.WriteVarUint(MessageSync)
+	e.WriteVarUint(SyncStep2)
+	e.WriteVarUint8Array(update)
+	return e.Bytes()
+}

--- a/services/collab/internal/yproto/yproto_test.go
+++ b/services/collab/internal/yproto/yproto_test.go
@@ -1,0 +1,88 @@
+package yproto
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestVarUintRoundTrip(t *testing.T) {
+	cases := []uint64{0, 1, 127, 128, 255, 300, 16384, 1 << 21, 1<<63 - 1}
+	for _, v := range cases {
+		e := NewEncoder()
+		e.WriteVarUint(v)
+		d := NewDecoder(e.Bytes())
+		got, err := d.ReadVarUint()
+		if err != nil {
+			t.Fatalf("decode %d: %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("var-uint round trip: got %d want %d", got, v)
+		}
+	}
+}
+
+func TestVarUint8ArrayRoundTrip(t *testing.T) {
+	payload := []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x7f, 0x80}
+	e := NewEncoder()
+	e.WriteVarUint8Array(payload)
+	d := NewDecoder(e.Bytes())
+	got, err := d.ReadVarUint8Array()
+	if err != nil {
+		t.Fatalf("decode array: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("array round trip: got %x want %x", got, payload)
+	}
+}
+
+// TestDecodeRealUpdateFrame parses a real y-protocols Update frame (captured
+// from a Yjs client) and confirms we extract the exact opaque payload.
+func TestDecodeRealUpdateFrame(t *testing.T) {
+	frame, _ := hex.DecodeString("00021f0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00")
+	wantUpdate, _ := hex.DecodeString("0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00")
+
+	d := NewDecoder(frame)
+	mt, err := d.ReadVarUint()
+	if err != nil || int(mt) != MessageSync {
+		t.Fatalf("messageType=%d err=%v", mt, err)
+	}
+	step, err := d.ReadVarUint()
+	if err != nil || int(step) != SyncUpdate {
+		t.Fatalf("step=%d err=%v", step, err)
+	}
+	upd, err := d.ReadVarUint8Array()
+	if err != nil {
+		t.Fatalf("read update: %v", err)
+	}
+	if !bytes.Equal(upd, wantUpdate) {
+		t.Fatalf("update payload: got %x want %x", upd, wantUpdate)
+	}
+}
+
+// TestEncodeSyncUpdateMatchesYjs confirms our framing of an opaque update is
+// byte-identical to what a Yjs client produces.
+func TestEncodeSyncUpdateMatchesYjs(t *testing.T) {
+	raw, _ := hex.DecodeString("0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00")
+	want, _ := hex.DecodeString("00021f0101dfdac0c204012800dfdac0c20400057469746c6501770548656c6c6f00")
+	got := EncodeSyncUpdate(raw)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("EncodeSyncUpdate: got %x want %x", got, want)
+	}
+}
+
+func TestEncodeSyncStep1Empty(t *testing.T) {
+	// messageSync(0) + SyncStep1(0) + varUint8Array([0]) => 00 00 01 00
+	want, _ := hex.DecodeString("00000100")
+	got := EncodeSyncStep1(EmptyStateVector)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("EncodeSyncStep1(empty): got %x want %x", got, want)
+	}
+}
+
+func TestTruncated(t *testing.T) {
+	d := NewDecoder([]byte{0x05}) // says length 5 but no data follows
+	if _, err := d.ReadVarUint8Array(); err != ErrTruncated {
+		t.Fatalf("expected ErrTruncated, got %v", err)
+	}
+}


### PR DESCRIPTION
## 概要
PR1 でフロントの `provider.ts` が **y-websocket** で `ws://…:8081/{room}` に接続するようになったが、collab サーバ(Go) は素WSブロードキャストのままで Yjs sync 非対応だった。本PRで collab を **y-websocket 互換の opaque リレー** に対応させる（ADR-0010/0011: Yjs を真実源、サーバは CRDT を解釈しない）。

## 実装
- **`internal/yproto`**: y-protocol のフレーミング最小実装。lib0 var-uint / var-uint8array コーデックと sync メッセージのエンコード/デコードヘルパ。CRDT 内容は一切解釈せず opaque バイト列として扱う。
- **`internal/hub`**: transport 非依存のリレーコア。room(=presentation)単位の接続管理 + in-memory の opaque update ログ。
  - **SyncStep1 受信** → 蓄積した全 update を Update メッセージとして再生 + 自分の SyncStep1(空 state vector) を返す（opaque なので diff 計算せず、相手にフル state を要求）
  - **SyncStep2 / Update 受信** → opaque payload を蓄積し、他クライアントへ Update として中継
  - **awareness / queryAwareness** → 蓄積せず他クライアントへそのまま中継
- **`cmd/collab/main.go`**: room を URL パスから取得（y-websocket の `/{roomname}` 規約。`?room=` も後方互換で受理）、フレームを hub に委譲、slow client 対策にクライアント毎の buffered write pump を追加。

## 検証
- `go build ./... && go vet ./... && go test -race ./...` すべて green
- 単体: yproto コーデック / 実Yjsバイト列のパース / hub の sync step1-2・update中継・room分離・awareness中継・malformed無視
- 結合(`main_test.go`): 実 httptest サーバ + gorilla クライアントで snapshot 再生・peer 間ブロードキャストを byte 一致で検証
- **実 y-websocket E2E（ローカル手動）**: Node の y-websocket クライアント2つを実 Go サーバへ接続 → 後発参加者が先行編集を取得、双方向に編集が伝播することを確認（"E2E PASS"）

## スコープ外
- 完全な CRDT エンジン（opaque リレーのみ）
- PostgreSQL 永続化（PR4）
- Fabric↔Yjs 双方向バインディング（PR3）

## フロント影響
なし。`provider.ts` は `ws://localhost:8081` + room を path に付与しており、本サーバの URL パス規約と互換。