### PR TITLE
共同編集(PR4b): JSONB投影とスライド操作の共同編集同期

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -8,6 +8,8 @@ import { useEditorStore } from "@features/editor/stores/editorStore";
 import { useSlideStore } from "@features/editor/stores/slideStore";
 import { useCollaboration } from "@features/editor/hooks/useCollaboration";
 import { useObjectBinding } from "@features/editor/hooks/useObjectBinding";
+import { useSlideStructure } from "@features/editor/hooks/useSlideStructure";
+import { SlideStructureProvider } from "@features/editor/hooks/slideStructureContext";
 import { getSlides, initializeDoc } from "@lib/collab/schema";
 import { slidesApi } from "@shared/api/slides";
 import { presentationsApi } from "@shared/api/presentations";
@@ -40,6 +42,8 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   // Open the collaboration room and bind the active slide's canvas to it.
   const { doc } = useCollaboration(id ?? null);
   useObjectBinding(doc, canvas, activeSlideId);
+  // Collaborative slide-list structure (add / remove / move) + JSONB projection.
+  const structure = useSlideStructure(doc, id ?? null, accessToken);
 
   useEffect(() => {
     if (!accessToken || !id) return;
@@ -59,6 +63,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   }, [id, accessToken, doc, setPresentationId, setSlides, setActiveSlide]);
 
   return (
+    <SlideStructureProvider value={structure}>
     <div className="flex h-screen flex-col overflow-hidden bg-surface-subtle">
       {/* Header */}
       <header className="flex h-12 items-center border-b border-border bg-surface px-4 shrink-0 gap-3">
@@ -149,5 +154,6 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
       {/* Bottom status bar */}
       <StatusBar />
     </div>
+    </SlideStructureProvider>
   );
 }

--- a/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
+++ b/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Plus, CopyPlus, Trash2 } from "lucide-react";
 import { useSlideStore } from "../../stores/slideStore";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStructureOps } from "../../hooks/slideStructureContext";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
@@ -18,6 +19,7 @@ export function SlidePanel() {
   const { slides, currentIndex, setCurrentIndex, addSlide, updateSlide, deleteSlide } = useSlideStore();
   const { setActiveSlide, presentationId } = useEditorStore();
   const { accessToken } = useAuthStore();
+  const structure = useSlideStructureOps();
   const [adding, setAdding] = useState(false);
   const [menu, setMenu] = useState<MenuState | null>(null);
 
@@ -32,6 +34,8 @@ export function SlidePanel() {
     try {
       const s = await slidesApi.create(accessToken, presentationId);
       addSlide(s as Slide);
+      // Mirror the new slide into the shared doc so peers see it too.
+      structure.addSlide((s as Slide).id);
       handleSelect(slides.length);
     } finally { setAdding(false); }
   }
@@ -44,6 +48,9 @@ export function SlidePanel() {
       await slidesApi.updateContent(accessToken, presentationId, created.id, slide.content);
       addSlide({ ...created, content: slide.content });
       updateSlide(created.id, slide.content as unknown as Record<string, unknown>);
+      // Mirror the duplicated slide into the shared doc; its objects sync via
+      // the per-slide ObjectBinding / projection autosave.
+      structure.addSlide(created.id);
       handleSelect(slides.length);
     } finally { setAdding(false); }
   }
