### PR TITLE
共同編集(PR4a): collabサーバの Yjs update を永続化し再起動・再接続で復元

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,8 +39,12 @@ services:
       dockerfile: Dockerfile
     environment:
       PORT: "8081"
+      DATABASE_URL: postgres://presentsai:presentsai@postgres:5432/presentsai?sslmode=disable
     ports:
       - "8081:8081"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   realtime:
     build:

--- a/services/collab/cmd/collab/main.go
+++ b/services/collab/cmd/collab/main.go
@@ -3,7 +3,9 @@
 // It speaks the y-protocol message framing (sync / awareness) and relays
 // opaque Yjs updates between clients in the same room. It does NOT interpret
 // CRDT contents; the authoritative merge happens in each client's Yjs doc
-// (ADR-0010/0011). Persistence is currently in-memory only (PR4 adds Postgres).
+// (ADR-0010/0011). The opaque update log is persisted via internal/store
+// (PostgreSQL when DATABASE_URL is set, else in-memory), so room state survives
+// restarts and the server re-seeds every newcomer (single-seed model).
 //
 // y-websocket connects to `ws://host:port/{roomname}`, so the room id is the
 // URL path segment.
@@ -20,6 +22,7 @@ import (
 	"github.com/joho/godotenv"
 
 	"github.com/ko-tarou/presentsai/services/collab/internal/hub"
+	"github.com/ko-tarou/presentsai/services/collab/internal/store"
 )
 
 var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
@@ -100,9 +103,26 @@ func makeHandler(h *hub.Hub) http.HandlerFunc {
 	}
 }
 
