### PR TITLE
共同編集(PR3b): バインディングを実エディタに配線しライブ同期を実現

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -6,6 +6,9 @@ import { ChevronLeft, Presentation, Bot, Mic } from "lucide-react";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { useEditorStore } from "@features/editor/stores/editorStore";
 import { useSlideStore } from "@features/editor/stores/slideStore";
+import { useCollaboration } from "@features/editor/hooks/useCollaboration";
+import { useObjectBinding } from "@features/editor/hooks/useObjectBinding";
+import { getSlides, initializeDoc } from "@lib/collab/schema";
 import { slidesApi } from "@shared/api/slides";
 import { presentationsApi } from "@shared/api/presentations";
 import { ShareButton } from "@features/dashboard/components/ShareButton";
@@ -29,10 +32,14 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { id } = use(params);
   const router = useRouter();
   const { accessToken } = useAuthStore();
-  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode } = useEditorStore();
+  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas } = useEditorStore();
   const { setSlides, slides } = useSlideStore();
   const [aiTab, setAiTab] = useState<AITab>(null);
   const [title, setTitle] = useState("Untitled");
+
+  // Open the collaboration room and bind the active slide's canvas to it.
+  const { doc } = useCollaboration(id ?? null);
+  useObjectBinding(doc, canvas, activeSlideId);
 
   useEffect(() => {
     if (!accessToken || !id) return;
@@ -41,9 +48,15 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
       const slideList = res.items as Slide[];
       setSlides(slideList);
       if (slideList.length > 0) setActiveSlide(slideList[0].id);
+      // Seed the shared doc on first join: if the room is still empty after the
+      // initial sync, this client publishes the loaded slides as the baseline.
+      // Subsequent joiners receive it over the wire and skip seeding.
+      if (doc && getSlides(doc).length === 0 && slideList.length > 0) {
+        initializeDoc(doc, slideList);
+      }
     });
     presentationsApi.get(accessToken, id).then(p => setTitle(p.title));
-  }, [id, accessToken, setPresentationId, setSlides, setActiveSlide]);
+  }, [id, accessToken, doc, setPresentationId, setSlides, setActiveSlide]);
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-surface-subtle">

--- a/web/src/features/editor/hooks/useCollaboration.ts
+++ b/web/src/features/editor/hooks/useCollaboration.ts
@@ -1,28 +1,32 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
+import * as Y from "yjs";
 import { CollabProvider } from "@lib/collab/provider";
 
 /**
- * Minimal collaboration wiring for PR1: opens a y-websocket room for the given
- * presentation and holds a reference to the shared Yjs doc. Fabric two-way
- * binding (PR3) and awareness (PR5) are intentionally not wired up yet.
+ * Opens a y-websocket room for the given presentation and exposes the shared
+ * Yjs doc reactively, so callers (the Fabric two-way binding, PR3) can bind to
+ * it once it exists. Awareness (PR5) is still out of scope.
  *
- * @returns the live {@link CollabProvider} (or null before connect), so callers
- *          can reach the shared doc / slide array.
+ * @returns the live {@link CollabProvider} and its shared {@link Y.Doc} (both
+ *          null before connect), kept in state so consumers re-render on connect.
  */
 export function useCollaboration(presentationId: string | null) {
-  const providerRef = useRef<CollabProvider | null>(null);
+  const [provider, setProvider] = useState<CollabProvider | null>(null);
+  const [doc, setDoc] = useState<Y.Doc | null>(null);
 
   useEffect(() => {
     if (!presentationId) return;
-    const provider = new CollabProvider(presentationId);
-    provider.connect();
-    providerRef.current = provider;
+    const p = new CollabProvider(presentationId);
+    p.connect();
+    setProvider(p);
+    setDoc(p.doc);
     return () => {
-      provider.destroy();
-      providerRef.current = null;
+      p.destroy();
+      setProvider(null);
+      setDoc(null);
     };
   }, [presentationId]);
 
-  return { provider: providerRef.current };
+  return { provider, doc };
 }

--- a/web/src/features/editor/hooks/useObjectBinding.ts
+++ b/web/src/features/editor/hooks/useObjectBinding.ts
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect } from "react";
+import type { Canvas, FabricObject } from "fabric";
+import * as Y from "yjs";
+import { getSlides, SLIDE_FIELDS, type YObjectMap } from "@lib/collab/schema";
+import { ObjectBinding, type ObjectJSON } from "@lib/collab/binding";
+import { FabricCanvasAdapter } from "@lib/collab/fabricAdapter";
+
+/**
+ * Wires the active slide's Fabric canvas to its `objects` Y.Array, both ways.
+ *
+ * Rebuilds the binding whenever the canvas, doc, or active slide changes. Fabric
+ * mutation events are routed to the binding (Fabric -> Yjs); the binding's own
+ * observer pushes remote edits onto the canvas (Yjs -> Fabric). Loop prevention
+ * is handled inside {@link ObjectBinding} (origin tag + re-entrancy guard).
+ */
+export function useObjectBinding(
+  doc: Y.Doc | null,
+  canvas: Canvas | null,
+  activeSlideId: string | null,
+) {
+  useEffect(() => {
+    if (!doc || !canvas || !activeSlideId) return;
+
+    const slides = getSlides(doc);
+    const idx = slides.toArray().findIndex((s) => s.get(SLIDE_FIELDS.id) === activeSlideId);
+    if (idx === -1) return;
+    const objects = slides.get(idx).get(SLIDE_FIELDS.objects) as
+      | Y.Array<YObjectMap>
+      | undefined;
+    if (!objects) return;
+
+    const adapter = new FabricCanvasAdapter(canvas);
+    const binding = new ObjectBinding(doc, objects, adapter);
+    binding.observe();
+    // Seed the canvas from whatever the doc already holds for this slide.
+    binding.reconcileToCanvas();
+
+    const onAdded = (e: { target?: FabricObject }) =>
+      e.target && binding.onObjectAdded(adapter.toObject(e.target as unknown as ObjectJSON));
+    const onModified = (e: { target?: FabricObject }) =>
+      e.target && binding.onObjectModified(adapter.toObject(e.target as unknown as ObjectJSON));
+    const onRemoved = (e: { target?: FabricObject }) => {
+      const id = (e.target as (FabricObject & { id?: string }) | undefined)?.id;
+      if (id) binding.onObjectRemoved({ id });
+    };
+
+    canvas.on("object:added", onAdded);
+    canvas.on("object:modified", onModified);
+    canvas.on("object:removed", onRemoved);
+
+    return () => {
+      canvas.off("object:added", onAdded);
+      canvas.off("object:modified", onModified);
+      canvas.off("object:removed", onRemoved);
+      binding.unobserve();
+    };
+  }, [doc, canvas, activeSlideId]);
+}