@@ -53,6 +60,8 @@ export function SlidePanel() {
     if (slides.length <= 1 || !accessToken || !presentationId) return;
     await slidesApi.delete(accessToken, presentationId, id);
     deleteSlide(id);
+    // Mirror the removal into the shared doc so peers drop it too.
+    structure.removeSlide(id);
   }
 
   function openMenu(e: React.MouseEvent, slideId: string) {

--- a/web/src/features/editor/components/SlideSorter/SlideSorter.tsx
+++ b/web/src/features/editor/components/SlideSorter/SlideSorter.tsx
@@ -1,17 +1,41 @@
 "use client";
+import { useRef, useState } from "react";
 import { Monitor } from "lucide-react";
 import { useSlideStore } from "../../stores/slideStore";
 import { useEditorStore } from "../../stores/editorStore";
+import { useSlideStructureOps } from "../../hooks/slideStructureContext";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { slidesApi } from "@shared/api/slides";
 import { SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
 
 export function SlideSorter() {
-  const { slides, currentIndex, setCurrentIndex } = useSlideStore();
-  const { setActiveSlide, setViewMode } = useEditorStore();
+  const { slides, currentIndex, setCurrentIndex, setSlides } = useSlideStore();
+  const { setActiveSlide, setViewMode, presentationId } = useEditorStore();
+  const { accessToken } = useAuthStore();
+  const structure = useSlideStructureOps();
+  const dragFrom = useRef<number | null>(null);
+  const [dragOver, setDragOver] = useState<number | null>(null);
 
   function openSlide(i: number) {
     setCurrentIndex(i);
     setActiveSlide(slides[i].id);
     setViewMode("normal");
+  }
+
+  // Reorder locally, mirror into the shared doc, and persist positions.
+  function reorder(from: number, to: number) {
+    if (from === to || from < 0 || to < 0 || from >= slides.length) return;
+    const id = slides[from].id;
+    const next = [...slides];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    setSlides(next.map((s, i) => ({ ...s, position: i })));
+    structure.moveSlide(id, to);
+    if (accessToken && presentationId) {
+      const positions: Record<string, number> = {};
+      next.forEach((s, i) => { positions[s.id] = i; });
+      void slidesApi.reorder(accessToken, presentationId, positions).catch(() => {});
+    }
   }
 
   return (
@@ -44,11 +68,24 @@ export function SlideSorter() {
                 key={slide.id}
                 onClick={() => openSlide(i)}
                 onDoubleClick={() => openSlide(i)}
+                draggable
+                onDragStart={() => { dragFrom.current = i; }}
+                onDragOver={(e) => { e.preventDefault(); setDragOver(i); }}
+                onDragLeave={() => setDragOver((d) => (d === i ? null : d))}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  if (dragFrom.current !== null) reorder(dragFrom.current, i);
+                  dragFrom.current = null;
+                  setDragOver(null);
+                }}
+                onDragEnd={() => { dragFrom.current = null; setDragOver(null); }}
                 className="group flex flex-col gap-1.5 text-left"
               >
                 <div
                   className={`relative overflow-hidden rounded-lg border-2 bg-white shadow-sm transition-all aspect-video group-hover:shadow-md ${
-                    i === currentIndex
+                    dragOver === i
+                      ? "border-primary-500 ring-2 ring-primary-300"
+                      : i === currentIndex
                       ? "border-primary-500 ring-2 ring-primary-200"
                       : "border-border group-hover:border-primary-300"
                   }`}

--- a/web/src/features/editor/hooks/slideStructureContext.tsx
+++ b/web/src/features/editor/hooks/slideStructureContext.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { createContext, useContext } from "react";
+
+/** Collaborative slide-structure operations exposed to the editor UI. */
+export interface SlideStructureOps {
+  addSlide: (id: string, position?: number) => void;
+  removeSlide: (id: string) => void;
+  moveSlide: (id: string, toIndex: number) => void;
+  ready: boolean;
+}
+
+/**
+ * Provides the collaborative slide-structure ops (from {@link useSlideStructure})
+ * to nested editor panels (SlidePanel / SlideSorter) without prop drilling. The
+ * default is a no-op so panels render safely before the doc connects or in
+ * isolation (e.g. tests / storybook).
+ */
+const noop: SlideStructureOps = {
+  addSlide: () => {},
+  removeSlide: () => {},
+  moveSlide: () => {},
+  ready: false,
+};
+
+const SlideStructureContext = createContext<SlideStructureOps>(noop);
+
+export const SlideStructureProvider = SlideStructureContext.Provider;
+
+/** Access the collaborative slide-structure ops in a nested panel. */
+export function useSlideStructureOps(): SlideStructureOps {
+  return useContext(SlideStructureContext);
+}

--- a/web/src/features/editor/hooks/useSlideStructure.ts
+++ b/web/src/features/editor/hooks/useSlideStructure.ts
@@ -1,0 +1,127 @@
+"use client";
+import { useEffect, useMemo, useRef } from "react";
+import * as Y from "yjs";
+import { getSlides } from "@lib/collab/schema";
+import { SlideStructureBinding, LOCAL_ORIGIN } from "@lib/collab/binding";
+import { projectDoc } from "@lib/collab/projection";
+import { useSlideStore } from "../stores/slideStore";
+import { slidesApi } from "@shared/api/slides";
+import type { Slide } from "@shared/types/slide";
+
+/** Debounce window for projecting Yjs state back into the JSONB store. */
+const PROJECTION_DELAY = 2000;
+
+/**
+ * Wires collaborative slide-list structure (add / remove / move) to the shared
+ * Yjs doc, and materializes the canonical slide state back into `slides.content`
+ * (JSONB) on a debounce (ADR-0011 projection).
+ *
+ * Returns structural ops the editor UI (SlidePanel / SlideSorter) calls; each
+ * runs through {@link SlideStructureBinding} so the change syncs to every peer.
+ * Remote structural changes are merged into the local slide store, preserving
+ * per-slide metadata (thumbnail, notes, transition) that lives outside the doc.
+ */
+export function useSlideStructure(
+  doc: Y.Doc | null,
+  presentationId: string | null,
+  accessToken: string | null,
+) {
+  const bindingRef = useRef<SlideStructureBinding | null>(null);
+  const projectRef = useRef<(() => void) | null>(null);
+  const projectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!doc) return;
+    const slides = getSlides(doc);
+
+    // Project the canonical doc state into JSONB, debounced. Scoped to
+    // *structural* changes (add / remove / move): per-slide object-content
+    // autosave is already owned by useCanvas, so persisting only structure here
+    // avoids N-fold write amplification on every object edit.
+    const scheduleProjection = () => {
+      if (!presentationId || !accessToken) return;
+      if (projectTimer.current) clearTimeout(projectTimer.current);
+      projectTimer.current = setTimeout(() => {
+        const proj = projectDoc(doc);
+        // Persist new ordering for all slides, and content for slides the local
+        // editor may not have an open canvas for (e.g. remotely added).
+        const positions: Record<string, number> = {};
+        proj.forEach((p) => { positions[p.id] = p.position; });
+        void slidesApi.reorder(accessToken, presentationId, positions).catch(() => {});
+        for (const p of proj) {
+          void slidesApi
+            .updateContent(accessToken, presentationId, p.id, p.content)
+            .catch(() => { /* ignore network errors during projection autosave */ });
+        }
+      }, PROJECTION_DELAY);
+    };
+
+    // Structural change -> merge order/content into the local store (keeping
+    // fields the doc does not track: thumbnailUrl, notes, meta) and schedule a
+    // JSONB projection. Local ops (LOCAL_ORIGIN) are filtered by the binding's
+    // observer, so this only fires for *remote* structural changes; local ops
+    // are projected explicitly via the returned methods below.
+    const binding = new SlideStructureBinding(doc, slides, {
+      setSlides: () => {
+        const projection = projectDoc(doc);
+        const prev = useSlideStore.getState().slides;
+        const byId = new Map(prev.map((s) => [s.id, s]));
+        const next: Slide[] = projection.map((p) => {
+          const existing = byId.get(p.id);
+          return {
+            ...(existing ?? {
+              id: p.id,
+              presentationId: presentationId ?? "",
+              notes: undefined,
+              thumbnailUrl: undefined,
+              createdAt: "",
+              updatedAt: "",
+            }),
+            position: p.position,
+            content: p.content,
+          } as Slide;
+        });
+        useSlideStore.getState().setSlides(next);
+        scheduleProjection();
+      },
+    });
+    binding.observe();
+    bindingRef.current = binding;
+    projectRef.current = scheduleProjection;
+
+    return () => {
+      binding.unobserve();
+      bindingRef.current = null;
+      projectRef.current = null;
+      if (projectTimer.current) clearTimeout(projectTimer.current);
+    };
+  }, [doc, presentationId, accessToken]);
+
+  return useMemo(
+    () => ({
+      /** Insert a new slide skeleton at `position` (defaults to the end). */
+      addSlide: (id: string, position?: number) => {
+        if (!presentationId) return;
+        bindingRef.current?.addSlide(id, presentationId, position);
+        projectRef.current?.();
+      },
+      /** Remove the slide with this id from the shared doc. */
+      removeSlide: (id: string) => {
+        bindingRef.current?.removeSlide(id);
+        projectRef.current?.();
+      },
+      /** Move the slide with this id to `toIndex`. */
+      moveSlide: (id: string, toIndex: number) => {
+        bindingRef.current?.moveSlide(id, toIndex);
+        projectRef.current?.();
+      },
+      /** True once the binding is live (doc connected). */
+      get ready() {
+        return bindingRef.current !== null;
+      },
+    }),
+    [presentationId],
+  );
+}
+
+export { LOCAL_ORIGIN };

