### PR TITLE
共同編集(PR3a): Fabric↔Yjs 双方向バインディングのコア実装

### DIFF
--- a/web/src/lib/collab/binding.test.ts
+++ b/web/src/lib/collab/binding.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as Y from "yjs";
+import { getSlides, slideToYMap, type YObjectMap, type YSlideMap } from "./schema";
+import {
+  ObjectBinding,
+  SlideStructureBinding,
+  LOCAL_ORIGIN,
+  type CanvasLike,
+  type ObjectJSON,
+} from "./binding";
+
+vi.mock("y-websocket", () => ({ WebsocketProvider: vi.fn() }));
+
+/**
+ * In-memory stand-in for the slice of the Fabric Canvas the binding uses. It
+ * also wires its own mutation events back through an attached ObjectBinding —
+ * exactly like the real canvas — so loop-prevention is genuinely exercised.
+ */
+class FakeCanvas implements CanvasLike {
+  objects: ObjectJSON[] = [];
+  renders = 0;
+  binding: ObjectBinding | null = null;
+
+  getObjects(): ObjectJSON[] {
+    return [...this.objects];
+  }
+  toObject(obj: ObjectJSON): ObjectJSON {
+    return { ...obj };
+  }
+  addObject(json: ObjectJSON): void {
+    this.objects.push({ ...json });
+    // Real fabric fires object:added on add — route it back like the hook does.
+    this.binding?.onObjectAdded({ ...json });
+  }
+  removeObject(id: string): void {
+    const before = this.objects.length;
+    this.objects = this.objects.filter((o) => o.id !== id);
+    if (this.objects.length !== before) this.binding?.onObjectRemoved({ id });
+  }
+  updateObject(id: string, patch: Record<string, unknown>): void {
+    const o = this.objects.find((x) => x.id === id);
+    if (!o) return;
+    Object.assign(o, patch);
+    this.binding?.onObjectModified(o as ObjectJSON);
+  }
+  requestRender(): void {
+    this.renders++;
+  }
+
+  /** Simulate a *user* edit: mutate locally and notify the binding. */
+  userAdd(json: ObjectJSON): void {
+    this.objects.push({ ...json });
+    this.binding?.onObjectAdded(json);
+  }
+  userModify(id: string, patch: Record<string, unknown>): void {
+    const o = this.objects.find((x) => x.id === id)!;
+    Object.assign(o, patch);
+    this.binding?.onObjectModified(o);
+  }
+  userRemove(id: string): void {
+    this.objects = this.objects.filter((o) => o.id !== id);
+    this.binding?.onObjectRemoved({ id });
+  }
+}
+
+function seedSlide(doc: Y.Doc, objects: ObjectJSON[] = []): YSlideMap {
+  const slides = getSlides(doc);
+  const map = slideToYMap({
+    id: "slide-1",
+    presentationId: "pres-1",
+    position: 0,
+    content: { version: "1.0", objects },
+    createdAt: "x",
+    updatedAt: "x",
+  });
+  doc.transact(() => slides.push([map]));
+  return slides.get(0);
+}
+
+function objectsArray(slide: YSlideMap): Y.Array<YObjectMap> {
+  return slide.get("objects") as Y.Array<YObjectMap>;
+}
+
+describe("ObjectBinding: Fabric -> Yjs", () => {
+  let doc: Y.Doc;
+  let canvas: FakeCanvas;
+  let binding: ObjectBinding;
+  let objects: Y.Array<YObjectMap>;
+
+  beforeEach(() => {
+    doc = new Y.Doc();
+    const slide = seedSlide(doc);
+    objects = objectsArray(slide);
+    canvas = new FakeCanvas();
+    binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+  });
+
+  it("writes a new object into the doc on add", () => {
+    canvas.userAdd({ id: "a", type: "rect", left: 5 });
+    expect(objects.length).toBe(1);
+    expect(objects.get(0).get("id")).toBe("a");
+    expect(objects.get(0).get("left")).toBe(5);
+  });
+
+  it("patches changed props into the object's Y.Map on modify", () => {
+    canvas.userAdd({ id: "a", type: "rect", left: 5 });
+    canvas.userModify("a", { left: 99 });
+    expect(objects.get(0).get("left")).toBe(99);
+    expect(objects.length).toBe(1);
+  });
+
+  it("deletes the object's Y.Map on remove", () => {
+    canvas.userAdd({ id: "a", type: "rect" });
+    canvas.userRemove("a");
+    expect(objects.length).toBe(0);
+  });
+
+  it("tags Fabric-originated writes with LOCAL_ORIGIN", () => {
+    const origins: unknown[] = [];
+    doc.on("afterTransaction", (txn) => origins.push(txn.origin));
+    canvas.userAdd({ id: "a", type: "rect" });
+    expect(origins).toContain(LOCAL_ORIGIN);
+  });
+});
+
+describe("ObjectBinding: Yjs -> Fabric", () => {
+  it("reconciles a remote property patch onto the canvas", () => {
+    const doc = new Y.Doc();
+    const slide = seedSlide(doc, [{ id: "a", type: "rect", left: 0 }]);
+    const objects = objectsArray(slide);
+    const canvas = new FakeCanvas();
+    const binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+
+    binding.reconcileToCanvas();
+    expect(canvas.objects.map((o) => o.id)).toEqual(["a"]);
+
+    doc.transact(() => objects.get(0).set("left", 42));
+    expect(canvas.objects[0].left).toBe(42);
+  });
+
+  it("applies a remote object insert onto the canvas", () => {
+    const doc = new Y.Doc();
+    const slide = seedSlide(doc, []);
+    const objects = objectsArray(slide);
+    const canvas = new FakeCanvas();
+    const binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+
+    doc.transact(() => {
+      const m = new Y.Map<unknown>();
+      m.set("id", "b");
+      m.set("type", "circle");
+      objects.push([m]);
+    });
+    expect(canvas.objects.map((o) => o.id)).toEqual(["b"]);
+  });
+
+  it("removes a canvas object when its Y.Map is deleted remotely", () => {
+    const doc = new Y.Doc();
+    const slide = seedSlide(doc, [{ id: "a", type: "rect" }]);
+    const objects = objectsArray(slide);
+    const canvas = new FakeCanvas();
+    const binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+    binding.reconcileToCanvas();
+    expect(canvas.objects).toHaveLength(1);
+
+    doc.transact(() => objects.delete(0, 1));
+    expect(canvas.objects).toHaveLength(0);
+  });
+});
+
+describe("ObjectBinding: loop prevention", () => {
+  it("does not write back to the doc while applying a remote change", () => {
+    const doc = new Y.Doc();
+    const slide = seedSlide(doc, []);
+    const objects = objectsArray(slide);
+    const canvas = new FakeCanvas();
+    const binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+
+    let txnCount = 0;
+    doc.on("afterTransaction", (txn) => {
+      if (txn.origin === LOCAL_ORIGIN) txnCount++;
+    });
+
+    // A purely remote insert: addObject() will route back through onObjectAdded,
+    // which must bail because applyingRemote is set -> zero LOCAL_ORIGIN txns.
+    doc.transact(() => {
+      const m = new Y.Map<unknown>();
+      m.set("id", "b");
+      objects.push([m]);
+    });
+
+    expect(canvas.objects.map((o) => o.id)).toEqual(["b"]);
+    expect(txnCount).toBe(0);
+    expect(objects.length).toBe(1); // not duplicated by a write-back
+  });
+
+  it("a local add does not re-trigger reconcile (origin guard)", () => {
+    const doc = new Y.Doc();
+    const slide = seedSlide(doc, []);
+    const objects = objectsArray(slide);
+    const canvas = new FakeCanvas();
+    const binding = new ObjectBinding(doc, objects, canvas);
+    canvas.binding = binding;
+    binding.observe();
+
+    const spy = vi.spyOn(binding, "reconcileToCanvas");
+    canvas.userAdd({ id: "a", type: "rect" });
+    expect(spy).not.toHaveBeenCalled();
+    expect(objects.length).toBe(1);
+  });
+});
+
+describe("ObjectBinding: two-peer convergence", () => {
+  it("converges two docs editing the same slide via applyUpdate round-trips", () => {
+    const docA = new Y.Doc();
+    const slideA = seedSlide(docA, [{ id: "a", type: "rect", left: 0 }]);
+    const objA = objectsArray(slideA);
+    const canvasA = new FakeCanvas();
+    const bindingA = new ObjectBinding(docA, objA, canvasA);
+    canvasA.binding = bindingA;
+    bindingA.observe();
+    bindingA.reconcileToCanvas();
+
+    // Peer B starts from A's full state (the "join the room" handshake).
+    const docB = new Y.Doc();
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA));
+    const slideB = getSlides(docB).get(0);
+    const objB = objectsArray(slideB);
+    const canvasB = new FakeCanvas();
+    const bindingB = new ObjectBinding(docB, objB, canvasB);
+    canvasB.binding = bindingB;
+    bindingB.observe();
+    bindingB.reconcileToCanvas();
+
+    // Relay every A update to B and vice-versa.
+    docA.on("update", (u) => Y.applyUpdate(docB, u));
+    docB.on("update", (u) => Y.applyUpdate(docA, u));
+
+    // A moves the rect; B adds a circle — concurrent-ish edits.
+    canvasA.userModify("a", { left: 100 });
+    canvasB.userAdd({ id: "c", type: "circle", top: 7 });
+
+    // Both docs hold the same objects + props.
+    const asJSON = (arr: Y.Array<YObjectMap>) =>
+      arr.map((m) => m.toJSON()).sort((x, y) => String(x.id).localeCompare(String(y.id)));
+    expect(asJSON(objA)).toEqual(asJSON(objB));
+
+    // Both canvases converged too.
+    const ids = (c: FakeCanvas) => c.objects.map((o) => o.id).sort();
+    expect(ids(canvasA)).toEqual(["a", "c"]);
+    expect(ids(canvasB)).toEqual(["a", "c"]);
+    expect(canvasA.objects.find((o) => o.id === "a")!.left).toBe(100);
+    expect(canvasB.objects.find((o) => o.id === "a")!.left).toBe(100);
+  });
+});
+
+describe("SlideStructureBinding", () => {
+  function setup() {
+    const doc = new Y.Doc();
+    const slides = getSlides(doc);
+    const received: { id: string; position: number }[][] = [];
+    const binding = new SlideStructureBinding(doc, slides, {
+      setSlides: (list) =>
+        received.push(list.map((s) => ({ id: s.id, position: s.position }))),
+    });
+    binding.observe();
+    return { doc, slides, binding, received };
+  }
+
+  it("adds slides and assigns sequential positions", () => {
+    const { slides, binding } = setup();
+    binding.addSlide("s1", "p");
+    binding.addSlide("s2", "p");
+    expect(slides.map((s) => s.get("id"))).toEqual(["s1", "s2"]);
+    expect(slides.map((s) => s.get("position"))).toEqual([0, 1]);
+  });
+
+  it("removes a slide and renumbers", () => {
+    const { slides, binding } = setup();
+    binding.addSlide("s1", "p");
+    binding.addSlide("s2", "p");
+    binding.addSlide("s3", "p");
+    binding.removeSlide("s2");
+    expect(slides.map((s) => s.get("id"))).toEqual(["s1", "s3"]);
+    expect(slides.map((s) => s.get("position"))).toEqual([0, 1]);
+  });
+
+  it("reorders a slide and renumbers, preserving objects", () => {
+    const { doc, slides, binding } = setup();
+    binding.addSlide("s1", "p");
+    binding.addSlide("s2", "p");
+    doc.transact(() => {
+      const objs = slides.get(0).get("objects") as Y.Array<YObjectMap>;
+      const m = new Y.Map<unknown>();
+      m.set("id", "obj-x");
+      objs.push([m]);
+    });
+    binding.moveSlide("s1", 1);
+    expect(slides.map((s) => s.get("id"))).toEqual(["s2", "s1"]);
+    expect(slides.map((s) => s.get("position"))).toEqual([0, 1]);
+    const movedObjs = slides.get(1).get("objects") as Y.Array<YObjectMap>;
+    expect(movedObjs.get(0).get("id")).toBe("obj-x");
+  });
+
+  it("pushes remote structural changes to the target list", () => {
+    const { doc, slides, received } = setup();
+    // Remote insert (not LOCAL_ORIGIN) should reach the target.
+    doc.transact(() => {
+      const m = new Y.Map<unknown>();
+      m.set("id", "remote-1");
+      m.set("position", 0);
+      m.set("objects", new Y.Array());
+      slides.push([m]);
+    });
+    expect(received.at(-1)).toEqual([{ id: "remote-1", position: 0 }]);
+  });
+
+  it("does not echo local structural ops back to the target", () => {
+    const { binding, received } = setup();
+    binding.addSlide("s1", "p"); // LOCAL_ORIGIN — observer must ignore it
+    expect(received).toHaveLength(0);
+  });
+});