+// newStore picks the persistence backend: Postgres when DATABASE_URL is set,
+// otherwise an in-memory store (no durability). A Postgres failure is fatal so
+// misconfiguration is loud rather than silently losing collaborative state.
+func newStore() store.Store {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		log.Printf("collab: DATABASE_URL unset, using in-memory store (no persistence)")
+		return store.NewMemStore()
+	}
+	pg, err := store.NewPostgresStore(dsn)
+	if err != nil {
+		log.Fatalf("collab: postgres store init failed: %v", err)
+	}
+	log.Printf("collab: using PostgreSQL persistence")
+	return pg
+}
+
 func main() {
 	godotenv.Load()
-	h := hub.New()
+	h := hub.New(newStore())
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/services/collab/cmd/collab/main_test.go
+++ b/services/collab/cmd/collab/main_test.go
@@ -57,7 +57,7 @@ func readBinary(t *testing.T, c *websocket.Conn) []byte {
 // TestE2ESyncStep1OverWebsocket: a client connecting to a populated room over a
 // real websocket receives the snapshot replay followed by the server SyncStep1.
 func TestE2ESyncStep1OverWebsocket(t *testing.T) {
-	h := hub.New()
+	h := hub.New(nil)
 	srv := httptest.NewServer(makeHandler(h))
 	defer srv.Close()
 
@@ -98,7 +98,7 @@ func TestE2ESyncStep1OverWebsocket(t *testing.T) {
 // TestE2EBroadcastBetweenTwoClients: an update from one client is relayed to a
 // second client in the same room over real websockets.
 func TestE2EBroadcastBetweenTwoClients(t *testing.T) {
-	h := hub.New()
+	h := hub.New(nil)
 	srv := httptest.NewServer(makeHandler(h))
 	defer srv.Close()
 
@@ -120,7 +120,7 @@ func TestE2EBroadcastBetweenTwoClients(t *testing.T) {
 
 // TestE2EHealth: the /health endpoint stays a plain JSON probe, not a room.
 func TestE2EHealth(t *testing.T) {
-	h := hub.New()
+	h := hub.New(nil)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"status":"ok"}`))

--- a/services/collab/go.mod
+++ b/services/collab/go.mod
@@ -5,3 +5,5 @@ go 1.23.4
 require github.com/joho/godotenv v1.5.1
 
 require github.com/gorilla/websocket v1.5.3
+
+require github.com/lib/pq v1.10.9

--- a/services/collab/go.sum
+++ b/services/collab/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/services/collab/internal/hub/hub.go
+++ b/services/collab/internal/hub/hub.go
@@ -19,8 +19,10 @@
 package hub
 
 import (
+	"log"
 	"sync"
 
+	"github.com/ko-tarou/presentsai/services/collab/internal/store"
 	"github.com/ko-tarou/presentsai/services/collab/internal/yproto"
 )
 
@@ -37,34 +39,56 @@ type Client interface {
 // Room holds the connected clients and the accumulated opaque update log
 // for a single presentation.
 type Room struct {
+	id    string
+	store store.Store
+
 	mu      sync.RWMutex
 	clients map[Client]struct{}
-	// updates is the append-only log of opaque Yjs updates seen in this
-	// room. Order is not significant for correctness (Yjs merges are
-	// commutative & idempotent) but is preserved for determinism.
+	// updates is the in-memory cache of the room's opaque Yjs update log,
+	// hydrated from the Store on first use. Order is not significant for
+	// correctness (Yjs merges are commutative & idempotent) but is preserved
+	// for determinism and matches the persisted order.
 	updates [][]byte
 }
 
-func newRoom() *Room {
-	return &Room{clients: make(map[Client]struct{})}
+func newRoom(id string, s store.Store) *Room {
+	r := &Room{id: id, store: s, clients: make(map[Client]struct{})}
+	// Hydrate the in-memory log from durable storage so a freshly started
+	// server (or a room re-created after going idle) restores prior state and
+	// can re-seed newcomers. This makes the server — not the first client —
+	// the source of the baseline (ADR-0011 single-seed model).
+	if loaded, err := s.Load(id); err != nil {
+		log.Printf("collab: load room %q failed: %v", id, err)
+	} else {
+		r.updates = loaded
+	}
+	return r
 }
 
-// Hub manages all rooms.
+// Hub manages all rooms and owns the persistence backend.
 type Hub struct {
+	store store.Store
 	mu    sync.Mutex
 	rooms map[string]*Room
 }
 
-// New returns an empty Hub.
-func New() *Hub { return &Hub{rooms: make(map[string]*Room)} }
+// New returns a Hub backed by the given Store. A nil store falls back to an
+// in-memory store (no durability), which keeps existing tests/usage working.
+func New(s store.Store) *Hub {
+	if s == nil {
+		s = store.NewMemStore()
+	}
+	return &Hub{store: s, rooms: make(map[string]*Room)}
+}
 
-// Room returns the room with the given id, creating it on first use.
+// Room returns the room with the given id, creating (and restoring) it on
+// first use.
 func (h *Hub) Room(id string) *Room {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	r, ok := h.rooms[id]
 	if !ok {
-		r = newRoom()
+		r = newRoom(id, h.store)
 		h.rooms[id] = r
 	}
 	return r
@@ -154,6 +178,11 @@ func (r *Room) handleSync(sender Client, dec *yproto.Decoder, original []byte) {
 			return
 		}
 		stored := append([]byte(nil), update...) // copy: msg buffer is reused
+		// Persist first so a crash between cache + broadcast cannot leave a
+		// durable gap; broadcast/cache are best-effort relay on top.
+		if err := r.store.Append(r.id, stored); err != nil {
+			log.Printf("collab: persist update for room %q failed: %v", r.id, err)
+		}
 		r.mu.Lock()
 		r.updates = append(r.updates, stored)
 		r.mu.Unlock()

--- a/services/collab/internal/hub/hub_test.go
+++ b/services/collab/internal/hub/hub_test.go
@@ -39,7 +39,7 @@ const (
 // TestUpdateStoredAndBroadcast: an Update frame is appended to the room log and
 // relayed to the *other* client (not echoed back to the sender).
 func TestUpdateStoredAndBroadcast(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 	a := &fakeClient{id: "a"}
 	b := &fakeClient{id: "b"}
@@ -67,7 +67,7 @@ func TestUpdateStoredAndBroadcast(t *testing.T) {
 // TestSyncStep1ReplaysSnapshot: a newcomer sending SyncStep1 receives every
 // stored update followed by the server's own SyncStep1 (empty state vector).
 func TestSyncStep1ReplaysSnapshot(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 
 	// Seed the room with two stored updates via an existing client.
@@ -101,7 +101,7 @@ func TestSyncStep1ReplaysSnapshot(t *testing.T) {
 // TestSyncStep2Stored: a SyncStep2 (full-state reply) is stored and broadcast
 // just like an Update.
 func TestSyncStep2Stored(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 	a := &fakeClient{id: "a"}
 	b := &fakeClient{id: "b"}
@@ -126,7 +126,7 @@ func TestSyncStep2Stored(t *testing.T) {
 
 // TestAwarenessRelayedNotStored: awareness is relayed verbatim and not stored.
 func TestAwarenessRelayedNotStored(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 	a := &fakeClient{id: "a"}
 	b := &fakeClient{id: "b"}
@@ -149,7 +149,7 @@ func TestAwarenessRelayedNotStored(t *testing.T) {
 
 // TestRoomSeparation: updates in one room never leak into another.
 func TestRoomSeparation(t *testing.T) {
-	h := New()
+	h := New(nil)
 	r1 := h.Room("deck-1")
 	r2 := h.Room("deck-2")
 	a := &fakeClient{id: "a"} // in deck-1
@@ -175,7 +175,7 @@ func TestRoomSeparation(t *testing.T) {
 
 // TestLeaveStopsBroadcast: a client that left no longer receives broadcasts.
 func TestLeaveStopsBroadcast(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 	a := &fakeClient{id: "a"}
 	b := &fakeClient{id: "b"}
@@ -191,7 +191,7 @@ func TestLeaveStopsBroadcast(t *testing.T) {
 
 // TestMalformedIgnored: garbage frames are ignored without panicking or storing.
 func TestMalformedIgnored(t *testing.T) {
-	h := New()
+	h := New(nil)
 	room := h.Room("deck-1")
 	a := &fakeClient{id: "a"}
 	room.Join(a)

--- a/services/collab/internal/hub/persistence_test.go
+++ b/services/collab/internal/hub/persistence_test.go
@@ -1,0 +1,81 @@
+package hub
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/store"
+	"github.com/ko-tarou/presentsai/services/collab/internal/yproto"
+)
+
+// TestUpdatePersistedToStore: an inbound update is written through to the Store,
+// not just the in-memory cache.
+func TestUpdatePersistedToStore(t *testing.T) {
+	s := store.NewMemStore()
+	h := New(s)
+	room := h.Room("deck-1")
+	a := &fakeClient{id: "a"}
+	room.Join(a)
+
+	room.HandleMessage(a, hexMust(t, updateFrame))
+
+	loaded, err := s.Load("deck-1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 persisted update, got %d", len(loaded))
+	}
+	if !bytes.Equal(loaded[0], hexMust(t, rawUpdate)) {
+		t.Fatalf("persisted payload mismatch: got %x", loaded[0])
+	}
+}
+
+// TestRoomRestoredFromStore simulates a server restart: a Store already holds a
+// room's update log, a fresh Hub is created over it, and a newcomer joining the
+// room must receive the restored snapshot. This proves reload-resilience and
+// that the *server* (not the first client) re-seeds the baseline.
+func TestRoomRestoredFromStore(t *testing.T) {
+	s := store.NewMemStore()
+	// Pre-seed the durable log as if a previous server instance had stored it.
+	if err := s.Append("deck-1", hexMust(t, rawUpdate)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Append("deck-1", hexMust(t, rawUpdate)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh Hub over the same store == server restart.
+	h := New(s)
+	room := h.Room("deck-1")
+	if room.UpdateCount() != 2 {
+		t.Fatalf("room should restore 2 updates from store, got %d", room.UpdateCount())
+	}
+
+	// Newcomer joins and announces an empty state vector; expects replay.
+	join := &fakeClient{id: "join"}
+	room.Join(join)
+	room.HandleMessage(join, hexMust(t, syncStep1Empty))
+
+	if len(join.recv) != 3 { // 2 replayed updates + server SyncStep1
+		t.Fatalf("expected 3 frames (2 restored updates + SyncStep1), got %d", len(join.recv))
+	}
+	wantUpdate := yproto.EncodeSyncUpdate(hexMust(t, rawUpdate))
+	if !bytes.Equal(join.recv[0], wantUpdate) || !bytes.Equal(join.recv[1], wantUpdate) {
+		t.Fatalf("restored snapshot frames are not the stored updates")
+	}
+}
+
+// TestRoomsShareNoStateAcrossStore: distinct rooms restore independently.
+func TestRoomsShareNoStateAcrossStore(t *testing.T) {
+	s := store.NewMemStore()
+	_ = s.Append("deck-1", hexMust(t, rawUpdate))
+
+	h := New(s)
+	if got := h.Room("deck-1").UpdateCount(); got != 1 {
+		t.Fatalf("deck-1 should restore 1 update, got %d", got)
+	}
+	if got := h.Room("deck-2").UpdateCount(); got != 0 {
+		t.Fatalf("deck-2 should restore 0 updates, got %d", got)
+	}
+}

--- a/services/collab/internal/store/mem.go
+++ b/services/collab/internal/store/mem.go
@@ -1,0 +1,35 @@
+package store
+
+import "sync"
+
+// MemStore is an in-memory Store. It is the default persistence backend (used
+// when no database is configured) and the backend exercised by unit tests.
+// Data does not survive a process restart.
+type MemStore struct {
+	mu   sync.RWMutex
+	logs map[string][][]byte
+}
+
+// NewMemStore returns an empty in-memory store.
+func NewMemStore() *MemStore {
+	return &MemStore{logs: make(map[string][][]byte)}
+}
+
+// Load returns a copy of the room's update log in append order.
+func (s *MemStore) Load(room string) ([][]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	log := s.logs[room]
+	out := make([][]byte, len(log))
+	copy(out, log)
+	return out, nil
+}
+
+// Append copies and records one opaque update for the room.
+func (s *MemStore) Append(room string, payload []byte) error {
+	stored := append([]byte(nil), payload...)
+	s.mu.Lock()
+	s.logs[room] = append(s.logs[room], stored)
+	s.mu.Unlock()
+	return nil
+}

--- a/services/collab/internal/store/mem_test.go
+++ b/services/collab/internal/store/mem_test.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestMemStoreAppendLoadRoundtrip(t *testing.T) {
+	s := NewMemStore()
+	if err := s.Append("r1", []byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Append("r1", []byte("b")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Load("r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || !bytes.Equal(got[0], []byte("a")) || !bytes.Equal(got[1], []byte("b")) {
+		t.Fatalf("roundtrip mismatch: %q", got)
+	}
+}
+
+func TestMemStoreLoadUnknownRoomEmpty(t *testing.T) {
+	got, err := NewMemStore().Load("nope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty log, got %d", len(got))
+	}
+}
+
+// TestMemStoreCopiesPayload: mutating the caller's buffer after Append must not
+// corrupt stored data (the store owns a copy).
+func TestMemStoreCopiesPayload(t *testing.T) {
+	s := NewMemStore()
+	buf := []byte{1, 2, 3}
+	_ = s.Append("r", buf)
+	buf[0] = 9
+	got, _ := s.Load("r")
+	if !bytes.Equal(got[0], []byte{1, 2, 3}) {
+		t.Fatalf("store did not copy payload: %v", got[0])
+	}
+}
+
+// TestMemStoreConcurrent: concurrent appends are race-free (run under -race).
+func TestMemStoreConcurrent(t *testing.T) {
+	s := NewMemStore()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.Append("r", []byte{0})
+			_, _ = s.Load("r")
+		}()
+	}
+	wg.Wait()
+	got, _ := s.Load("r")
+	if len(got) != 50 {
+		t.Fatalf("expected 50 appends, got %d", len(got))
+	}
+}

--- a/services/collab/internal/store/postgres.go
+++ b/services/collab/internal/store/postgres.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"database/sql"
+
+	_ "github.com/lib/pq"
+)
+
+// schema is applied on open; additive and idempotent so it is safe to run on
+// every boot. `seq` orders updates within a room; the payload is the opaque
+// Yjs update bytes (bytea), never interpreted server-side.
+const schema = `
+CREATE TABLE IF NOT EXISTS yjs_updates (
+    room    TEXT   NOT NULL,
+    seq     BIGSERIAL,
+    payload BYTEA  NOT NULL,
+    PRIMARY KEY (room, seq)
+);
+CREATE INDEX IF NOT EXISTS yjs_updates_room_seq ON yjs_updates (room, seq);
+`
+
+// PostgresStore persists the per-room update log in PostgreSQL. It is selected
+// when DATABASE_URL is set; otherwise the server falls back to MemStore.
+type PostgresStore struct {
+	db *sql.DB
+}
+
+// NewPostgresStore opens a connection pool to dsn and ensures the schema
+// exists. The caller owns Close().
+func NewPostgresStore(dsn string) (*PostgresStore, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(schema); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &PostgresStore{db: db}, nil
+}
+
+// Close releases the underlying connection pool.
+func (s *PostgresStore) Close() error { return s.db.Close() }
+
+// Load returns the room's updates ordered by seq.
+func (s *PostgresStore) Load(room string) ([][]byte, error) {
+	rows, err := s.db.Query(
+		`SELECT payload FROM yjs_updates WHERE room = $1 ORDER BY seq`, room)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out [][]byte
+	for rows.Next() {
+		var payload []byte
+		if err := rows.Scan(&payload); err != nil {
+			return nil, err
+		}
+		out = append(out, payload)
+	}
+	return out, rows.Err()
+}
+
+// Append durably records one opaque update for the room.
+func (s *PostgresStore) Append(room string, payload []byte) error {
+	_, err := s.db.Exec(
+		`INSERT INTO yjs_updates (room, payload) VALUES ($1, $2)`, room, payload)
+	return err
+}

--- a/services/collab/internal/store/store.go
+++ b/services/collab/internal/store/store.go
@@ -1,0 +1,22 @@
+// Package store persists the opaque Yjs update log per room so that room
+// state survives server restarts and every client (not just the first joiner)
+// can be re-seeded from the server (ADR-0011 single-seed model).
+//
+// The store is deliberately CRDT-agnostic: it stores and returns opaque update
+// bytes in append order. The authoritative merge still happens in each client's
+// Yjs document. A Store implementation only needs to (a) append an opaque
+// payload to a room's log and (b) load a room's full log on demand.
+package store
+
+// Store is the persistence boundary for the per-room Yjs update log.
+//
+// Implementations must be safe for concurrent use by multiple goroutines.
+type Store interface {
+	// Load returns every stored update for the room in append order. A room
+	// with no history returns an empty slice (never an error for "not found").
+	Load(room string) ([][]byte, error)
+	// Append durably records one opaque update for the room. The payload is
+	// owned by the caller after the call returns; implementations that retain
+	// it must copy.
+	Append(room string, payload []byte) error
+}


### PR DESCRIPTION
## 概要
collab サーバが room の opaque Yjs update を永続化し、room 起動時（=サーバ再起動／idle 後の再生成）に復元するようにする。これによりリロードで状態が失われる問題と、初回 join の二重シードの理論レースを解消し、**サーバが baseline の源**になる単一シードモデルへ移行する。CRDT は解釈せずバイナリのまま保存する。

## 変更点
- `internal/store`: CRDT 非解釈の永続化境界。
  - `Store` インターフェース（`Load(room)`, `Append(room, payload)`）
  - `MemStore`: 既定／テスト用のインメモリ実装
  - `PostgresStore`: `yjs_updates(room, seq, payload)` に追記。スキーマは additive かつ冪等（`CREATE TABLE IF NOT EXISTS`）で起動時に適用
- `internal/hub`: Hub が Store を保持。room 生成時に `Load` で update ログを復元し、各 update を `Append` で write-through
- `cmd/collab`: `DATABASE_URL` があれば Postgres、なければインメモリ（耐久性なし）。設定ミスは fatal で顕在化
- `docker-compose.dev.yml`: collab に dev DB の `DATABASE_URL` と `depends_on: postgres(healthy)` を追加

## テスト
- `go build ./...` green
- `go vet ./...` green
- `go test -race ./...` green（store 往復・payload コピー・並行・room 復元・newcomer への再生）

\`\`\`
ok  collab/cmd/collab
ok  collab/internal/hub
ok  collab/internal/store
ok  collab/internal/yproto
\`\`\`

## 設計メモ
- リレーは引き続き opaque（ADR-0010/0011）。サーバは CRDT をマージしない
- persist → cache → broadcast の順。クラッシュで耐久ログに欠落を作らないため
- CI の collab テストは Postgres 不要（MemStore のみ）。Postgres 経路は本番/dev compose で有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)