--- a/web/src/lib/collab/projection.test.ts
+++ b/web/src/lib/collab/projection.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import * as Y from "yjs";
+import { getSlides, slideToYMap, type YObjectMap } from "./schema";
+import { SlideStructureBinding } from "./binding";
+import { projectDoc } from "./projection";
+
+vi.mock("y-websocket", () => ({ WebsocketProvider: vi.fn() }));
+
+function seed(doc: Y.Doc) {
+  const slides = getSlides(doc);
+  doc.transact(() => {
+    slides.push([
+      slideToYMap({
+        id: "s1",
+        presentationId: "p",
+        position: 0,
+        content: { version: "1.0", objects: [{ id: "o1", type: "rect", left: 3 }] },
+        createdAt: "x",
+        updatedAt: "x",
+      }),
+    ]);
+  });
+}
+
+describe("projectDoc (JSONB projection)", () => {
+  it("projects ordered slides with id, position, and materialized content", () => {
+    const doc = new Y.Doc();
+    seed(doc);
+    const out = projectDoc(doc);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("s1");
+    expect(out[0].position).toBe(0);
+    expect(out[0].content.version).toBe("1.0");
+    expect(out[0].content.objects).toEqual([{ id: "o1", type: "rect", left: 3 }]);
+  });
+
+  it("reflects a live object edit in the projection", () => {
+    const doc = new Y.Doc();
+    seed(doc);
+    const objects = getSlides(doc).get(0).get("objects") as Y.Array<YObjectMap>;
+    doc.transact(() => objects.get(0).set("left", 99));
+    expect(projectDoc(doc)[0].content.objects[0]).toMatchObject({ left: 99 });
+  });
+
+  it("skips slide maps without a stable id", () => {
+    const doc = new Y.Doc();
+    doc.transact(() => {
+      const m = new Y.Map<unknown>();
+      m.set("position", 0);
+      getSlides(doc).push([m]);
+    });
+    expect(projectDoc(doc)).toHaveLength(0);
+  });
+
+  it("survives a persistence round-trip (encode/applyUpdate) intact", () => {
+    const docA = new Y.Doc();
+    seed(docA);
+    const update = Y.encodeStateAsUpdate(docA);
+
+    // Simulate server restart + restore: a fresh doc rebuilt from the update log.
+    const docB = new Y.Doc();
+    Y.applyUpdate(docB, update);
+
+    expect(projectDoc(docB)).toEqual(projectDoc(docA));
+  });
+});
+
+describe("structure sync + projection convergence", () => {
+  it("add / move / remove on one peer project identically on a synced peer", () => {
+    const docA = new Y.Doc();
+    const bindingA = new SlideStructureBinding(docA, getSlides(docA), { setSlides: () => {} });
+    bindingA.observe();
+
+    const docB = new Y.Doc();
+    const bindingB = new SlideStructureBinding(docB, getSlides(docB), { setSlides: () => {} });
+    bindingB.observe();
+    docA.on("update", (u) => Y.applyUpdate(docB, u));
+    docB.on("update", (u) => Y.applyUpdate(docA, u));
+
+    bindingA.addSlide("s1", "p");
+    bindingA.addSlide("s2", "p");
+    bindingB.addSlide("s3", "p");
+    bindingA.moveSlide("s1", 2);
+    bindingB.removeSlide("s2");
+
+    const idsA = projectDoc(docA).map((s) => s.id);
+    const idsB = projectDoc(docB).map((s) => s.id);
+    expect(idsA).toEqual(idsB);
+    // positions are contiguous from 0..n-1 on both peers.
+    expect(projectDoc(docA).map((s) => s.position)).toEqual(idsA.map((_, i) => i));
+  });
+});

