### PR TITLE
共同編集(PR5): awareness で他参加者のプレゼンスをライブ共有

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.0.0",
         "recharts": "^2.14.1",
         "tailwind-merge": "^2.6.0",
+        "y-protocols": "^1.0.7",
         "y-websocket": "^3.0.0",
         "yjs": "^13.6.21",
         "zustand": "^5.0.3"

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "openai": "^4.77.0",
     "yjs": "^13.6.21",
     "y-websocket": "^3.0.0",
+    "y-protocols": "^1.0.7",
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.6.0",
     "lucide-react": "^0.525.0"

--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -8,6 +8,8 @@ import { useEditorStore } from "@features/editor/stores/editorStore";
 import { useSlideStore } from "@features/editor/stores/slideStore";
 import { useCollaboration } from "@features/editor/hooks/useCollaboration";
 import { useObjectBinding } from "@features/editor/hooks/useObjectBinding";
+import { usePresence } from "@features/editor/hooks/usePresence";
+import { PresenceBar } from "@features/editor/components/PresenceBar";
 import { useSlideStructure } from "@features/editor/hooks/useSlideStructure";
 import { SlideStructureProvider } from "@features/editor/hooks/slideStructureContext";
 import { getSlides, initializeDoc } from "@lib/collab/schema";
@@ -40,8 +42,10 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const [title, setTitle] = useState("Untitled");
 
   // Open the collaboration room and bind the active slide's canvas to it.
-  const { doc } = useCollaboration(id ?? null);
+  const { provider, doc } = useCollaboration(id ?? null);
   useObjectBinding(doc, canvas, activeSlideId);
+  // Live presence: publish/read other editors' slide + selection (ephemeral).
+  const { peers } = usePresence(provider, canvas, activeSlideId);
   // Collaborative slide-list structure (add / remove / move) + JSONB projection.
   const structure = useSlideStructure(doc, id ?? null, accessToken);
 
@@ -92,6 +96,9 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
         <QuickAccess />
 
         <div className="flex-1" />
+
+        {/* Live collaborators (presence) */}
+        <PresenceBar peers={peers} activeSlideId={activeSlideId} />
 
         {/* Export */}
         <ExportButton />