--- a/web/src/lib/collab/binding.ts
+++ b/web/src/lib/collab/binding.ts
@@ -1,0 +1,312 @@
+import * as Y from "yjs";
+import {
+  SLIDE_FIELDS,
+  objectToYMap,
+  type YObjectMap,
+  type YSlideMap,
+} from "./schema";
+
+/**
+ * Two-way binding between a Fabric canvas and the shared Yjs doc (ADR-0011).
+ *
+ * The Yjs doc is the source of truth; this module keeps a single slide's Fabric
+ * canvas and the slide-list structure in sync with it, in both directions, and
+ * — crucially — without looping.
+ *
+ * Loop prevention has two independent guards:
+ *
+ *  1. `LOCAL_ORIGIN` transaction tag. Every Fabric -> Yjs write runs inside
+ *     `doc.transact(fn, LOCAL_ORIGIN)`. The Yjs observer ignores transactions
+ *     whose origin is `LOCAL_ORIGIN`, so our own writes never bounce back into
+ *     Fabric.
+ *  2. `applyingRemote` re-entrancy flag. While a remote Yjs change is being
+ *     applied to the canvas, the canvas fires its own object:added/modified/
+ *     removed events; the Fabric -> Yjs path checks this flag and bails, so a
+ *     remote edit never gets written back to Yjs.
+ *
+ * Editing conflicts are left to Yjs' CRDT (commutative, idempotent merges).
+ *
+ * Fabric is abstracted behind the minimal {@link CanvasLike} interface so the
+ * binding is exercised in unit tests without a real WebGL/canvas2d context, and
+ * so the wiring in the editor hook stays a thin adapter.
+ */
+
+/** Transaction origin tag marking Yjs writes that originated locally (Fabric). */
+export const LOCAL_ORIGIN = Symbol("presentsai:fabric");
+
+/** Plain serialized fabric object (always carries a stable `id`). */
+export type ObjectJSON = Record<string, unknown> & { id: string };
+
+/** The slice of the Fabric Canvas API the binding depends on. */
+export interface CanvasLike {
+  /** All objects currently on the canvas, in z-order. */
+  getObjects(): ObjectJSON[];
+  /** Serialize one object to the same plain shape stored in Yjs. */
+  toObject(obj: ObjectJSON): ObjectJSON;
+  /** Construct + add a fabric object from a plain record. */
+  addObject(json: ObjectJSON): void | Promise<void>;
+  /** Remove the object carrying this stable id, if present. */
+  removeObject(id: string): void;
+  /** Apply a property patch to the object with this id, if present. */
+  updateObject(id: string, patch: Record<string, unknown>): void;
+  /** Request a repaint after a batch of remote changes. */
+  requestRender(): void;
+}
+
+function objectId(o: ObjectJSON): string {
+  return o.id;
+}
+
+/**
+ * Binds one slide's `objects` Y.Array<Y.Map> to a Fabric canvas, both ways.
+ *
+ * Lifecycle: construct, then call {@link reconcileToCanvas} once to seed the
+ * canvas from the doc; thereafter feed Fabric events through the `onObject*`
+ * methods and let {@link observe} push remote changes back to the canvas.
+ */
+export class ObjectBinding {
+  private applyingRemote = false;
+  private readonly observer: (events: Y.YEvent<Y.Map<unknown>>[], txn: Y.Transaction) => void;
+
+  constructor(
+    private readonly doc: Y.Doc,
+    private readonly objects: Y.Array<YObjectMap>,
+    private readonly canvas: CanvasLike,
+  ) {
+    this.observer = (_events, txn) => {
+      // Skip our own writes (origin guard #1) — they are already on the canvas.
+      if (txn.origin === LOCAL_ORIGIN) return;
+      this.reconcileToCanvas();
+    };
+  }
+
+  /** Start listening for remote (non-local) changes to this slide's objects. */
+  observe(): void {
+    this.objects.observeDeep(this.observer);
+  }
+
+  /** Stop listening. Safe to call multiple times. */
+  unobserve(): void {
+    this.objects.unobserveDeep(this.observer);
+  }
+
+  /** True while a remote Yjs change is being applied to the canvas. */
+  get isApplyingRemote(): boolean {
+    return this.applyingRemote;
+  }
+
+  private indexOfId(id: string): number {
+    for (let i = 0; i < this.objects.length; i++) {
+      if (this.objects.get(i).get("id") === id) return i;
+    }
+    return -1;
+  }
+
+  // ---- Fabric -> Yjs ------------------------------------------------------
+
+  /** Mirror a freshly added fabric object into the doc (unless remote-applying). */
+  onObjectAdded(obj: ObjectJSON): void {
+    if (this.applyingRemote) return;
+    const json = this.canvas.toObject(obj);
+    const id = objectId(json);
+    this.doc.transact(() => {
+      if (this.indexOfId(id) === -1) this.objects.push([objectToYMap(json)]);
+    }, LOCAL_ORIGIN);
+  }
+
+  /** Mirror a modified fabric object's properties into its Y.Map. */
+  onObjectModified(obj: ObjectJSON): void {
+    if (this.applyingRemote) return;
+    const json = this.canvas.toObject(obj);
+    const id = objectId(json);
+    this.doc.transact(() => {
+      const idx = this.indexOfId(id);
+      if (idx === -1) {
+        this.objects.push([objectToYMap(json)]);
+        return;
+      }
+      const map = this.objects.get(idx);
+      for (const [k, v] of Object.entries(json)) {
+        if (map.get(k) !== v) map.set(k, v);
+      }
+    }, LOCAL_ORIGIN);
+  }
+
+  /** Remove the object's Y.Map from the doc. */
+  onObjectRemoved(obj: ObjectJSON): void {
+    if (this.applyingRemote) return;
+    const id = objectId(obj);
+    this.doc.transact(() => {
+      const idx = this.indexOfId(id);
+      if (idx !== -1) this.objects.delete(idx, 1);
+    }, LOCAL_ORIGIN);
+  }
+
+  // ---- Yjs -> Fabric ------------------------------------------------------
+
+  /**
+   * Make the canvas match the doc: add missing objects, drop extra ones, and
+   * patch changed properties. Runs with the re-entrancy guard set so the
+   * canvas' own mutation events do not write back to the doc (guard #2).
+   */
+  reconcileToCanvas(): void {
+    this.applyingRemote = true;
+    try {
+      const docObjects = this.objects.map((m) => m.toJSON() as ObjectJSON);
+      const docIds = new Set(docObjects.map(objectId));
+      const canvasById = new Map(this.canvas.getObjects().map((o) => [objectId(o), o]));
+
+      // Remove canvas objects no longer in the doc.
+      for (const id of canvasById.keys()) {
+        if (!docIds.has(id)) this.canvas.removeObject(id);
+      }
+      // Add or patch from the doc.
+      for (const json of docObjects) {
+        const id = objectId(json);
+        if (canvasById.has(id)) {
+          this.canvas.updateObject(id, json);
+        } else {
+          void this.canvas.addObject(json);
+        }
+      }
+      this.canvas.requestRender();
+    } finally {
+      this.applyingRemote = false;
+    }
+  }
+}
+
+// ---- Slide-list structure binding -----------------------------------------
+
+/** Minimal view of the slide list this binding mutates / reads from. */
+export interface SlideListLike {
+  /** Replace the materialized slide list (positions are taken from the doc). */
+  setSlides(slides: { id: string; content: unknown; position: number }[]): void;
+}
+
+/**
+ * Builds a Y.Map for a slide skeleton (no objects yet) used when adding slides
+ * collaboratively. Object content syncs through {@link ObjectBinding}.
+ */
+export function slideSkeletonYMap(
+  id: string,
+  presentationId: string,
+  position: number,
+): YSlideMap {
+  const map = new Y.Map<unknown>();
+  map.set(SLIDE_FIELDS.id, id);
+  map.set(SLIDE_FIELDS.presentationId, presentationId);
+  map.set(SLIDE_FIELDS.position, position);
+  map.set(SLIDE_FIELDS.version, "1.0");
+  map.set(SLIDE_FIELDS.objects, new Y.Array<YObjectMap>());
+  return map;
+}
+
+/**
+ * Binds the slide list (add / delete / reorder) to the root slides Y.Array.
+ * Structural ops run under {@link LOCAL_ORIGIN}; remote structural changes are
+ * pushed to the supplied {@link SlideListLike}.
+ */
+export class SlideStructureBinding {
+  private readonly observer: (event: Y.YArrayEvent<YSlideMap>, txn: Y.Transaction) => void;
+
+  constructor(
+    private readonly doc: Y.Doc,
+    private readonly slides: Y.Array<YSlideMap>,
+    private readonly target: SlideListLike,
+  ) {
+    this.observer = (_event, txn) => {
+      if (txn.origin === LOCAL_ORIGIN) return;
+      this.pushToTarget();
+    };
+  }
+
+  observe(): void {
+    this.slides.observe(this.observer);
+  }
+
+  unobserve(): void {
+    this.slides.unobserve(this.observer);
+  }
+
+  private indexOfId(id: string): number {
+    for (let i = 0; i < this.slides.length; i++) {
+      if (this.slides.get(i).get("id") === id) return i;
+    }
+    return -1;
+  }
+
+  /** Local: insert a new slide skeleton at `position` (defaults to the end). */
+  addSlide(id: string, presentationId: string, position?: number): void {
+    this.doc.transact(() => {
+      const pos = position ?? this.slides.length;
+      this.slides.insert(pos, [slideSkeletonYMap(id, presentationId, pos)]);
+      this.renumber();
+    }, LOCAL_ORIGIN);
+  }
+
+  /** Local: remove the slide with this id. */
+  removeSlide(id: string): void {
+    this.doc.transact(() => {
+      const idx = this.indexOfId(id);
+      if (idx === -1) return;
+      this.slides.delete(idx, 1);
+      this.renumber();
+    }, LOCAL_ORIGIN);
+  }
+
+  /** Local: move the slide with this id to `toIndex`. */
+  moveSlide(id: string, toIndex: number): void {
+    this.doc.transact(() => {
+      const from = this.indexOfId(id);
+      if (from === -1 || from === toIndex) return;
+      const map = this.slides.get(from);
+      // Detach + clone, since a Y type instance cannot live in two places.
+      const clone = cloneSlideMap(map);
+      this.slides.delete(from, 1);
+      const dest = Math.max(0, Math.min(toIndex, this.slides.length));
+      this.slides.insert(dest, [clone]);
+      this.renumber();
+    }, LOCAL_ORIGIN);
+  }
+
+  /** Re-derive each slide's `position` from its array index. Caller transacts. */
+  private renumber(): void {
+    for (let i = 0; i < this.slides.length; i++) {
+      const m = this.slides.get(i);
+      if (m.get(SLIDE_FIELDS.position) !== i) m.set(SLIDE_FIELDS.position, i);
+    }
+  }
+
+  /** Project the doc's slide order/content into the materialized target. */
+  pushToTarget(): void {
+    const list = this.slides.map((m, i) => ({
+      id: m.get(SLIDE_FIELDS.id) as string,
+      position: (m.get(SLIDE_FIELDS.position) as number | undefined) ?? i,
+      content: {
+        version: (m.get(SLIDE_FIELDS.version) as string | undefined) ?? "1.0",
+        background: m.get(SLIDE_FIELDS.background),
+        objects:
+          (m.get(SLIDE_FIELDS.objects) as Y.Array<YObjectMap> | undefined)?.map(
+            (o) => o.toJSON(),
+          ) ?? [],
+      },
+    }));
+    this.target.setSlides(list);
+  }
+}
+
+/** Deep-clone a slide Y.Map (used when reordering, which requires detach). */
+function cloneSlideMap(map: YSlideMap): YSlideMap {
+  const next = new Y.Map<unknown>();
+  map.forEach((value, key) => {
+    if (value instanceof Y.Array) {
+      const arr = new Y.Array<YObjectMap>();
+      arr.push(value.map((o) => objectToYMap((o as YObjectMap).toJSON())));
+      next.set(key, arr);
+    } else {
+      next.set(key, value);
+    }
+  });
+  return next;
+}