--- a/web/src/lib/collab/projection.ts
+++ b/web/src/lib/collab/projection.ts
@@ -1,0 +1,42 @@
+import * as Y from "yjs";
+import { getSlides, yMapToSlideContent, SLIDE_FIELDS } from "./schema";
+import type { SlideContent } from "@shared/types/slide";
+
+/**
+ * JSONB projection of the Yjs doc (ADR-0011).
+ *
+ * The Yjs doc is the source of truth for live editing; `slides.content` (JSONB)
+ * is a materialized projection used for display, export, and non-collab viewing.
+ * The server persists only opaque Yjs updates (it never interprets the CRDT), so
+ * the canonical slide state is projected back to the JSONB store *by a client*,
+ * debounced, reusing the existing `slidesApi.updateContent` autosave path.
+ *
+ * This module holds the pure projection helper so it is unit-testable without a
+ * network or React.
+ */
+
+/** One slide's canonical projection: its stable id + materialized content. */
+export interface SlideProjection {
+  id: string;
+  position: number;
+  content: SlideContent;
+}
+
+/**
+ * Projects the whole doc into an ordered list of `{ id, position, content }`.
+ * Slides without an id are skipped (a slide map is only meaningful once seeded
+ * with its stable id).
+ */
+export function projectDoc(doc: Y.Doc): SlideProjection[] {
+  const out: SlideProjection[] = [];
+  getSlides(doc).forEach((slide, i) => {
+    const id = slide.get(SLIDE_FIELDS.id) as string | undefined;
+    if (!id) return;
+    out.push({
+      id,
+      position: (slide.get(SLIDE_FIELDS.position) as number | undefined) ?? i,
+      content: yMapToSlideContent(slide),
+    });
+  });
+  return out;
+}