--- a/web/src/lib/collab/fabricAdapter.ts
+++ b/web/src/lib/collab/fabricAdapter.ts
@@ -1,0 +1,64 @@
+import { Canvas, FabricObject, util } from "fabric";
+import { ensureObjectId, CUSTOM_OBJECT_PROPERTIES } from "@lib/fabric/objectId";
+import type { CanvasLike, ObjectJSON } from "./binding";
+
+/**
+ * Adapts a real Fabric {@link Canvas} to the framework-agnostic
+ * {@link CanvasLike} interface that {@link ObjectBinding} drives.
+ *
+ * Kept deliberately thin: it serializes/enlivens objects and looks them up by
+ * the stable custom `id` (see lib/fabric/objectId). All loop-prevention lives
+ * in the binding; this adapter is pure plumbing.
+ */
+export class FabricCanvasAdapter implements CanvasLike {
+  constructor(private readonly canvas: Canvas) {}
+
+  private withId(o: FabricObject): ObjectJSON {
+    const id = ensureObjectId(o);
+    return Object.assign(o.toObject([...CUSTOM_OBJECT_PROPERTIES]), { id }) as ObjectJSON;
+  }
+
+  private find(id: string): FabricObject | undefined {
+    return this.canvas
+      .getObjects()
+      .find((o) => (o as FabricObject & { id?: string }).id === id);
+  }
+
+  getObjects(): ObjectJSON[] {
+    return this.canvas.getObjects().map((o) => this.withId(o));
+  }
+
+  toObject(obj: ObjectJSON): ObjectJSON {
+    // `obj` here is the live FabricObject passed through from a canvas event.
+    return this.withId(obj as unknown as FabricObject);
+  }
+
+  async addObject(json: ObjectJSON): Promise<void> {
+    if (this.find(json.id)) return;
+    const [obj] = await util.enlivenObjects<FabricObject>([json]);
+    if (!obj) return;
+    (obj as FabricObject & { id?: string }).id = json.id;
+    obj.set?.("id", json.id);
+    this.canvas.add(obj);
+  }
+
+  removeObject(id: string): void {
+    const obj = this.find(id);
+    if (obj) this.canvas.remove(obj);
+  }
+
+  updateObject(id: string, patch: Record<string, unknown>): void {
+    const obj = this.find(id);
+    if (!obj) return;
+    // Geometry/style props only; `type`/`id` are immutable identity.
+    const { type: _t, id: _i, ...rest } = patch;
+    void _t;
+    void _i;
+    obj.set(rest);
+    obj.setCoords();
+  }
+
+  requestRender(): void {
+    this.canvas.requestRenderAll();
+  }
+}


### PR DESCRIPTION
## 概要

PR3a(#102)のコアバインディングを **実 Fabric canvas とエディタに接続**し、
2クライアントが同じデッキを同時編集 → ライブ同期できる状態を成立させる。

> ベースは #102。#102 がマージされたら本PRのベースを main に切り替える。

## 変更点

- **`FabricCanvasAdapter`** — 実 `fabric.Canvas` を `CanvasLike` に適合させる薄いアダプタ。
  `util.enlivenObjects` で JSON→オブジェクト復元、安定 `id` で検索。
  ループ防止ロジックは持たず純粋な配線に徹する(ガードはすべて PR3a のコア側)。
- **`useObjectBinding`** — アクティブスライドの canvas を `objects` Y.Array に双方向接続する
  フック。canvas の `object:added/modified/removed` を binding へ流し、binding の observer が
  リモート編集を canvas へ反映。canvas/doc/active slide の変化でバインディングを張り直す。
- **`useCollaboration`** — doc を state で reactive に公開(接続時に consumer が再レンダ)。
- **editor page** — ルーム接続・active slide のバインド・初回 join 時の doc シードを配線。
  ルームが空なら最初の参加者が読み込んだスライドをベースラインとして publish、以降の参加者は
  ワイヤ越しに受信してシードをスキップ。

## ライブ同期の成立

PR3a のコアテストで「2 Y.Doc 間の applyUpdate 往復収束」を検証済み。本PRはその往復を
y-websocket(PR2 のリレーサーバ)経由の実 canvas に接続するもの。

## 検証

- `npm run build`: green
- `npx tsc --noEmit`: green
- `eslint`(変更ファイル): clean
- 既存テスト破壊なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)