--- a/web/src/features/editor/components/PresenceBar.tsx
+++ b/web/src/features/editor/components/PresenceBar.tsx
@@ -1,0 +1,47 @@
+"use client";
+import type { RemotePresence } from "@lib/collab/presence";
+
+/** First grapheme of a name, used as an avatar initial. */
+function initial(name: string): string {
+  return [...name][0] ?? "?";
+}
+
+/**
+ * Compact participant strip for the editor header: one colored avatar per remote
+ * peer, captioned with which slide they are on. Renders nothing when alone, so it
+ * stays invisible in single-user editing.
+ */
+export function PresenceBar({
+  peers,
+  activeSlideId,
+}: {
+  peers: RemotePresence[];
+  activeSlideId: string | null;
+}) {
+  if (peers.length === 0) return null;
+
+  return (
+    <div className="flex items-center -space-x-1.5" aria-label="共同編集者">
+      {peers.map((p) => {
+        const here = p.slideId === activeSlideId;
+        const label = here
+          ? `${p.name}（このスライド）`
+          : `${p.name}（別のスライド）`;
+        return (
+          <span
+            key={p.clientId}
+            title={label}
+            className="flex h-6 w-6 items-center justify-center rounded-full border-2 text-[10px] font-semibold text-white ring-1 ring-white/40"
+            style={{
+              backgroundColor: p.color,
+              borderColor: here ? p.color : "transparent",
+              opacity: here ? 1 : 0.45,
+            }}
+          >
+            {initial(p.name)}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/features/editor/hooks/usePresence.ts
+++ b/web/src/features/editor/hooks/usePresence.ts
@@ -1,0 +1,85 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import type { Canvas } from "fabric";
+import { CollabProvider } from "@lib/collab/provider";
+import {
+  PresenceManager,
+  type RemotePresence,
+} from "@lib/collab/presence";
+
+/** A short, stable anonymous label for an unauthenticated/unnamed session. */
+function anonName(clientId: number): string {
+  return `ゲスト ${Math.abs(clientId) % 1000}`;
+}
+
+/**
+ * Connects local editor state to the collaborative awareness channel and exposes
+ * every other peer's presence reactively.
+ *
+ * Publishes: identity (name + color), current slide, selected object id, and the
+ * pointer position (slide coordinates). Subscribes to remote awareness changes
+ * and mirrors them into React state so overlays re-render. On unmount the manager
+ * clears local presence so peers drop this client immediately (no 30s timeout).
+ */
+export function usePresence(
+  provider: CollabProvider | null,
+  canvas: Canvas | null,
+  activeSlideId: string | null,
+  identity?: { name?: string },
+): { peers: RemotePresence[] } {
+  const [peers, setPeers] = useState<RemotePresence[]>([]);
+  const managerRef = useRef<PresenceManager | null>(null);
+
+  // Build the manager once per connected provider.
+  useEffect(() => {
+    const awareness = provider?.awareness;
+    if (!awareness) return;
+    const name = identity?.name ?? anonName(awareness.clientID);
+    const manager = new PresenceManager(awareness, { name });
+    managerRef.current = manager;
+    const unsubscribe = manager.onChange(() => setPeers(manager.remoteStates()));
+    setPeers(manager.remoteStates());
+    return () => {
+      unsubscribe();
+      manager.destroy();
+      managerRef.current = null;
+    };
+  }, [provider, identity?.name]);
+
+  // Publish the active slide whenever it (or the manager) changes. `provider`
+  // is a dep so this re-runs right after a new manager is created on connect,
+  // seeding the initial slide without an extra effect.
+  useEffect(() => {
+    managerRef.current?.update({ slideId: activeSlideId });
+  }, [activeSlideId, provider]);
+
+  // Track selection + pointer on the live canvas.
+  useEffect(() => {
+    const manager = managerRef.current;
+    if (!canvas || !manager) return;
+
+    const selectedId = () => {
+      const obj = canvas.getActiveObject() as { id?: string } | undefined;
+      return obj?.id ?? null;
+    };
+    const onSelection = () => manager.update({ selectedId: selectedId() });
+    const onMove = (e: { scenePoint?: { x: number; y: number }; pointer?: { x: number; y: number } }) => {
+      const p = e.scenePoint ?? e.pointer;
+      if (p) manager.update({ cursor: { x: Math.round(p.x), y: Math.round(p.y) } });
+    };
+
+    canvas.on("selection:created", onSelection);
+    canvas.on("selection:updated", onSelection);
+    canvas.on("selection:cleared", onSelection);
+    canvas.on("mouse:move", onMove);
+    onSelection();
+    return () => {
+      canvas.off("selection:created", onSelection);
+      canvas.off("selection:updated", onSelection);
+      canvas.off("selection:cleared", onSelection);
+      canvas.off("mouse:move", onMove);
+    };
+  }, [canvas]);
+
+  return { peers };
+}

--- a/web/src/lib/collab/presence.test.ts
+++ b/web/src/lib/collab/presence.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import {
+  Awareness,
+  encodeAwarenessUpdate,
+  applyAwarenessUpdate,
+} from "y-protocols/awareness";
+import {
+  PresenceManager,
+  PRESENCE_FIELD,
+  colorForClient,
+} from "./presence";
+
+/**
+ * Two clients in a room. We relay awareness updates between them exactly like
+ * the collab server does (verbatim, no interpretation) by re-encoding the full
+ * state of one side and applying it to the other.
+ */
+function link(a: Awareness, b: Awareness): void {
+  const relay = (from: Awareness, to: Awareness) =>
+    (
+      { added, updated, removed }: {
+        added: number[];
+        updated: number[];
+        removed: number[];
+      },
+    ) => {
+      // Mirror y-websocket: relay exactly the clients touched by this update,
+      // so removals (null state on leave) propagate too — not just live states.
+      const changed = [...added, ...updated, ...removed];
+      const update = encodeAwarenessUpdate(from, changed);
+      applyAwarenessUpdate(to, update, "remote");
+    };
+  a.on("update", relay(a, b));
+  b.on("update", relay(b, a));
+}
+
+describe("PresenceManager", () => {
+  it("publishes identity on construction", () => {
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const m = new PresenceManager(awareness, { name: "Alice", color: "#f00" });
+
+    const local = awareness.getLocalState()?.[PRESENCE_FIELD];
+    expect(local).toMatchObject({ name: "Alice", color: "#f00", slideId: null });
+    expect(m.localState.selectedId).toBeNull();
+  });
+
+  it("derives a deterministic color when none is given", () => {
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const m = new PresenceManager(awareness, { name: "Bob" });
+    expect(m.localState.color).toBe(colorForClient(awareness.clientID));
+  });
+
+  it("merges partial updates without clobbering identity", () => {
+    const doc = new Y.Doc();
+    const awareness = new Awareness(doc);
+    const m = new PresenceManager(awareness, { name: "Alice", color: "#f00" });
+
+    m.update({ slideId: "s1" });
+    m.update({ selectedId: "obj-9" });
+
+    expect(m.localState).toMatchObject({
+      name: "Alice",
+      color: "#f00",
+      slideId: "s1",
+      selectedId: "obj-9",
+    });
+  });
+
+  it("surfaces a remote peer's presence and reflects updates", () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const awA = new Awareness(docA);
+    const awB = new Awareness(docB);
+    link(awA, awB);
+
+    const a = new PresenceManager(awA, { name: "Alice" });
+    const b = new PresenceManager(awB, { name: "Bob" });
+
+    a.update({ slideId: "s1", selectedId: "rect-1" });
+
+    // Bob sees Alice (and only Alice) among remote states.
+    const seenByBob = b.remoteStates();
+    expect(seenByBob).toHaveLength(1);
+    expect(seenByBob[0]).toMatchObject({
+      clientId: awA.clientID,
+      name: "Alice",
+      slideId: "s1",
+      selectedId: "rect-1",
+    });
+
+    // A peer never lists itself.
+    expect(a.remoteStates().map((p) => p.clientId)).not.toContain(awA.clientID);
+  });
+
+  it("notifies onChange subscribers when a remote peer updates", () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const awA = new Awareness(docA);
+    const awB = new Awareness(docB);
+    link(awA, awB);
+
+    const a = new PresenceManager(awA, { name: "Alice" });
+    new PresenceManager(awB, { name: "Bob" });
+
+    let calls = 0;
+    const off = a.onChange(() => {
+      calls += 1;
+    });
+    awB.setLocalStateField(PRESENCE_FIELD, {
+      name: "Bob",
+      color: "#0f0",
+      slideId: "s2",
+      selectedId: null,
+      cursor: null,
+    });
+    expect(calls).toBeGreaterThan(0);
+    off();
+  });
+
+  it("clears local presence on destroy so peers drop it", () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const awA = new Awareness(docA);
+    const awB = new Awareness(docB);
+    link(awA, awB);
+
+    const a = new PresenceManager(awA, { name: "Alice" });
+    const b = new PresenceManager(awB, { name: "Bob" });
+
+    expect(b.remoteStates()).toHaveLength(1);
+    a.destroy();
+    expect(b.remoteStates()).toHaveLength(0);
+  });
+});

--- a/web/src/lib/collab/presence.ts
+++ b/web/src/lib/collab/presence.ts
@@ -1,0 +1,126 @@
+import type { Awareness } from "y-protocols/awareness";
+
+/**
+ * Live presence (awareness) layer for collaborative editing.
+ *
+ * Presence is *ephemeral* (ADR-0011): it is never written into the Yjs doc and
+ * never persisted by the collab server, which relays awareness frames verbatim
+ * (see `TestAwarenessRelayedNotStored`). Each client publishes who it is, which
+ * slide it is on, what object it has selected and (optionally) its cursor, and
+ * reads the same back for every other connected client.
+ *
+ * This module is intentionally framework-free so it can be unit-tested against a
+ * bare `Awareness` instance without a websocket.
+ */
+
+/** Identity + live position one peer broadcasts about itself. */
+export interface PresenceState {
+  /** Display name (or anonymous id) shown in the participant list. */
+  name: string;
+  /** Stable per-session color used for the cursor / selection highlight. */
+  color: string;
+  /** Id of the slide the peer is currently viewing/editing. */
+  slideId: string | null;
+  /** Id of the object the peer currently has selected, if any. */
+  selectedId: string | null;
+  /** Cursor position in slide coordinates, if tracked. */
+  cursor: { x: number; y: number } | null;
+}
+
+/** A remote peer's presence, tagged with the awareness clientID that owns it. */
+export interface RemotePresence extends PresenceState {
+  clientId: number;
+}
+
+/** Awareness field key under which the whole {@link PresenceState} lives. */
+export const PRESENCE_FIELD = "presence";
+
+/** Distinct, accessible palette assigned to peers by clientID. */
+const PALETTE = [
+  "#2563eb", // blue
+  "#db2777", // pink
+  "#16a34a", // green
+  "#d97706", // amber
+  "#7c3aed", // violet
+  "#0891b2", // cyan
+  "#dc2626", // red
+  "#4f46e5", // indigo
+];
+
+/** Deterministically pick a palette color for a clientID. */
+export function colorForClient(clientId: number): string {
+  return PALETTE[Math.abs(clientId) % PALETTE.length];
+}
+
+/**
+ * Wraps a y-protocols {@link Awareness} instance with typed presence helpers.
+ *
+ * Owns exactly one awareness field ({@link PRESENCE_FIELD}); it merges partial
+ * updates into the existing local state so callers can publish slide / selection
+ * / cursor changes independently without clobbering identity.
+ */
+export class PresenceManager {
+  private local: PresenceState;
+
+  constructor(
+    private readonly awareness: Awareness,
+    identity: { name: string; color?: string },
+  ) {
+    this.local = {
+      name: identity.name,
+      color: identity.color ?? colorForClient(awareness.clientID),
+      slideId: null,
+      selectedId: null,
+      cursor: null,
+    };
+    this.publish();
+  }
+
+  /** The awareness clientID that identifies this client's own presence. */
+  get clientId(): number {
+    return this.awareness.clientID;
+  }
+
+  /** This client's currently published presence (read-only snapshot). */
+  get localState(): PresenceState {
+    return { ...this.local };
+  }
+
+  /** Merge a partial update into local presence and broadcast it. */
+  update(patch: Partial<Omit<PresenceState, "name" | "color">>): void {
+    this.local = { ...this.local, ...patch };
+    this.publish();
+  }
+
+  private publish(): void {
+    this.awareness.setLocalStateField(PRESENCE_FIELD, this.local);
+  }
+
+  /** Every *other* peer's presence (the local client is excluded). */
+  remoteStates(): RemotePresence[] {
+    const out: RemotePresence[] = [];
+    for (const [clientId, state] of this.awareness.getStates()) {
+      if (clientId === this.awareness.clientID) continue;
+      const presence = (state as Record<string, unknown>)[PRESENCE_FIELD] as
+        | PresenceState
+        | undefined;
+      if (presence) out.push({ clientId, ...presence });
+    }
+    return out;
+  }
+
+  /** Subscribe to any awareness change; returns an unsubscribe function. */
+  onChange(fn: () => void): () => void {
+    this.awareness.on("change", fn);
+    return () => this.awareness.off("change", fn);
+  }
+
+  /**
+   * Clear this client's presence on leave so peers drop it immediately instead
+   * of waiting for the 30s awareness timeout. Matches y-websocket's own
+   * `beforeunload` cleanup but is also invoked on React unmount.
+   */
+  destroy(): void {
+    this.awareness.setLocalState(null);
+  }
+}

--- a/web/src/lib/collab/provider.ts
+++ b/web/src/lib/collab/provider.ts
@@ -1,15 +1,17 @@
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";
+import type { Awareness } from "y-protocols/awareness";
 import { getSlides, type YSlideMap } from "./schema";
 
 /**
  * Collaboration provider backed by `y-websocket`.
  *
  * One provider == one presentation "room". The Yjs doc is the source of truth
- * (ADR-0011); this class only owns connection lifecycle (connect / disconnect /
- * auto-reconnect, handled by y-websocket) and exposes the shared doc + slide
- * array. Fabric two-way binding and awareness are intentionally out of scope
- * for this PR.
+ * (ADR-0011); this class owns connection lifecycle (connect / disconnect /
+ * auto-reconnect, handled by y-websocket) and exposes the shared doc, slide
+ * array, and the ephemeral awareness channel for live presence. y-websocket
+ * encodes awareness updates onto the same socket the collab server relays
+ * verbatim, so presence rides the existing transport with no server changes.
  */
 export class CollabProvider {
   readonly doc: Y.Doc;
@@ -47,6 +49,14 @@ export class CollabProvider {
   /** The shared, ordered slide list (Y.Array<Y.Map>). */
   get slides(): Y.Array<YSlideMap> {
     return getSlides(this.doc);
+  }
+
+  /**
+   * The ephemeral awareness channel (live presence), or null before connect.
+   * y-websocket owns the instance; callers wrap it with {@link PresenceManager}.
+   */
+  get awareness(): Awareness | null {
+    return this.provider?.awareness ?? null;
   }
 
   /** Closes the socket and tears down the provider, keeping the doc intact. */


### PR DESCRIPTION
## 概要
Yjs 共同編集シリーズの最終 PR。awareness（y-protocols）を接続し、他参加者の**現在スライド・選択オブジェクト・カーソル**をライブ共有する。presence は **ephemeral**（doc に書かず永続化しない）で、collab サーバは既存の opaque リレーのまま（サーバ変更なし）。

## 変更点
- **CollabProvider**: y-websocket が持つ `awareness` を公開。presence は既存 WS をそのまま流れる。
- **PresenceManager** (`presence.ts`): 識別情報（名前/色）・slideId・selectedId・cursor を持つ presence を publish / 購読する framework-free な層。部分更新を merge し identity を壊さない。離脱時 `setLocalState(null)` で即時クリーンアップ（30秒タイムアウト待ちにしない）。
- **usePresence** フック: エディタの `selection:*` / `mouse:move` / activeSlide を awareness に配線。unmount で presence をクリア。
- **PresenceBar**: 共同編集者を色付きアバターで表示。同一スライド在席をハイライト、別スライドは減光。単独編集時は非表示。
- **presence.test.ts**: 2クライアント間で awareness をリレーし、publish→受信→状態反映・離脱クリア・onChange 通知を検証（6件）。

## スコープ判断
- カーソル座標は publish 済みだが、ピクセル精度のキャンバス重畳オーバーレイ（zoom/pan 追従）は複雑度と PR 行数の観点で見送り、必須要件「誰がどのスライドにいるか＋選択ハイライト」を堅牢に実装。次フェーズで余力対応可。

## 検証
- `web`: `npm run build` green / `npx vitest run` 117 passed / `tsc --noEmit` clean
- `services/collab`: 変更なし、`go build` / `go test` green（opaque リレー維持を `TestAwarenessRelayedNotStored` が担保）