### PR DESCRIPTION
## 概要
確定状態を `slides.content`(JSONB) に materialize して保存し、スライドの追加/削除/並べ替えを共同編集で同期する。サーバは引き続き opaque リレー（CRDT 非解釈）のまま、クライアントが正準スライド状態をデバウンス投影する。

## 変更点
- `lib/collab/projection.ts`: `projectDoc(doc)` — doc を `{ id, position, content }[]` に materialize する純関数
- `hooks/useSlideStructure.ts`: `SlideStructureBinding` を doc に束ね、`addSlide / removeSlide / moveSlide` を公開。**構造変更時のみ** JSONB をデバウンス投影（object 編集の per-slide autosave は既存 `useCanvas` が担当するため、ここで全スライド投影すると書き込みが N 倍になるのを回避）。リモート構造変更は thumbnail/notes 等のメタを保持して `slideStore` へマージ
- `hooks/slideStructureContext.tsx`: ネストパネルへ prop drilling 無しで構造 ops を配る Context
- `SlidePanel`: 追加/複製/削除を doc にミラー
- `SlideSorter`: ドラッグ&ドロップ並べ替えを追加し `moveSlide` で同期 + `positions` 永続化
- `editor/[id]/page.tsx`: `useSlideStructure` を起動し `SlideStructureProvider` で body をラップ

## テスト
- `npm run build` green
- `npx tsc --noEmit` green / `npm run lint` 0 errors（既存 warning のみ）
- `npx vitest run` green: 111 tests（+5）
  - JSONB 投影（id/position/content、live 編集反映、id 欠落スキップ）
  - 永続化往復（encodeStateAsUpdate→applyUpdate で投影が一致）
  - 構造同期収束（2 peer で add/move/remove が同一に投影され position 連番）

## 設計メモ
- 真実源は Yjs doc、JSONB は materialized ミラー（ADR-0011）
- 投影は構造変更にスコープ。content autosave は useCanvas が per-slide で実施

## 補足（行数）
本体 ~256 行（テスト 92 行除く）でガイドライン 200 行を超過。投影＋スライド操作配線は一体で、これ以上分割すると片肺配線になるため 1 PR にまとめた（論理コミットは 3 分割）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)