### PR DESCRIPTION
## 概要

共同編集の中核となる **Fabric.js ↔ Yjs 双方向バインディングのコア**を実装する。
Yjs doc を真実源とし(ADR-0011)、1スライドの `objects` Y.Array と Fabric canvas を
双方向同期させる `ObjectBinding`、スライド構造(追加/削除/並べ替え)を同期する
`SlideStructureBinding` を追加。

本PRは**フレームワーク非依存のコア + 単体テスト**のみ。実 canvas への配線は PR3b で行う。

## 無限ループ防止(本PRの最重要点)

2つの独立したガードで安全性を担保:

1. **`LOCAL_ORIGIN` トランザクションタグ** — Fabric→Yjs の書き込みはすべて
   `doc.transact(fn, LOCAL_ORIGIN)` で実行。observer は `txn.origin === LOCAL_ORIGIN`
   の変更を無視し、自分由来の変更を Fabric へ再適用しない。
2. **`applyingRemote` 再入ガード** — リモート変更を canvas へ適用中は、canvas が
   発火する mutation イベントを Yjs へ書き戻さない。

編集競合は Yjs CRDT(可換・冪等)に委ねる。

## 設計

- Fabric を最小インターフェース `CanvasLike` 越しに扱い、実 WebGL/canvas2d なしで
  単体テスト可能。実 canvas との接続は薄いアダプタ(PR3b)に隔離。
- オブジェクト対応付けは既存の安定 custom `id`(lib/fabric/objectId)を使用。

## テスト

`web/src/lib/collab/binding.test.ts`(15件):
- Fabric→Yjs: 追加/変更(差分パッチ)/削除、LOCAL_ORIGIN タグ付与
- Yjs→Fabric: リモート挿入/削除/プロパティパッチの reconcile
- ループ防止: リモート適用中に書き戻さない / ローカル変更が reconcile を再トリガしない
- **2 Y.Doc 間の `applyUpdate` 往復で収束**(2クライアント相当: A が移動・B が追加 → 両doc/両canvasが一致)
- SlideStructureBinding: 追加/削除/並べ替え(positionリナンバ・objects保持)、リモート構造変更の投影

## 検証

- `npm run build`: green
- `npx tsc --noEmit`: green
- `npx vitest run`: 106 passed(既存91 + 新規15)
- `eslint`: clean
- Go collab サービス: 変更なし、build/test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)