### PR TITLE
P2安定化: realtime WS自動再接続＋遅参viewerの初期同期

### DIFF
--- a/services/realtime/cmd/realtime/main.go
+++ b/services/realtime/cmd/realtime/main.go
@@ -17,6 +17,11 @@ type Session struct {
 	mu        sync.RWMutex
 	presenter *websocket.Conn
 	viewers   map[*websocket.Conn]bool
+	// lastState holds the most recent slide-change frame so a viewer that joins
+	// (or reconnects) mid-presentation is synced to the current slide
+	// immediately, instead of waiting for the next slide-change. nil until the
+	// presenter has sent at least one frame.
+	lastState []byte
 }
 
 var sessions = make(map[string]*Session)
@@ -58,11 +63,14 @@ func handlePresenter(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			break
 		}
-		sess.mu.RLock()
+		sess.mu.Lock()
+		// Retain the latest frame so late-joining viewers can be snapshotted.
+		// Copy because gorilla reuses the read buffer across ReadMessage calls.
+		sess.lastState = append(sess.lastState[:0:0], msg...)
 		for v := range sess.viewers {
 			v.WriteMessage(websocket.TextMessage, msg)
 		}
-		sess.mu.RUnlock()
+		sess.mu.Unlock()
 	}
 }
 
@@ -79,7 +87,13 @@ func handleViewer(w http.ResponseWriter, r *http.Request) {
 	sess := getSession(sessionID)
 	sess.mu.Lock()
 	sess.viewers[conn] = true
+	// Snapshot the current slide to the new viewer so it lands on the slide the
+	// presenter is on, rather than slide 0, until the next slide-change.
+	snapshot := sess.lastState
 	sess.mu.Unlock()
+	if snapshot != nil {
+		conn.WriteMessage(websocket.TextMessage, snapshot)
+	}
 	defer func() {
 		sess.mu.Lock()
 		delete(sess.viewers, conn)

--- a/services/realtime/cmd/realtime/main_test.go
+++ b/services/realtime/cmd/realtime/main_test.go
@@ -90,3 +90,75 @@ func TestViewersAreIsolatedBySession(t *testing.T) {
 		t.Fatalf("viewer in another session unexpectedly received a broadcast")
 	}
 }
+
+// TestLateJoinerReceivesSnapshot covers the P2 late-join fix: a viewer that
+// connects AFTER the presenter has already advanced must immediately receive
+// the current slide, not slide 0.
+func TestLateJoinerReceivesSnapshot(t *testing.T) {
+	// Fresh registry so a prior test's session cannot leak state in.
+	sessionsMu.Lock()
+	sessions = make(map[string]*Session)
+	sessionsMu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/presenter", handlePresenter)
+	mux.HandleFunc("/viewer", handleViewer)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dialer := websocket.DefaultDialer
+
+	// Presenter connects and advances to slide 7 with no viewers attached yet.
+	presenter, _, err := dialer.Dial(wsURL(srv.URL, "/presenter?session=late"), nil)
+	if err != nil {
+		t.Fatalf("presenter dial: %v", err)
+	}
+	defer presenter.Close()
+
+	snapshot := []byte(`{"type":"slide-change","slideIndex":7}`)
+	if err := presenter.WriteMessage(websocket.TextMessage, snapshot); err != nil {
+		t.Fatalf("presenter write: %v", err)
+	}
+	// Let the server record lastState before the viewer joins.
+	time.Sleep(50 * time.Millisecond)
+
+	// Late viewer joins and must be synced to slide 7 right away.
+	viewer, _, err := dialer.Dial(wsURL(srv.URL, "/viewer?session=late"), nil)
+	if err != nil {
+		t.Fatalf("late viewer dial: %v", err)
+	}
+	defer viewer.Close()
+
+	viewer.SetReadDeadline(time.Now().Add(time.Second))
+	_, got, err := viewer.ReadMessage()
+	if err != nil {
+		t.Fatalf("late viewer read: %v", err)
+	}
+	if string(got) != string(snapshot) {
+		t.Fatalf("late viewer got %q, want %q", got, snapshot)
+	}
+}
+
+// TestViewerWithoutPriorStateGetsNoSnapshot ensures a viewer that joins before
+// any slide-change is not sent a stray empty/zero frame.
+func TestViewerWithoutPriorStateGetsNoSnapshot(t *testing.T) {
+	sessionsMu.Lock()
+	sessions = make(map[string]*Session)
+	sessionsMu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/viewer", handleViewer)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	viewer, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/viewer?session=empty"), nil)
+	if err != nil {
+		t.Fatalf("viewer dial: %v", err)
+	}
+	defer viewer.Close()
+
+	viewer.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if _, _, err := viewer.ReadMessage(); err == nil {
+		t.Fatalf("viewer unexpectedly received a snapshot with no prior state")
+	}
+}

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -9,7 +9,7 @@ import type { Slide } from "@shared/types/slide";
 const STATUS_LABEL: Record<ViewerStatus, string> = {
   connecting: "接続中…",
   connected: "発表者に同期中",
-  disconnected: "切断 — 手動操作",
+  disconnected: "切断 — 再接続中（手動操作可）",
 };
 
 export default function ViewPage({ params }: { params: Promise<{ id: string }> }) {

--- a/web/src/lib/realtime/presenter.test.ts
+++ b/web/src/lib/realtime/presenter.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { parseSlideChange, ViewerSocket, type ViewerStatus } from "./presenter";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseSlideChange, backoffDelay, ViewerSocket, PresenterSocket, type ViewerStatus } from "./presenter";
 
 describe("parseSlideChange", () => {
   it("returns the index for a well-formed slide-change frame", () => {
@@ -17,8 +17,25 @@ describe("parseSlideChange", () => {
   });
 });
 
+describe("backoffDelay", () => {
+  it("grows exponentially from 500ms and caps at 10s (no jitter)", () => {
+    const noJitter = () => 0;
+    expect(backoffDelay(0, noJitter)).toBe(500);
+    expect(backoffDelay(1, noJitter)).toBe(1000);
+    expect(backoffDelay(2, noJitter)).toBe(2000);
+    expect(backoffDelay(3, noJitter)).toBe(4000);
+    expect(backoffDelay(10, noJitter)).toBe(10_000); // capped
+  });
+
+  it("adds up to 30% jitter", () => {
+    expect(backoffDelay(0, () => 1)).toBe(650); // 500 * 1.3
+    expect(backoffDelay(1, () => 1)).toBe(1300); // 1000 * 1.3
+  });
+});
+
 // Minimal WebSocket stand-in so we can drive lifecycle + messages without a server.
 class FakeWebSocket {
+  static OPEN = 1;
   static instances: FakeWebSocket[] = [];
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
@@ -26,16 +43,24 @@ class FakeWebSocket {
   onmessage: ((e: { data: unknown }) => void) | null = null;
   readyState = 0;
   closed = false;
+  sent: string[] = [];
   constructor(public url: string) {
     FakeWebSocket.instances.push(this);
   }
+  send(data: string) { this.sent.push(data); }
   close() { this.closed = true; }
+  open() { this.readyState = FakeWebSocket.OPEN; this.onopen?.(); }
 }
 
 describe("ViewerSocket", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("reports connecting immediately, then connected on open", () => {
@@ -44,7 +69,7 @@ describe("ViewerSocket", () => {
     const ws = FakeWebSocket.instances[0];
     expect(ws.url).toContain("/viewer?session=sess-1");
     expect(statuses).toEqual(["connecting"]);
-    ws.onopen?.();
+    ws.open();
     expect(statuses).toEqual(["connecting", "connected"]);
   });
 
@@ -58,24 +83,90 @@ describe("ViewerSocket", () => {
     expect(seen).toEqual([5]);
   });
 
-  it("reports disconnected on close and error", () => {
+  it("reconnects with backoff after an unexpected close, reporting disconnected then connecting", () => {
     const statuses: ViewerStatus[] = [];
-    new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) });
+    new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) }, () => 0);
     const ws = FakeWebSocket.instances[0];
-    ws.onclose?.();
-    ws.onerror?.();
-    expect(statuses).toEqual(["connecting", "disconnected", "disconnected"]);
+    ws.open();
+    expect(statuses).toEqual(["connecting", "connected"]);
+
+    ws.onclose?.(); // server drop
+    expect(statuses).toEqual(["connecting", "connected", "disconnected"]);
+    expect(FakeWebSocket.instances).toHaveLength(1); // not yet reconnected
+
+    vi.advanceTimersByTime(500); // first backoff step
+    expect(FakeWebSocket.instances).toHaveLength(2); // reconnect attempted
+    expect(statuses).toEqual(["connecting", "connected", "disconnected", "connecting"]);
   });
 
-  it("detaches handlers and closes the socket on destroy", () => {
+  it("backs off progressively across repeated drops", () => {
+    new ViewerSocket("s", { onSlideChange: () => {} }, () => 0);
+    FakeWebSocket.instances[0].onclose?.();
+    vi.advanceTimersByTime(499);
+    expect(FakeWebSocket.instances).toHaveLength(1); // not reconnected before 500ms
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    FakeWebSocket.instances[1].onclose?.();
+    vi.advanceTimersByTime(999);
+    expect(FakeWebSocket.instances).toHaveLength(2); // 2nd attempt waits 1000ms
+    vi.advanceTimersByTime(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
+  it("a duplicate close/error from the same dead socket schedules only one reconnect", () => {
+    new ViewerSocket("s", { onSlideChange: () => {} }, () => 0);
+    const ws = FakeWebSocket.instances[0];
+    ws.onclose?.();
+    ws.onerror?.(); // handlers were detached, so this is a no-op
+    vi.advanceTimersByTime(500);
+    expect(FakeWebSocket.instances).toHaveLength(2); // exactly one reconnect
+  });
+
+  it("stops reconnecting and closes the socket on destroy", () => {
     const statuses: ViewerStatus[] = [];
-    const sock = new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) });
+    const sock = new ViewerSocket("s", { onSlideChange: () => {}, onStatus: (st) => statuses.push(st) }, () => 0);
     const ws = FakeWebSocket.instances[0];
     sock.destroy();
     expect(ws.closed).toBe(true);
     expect(ws.onclose).toBeNull();
     expect(ws.onmessage).toBeNull();
-    // a stray close after destroy must not push another status update
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.instances).toHaveLength(1); // no reconnect after destroy
     expect(statuses).toEqual(["connecting"]);
+  });
+});
+
+describe("PresenterSocket", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends slide-change frames once open", () => {
+    const sock = new PresenterSocket("s");
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    sock.sendSlideChange(3);
+    expect(ws.sent).toContain(JSON.stringify({ type: "slide-change", slideIndex: 3 }));
+  });
+
+  it("re-publishes the current slide on reconnect so the server snapshot stays accurate", () => {
+    const sock = new PresenterSocket("s", () => 0);
+    const ws1 = FakeWebSocket.instances[0];
+    ws1.open();
+    sock.sendSlideChange(7);
+
+    ws1.onclose?.(); // drop
+    vi.advanceTimersByTime(500); // reconnect
+    const ws2 = FakeWebSocket.instances[1];
+    ws2.open();
+    // On reconnect, the presenter re-sends slide 7 (its remembered position).
+    expect(ws2.sent).toContain(JSON.stringify({ type: "slide-change", slideIndex: 7 }));
   });
 });

--- a/web/src/lib/realtime/presenter.ts
+++ b/web/src/lib/realtime/presenter.ts
@@ -1,23 +1,23 @@
-export class PresenterSocket {
-  private ws: WebSocket | null = null;
-  constructor(sessionId: string) {
-    const url = `${process.env.NEXT_PUBLIC_REALTIME_URL ?? "ws://localhost:8082"}/presenter?session=${sessionId}`;
-    this.ws = new WebSocket(url);
-  }
-  sendSlideChange(index: number) {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: "slide-change", slideIndex: index }));
-    }
-  }
-  destroy() { this.ws?.close(); }
-}
-
-/** Connection lifecycle reported to the viewer UI. */
+/** Connection lifecycle reported to the UI. */
 export type ViewerStatus = "connecting" | "connected" | "disconnected";
 
 export interface ViewerSocketHandlers {
   onSlideChange: (index: number) => void;
   onStatus?: (status: ViewerStatus) => void;
+}
+
+/**
+ * Exponential-backoff schedule for realtime reconnects: 500ms, 1s, 2s, 4s,
+ * capped at 10s, with up to 30% jitter so a fleet of viewers reconnecting after
+ * a server blip does not stampede. Pure + injectable so it is unit-testable.
+ */
+export function backoffDelay(attempt: number, rand: () => number = Math.random): number {
+  const base = Math.min(500 * 2 ** attempt, 10_000);
+  return Math.round(base * (1 + rand() * 0.3));
+}
+
+function realtimeBase(): string {
+  return process.env.NEXT_PUBLIC_REALTIME_URL ?? "ws://localhost:8082";
 }
 
 /**
@@ -38,31 +38,126 @@ export function parseSlideChange(data: unknown): number | null {
   return null;
 }
 
-export class ViewerSocket {
-  private ws: WebSocket | null = null;
-  constructor(sessionId: string, handlers: ViewerSocketHandlers | ((index: number) => void)) {
-    // Backwards-compatible: a bare callback is treated as onSlideChange.
-    const h: ViewerSocketHandlers = typeof handlers === "function" ? { onSlideChange: handlers } : handlers;
-    const url = `${process.env.NEXT_PUBLIC_REALTIME_URL ?? "ws://localhost:8082"}/viewer?session=${sessionId}`;
-    h.onStatus?.("connecting");
-    this.ws = new WebSocket(url);
-    this.ws.onopen = () => h.onStatus?.("connected");
-    this.ws.onclose = () => h.onStatus?.("disconnected");
-    this.ws.onerror = () => h.onStatus?.("disconnected");
-    this.ws.onmessage = (e) => {
-      const index = parseSlideChange(e.data);
-      if (index !== null) h.onSlideChange(index);
-    };
+/**
+ * A WebSocket that transparently reconnects with exponential backoff until
+ * {@link ReconnectingSocket.destroy} is called. Subclasses supply the URL and
+ * react to open/message/status via the protected hooks. Keeps the socket
+ * lifecycle (and the "is this close intentional?" bookkeeping) in one place so
+ * both presenter and viewer get identical, tested reconnect behaviour.
+ */
+class ReconnectingSocket {
+  protected ws: WebSocket | null = null;
+  private attempt = 0;
+  private closedByUs = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly url: string,
+    private readonly rand: () => number = Math.random,
+  ) {}
+
+  /** Must be called by subclasses once their fields are initialised. */
+  protected start() {
+    this.connect();
   }
-  destroy() {
-    // Drop handlers before closing so an unmount-triggered close does not
-    // bubble a "disconnected" status into a component that is going away.
+
+  private connect() {
+    this.onStatus("connecting");
+    const ws = new WebSocket(this.url);
+    this.ws = ws;
+    ws.onopen = () => {
+      this.attempt = 0;
+      this.onStatus("connected");
+      this.onOpen();
+    };
+    ws.onmessage = (e) => this.onMessage(e.data);
+    ws.onclose = () => this.handleDrop();
+    ws.onerror = () => this.handleDrop();
+  }
+
+  private handleDrop() {
+    if (this.closedByUs) return;
+    // Detach so a duplicate close/error from the same dead socket cannot trigger
+    // a second reconnect schedule.
     if (this.ws) {
-      this.ws.onopen = null;
-      this.ws.onclose = null;
-      this.ws.onerror = null;
-      this.ws.onmessage = null;
-      this.ws.close();
+      this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
     }
+    this.onStatus("disconnected");
+    const delay = backoffDelay(this.attempt++, this.rand);
+    this.timer = setTimeout(() => this.connect(), delay);
+  }
+
+  /** Stop reconnecting and tear down the current socket. Idempotent. */
+  destroy() {
+    this.closedByUs = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.ws) {
+      this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  // --- hooks ---
+  protected onOpen(): void {}
+  protected onMessage(_data: unknown): void {}
+  protected onStatus(_status: ViewerStatus): void {}
+}
+
+/**
+ * Presenter side of the realtime channel. Auto-reconnects with backoff and, on
+ * every (re)connect, re-sends the current slide so the server's late-join
+ * snapshot stays accurate even across a server restart or presenter reconnect.
+ */
+export class PresenterSocket extends ReconnectingSocket {
+  private lastIndex = 0;
+
+  constructor(sessionId: string, rand: () => number = Math.random) {
+    super(`${realtimeBase()}/presenter?session=${sessionId}`, rand);
+    this.start();
+  }
+
+  protected onOpen(): void {
+    // Re-publish current position so a freshly (re)connected server snapshots it.
+    this.transmit(this.lastIndex);
+  }
+
+  sendSlideChange(index: number) {
+    this.lastIndex = index;
+    this.transmit(index);
+  }
+
+  private transmit(index: number) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: "slide-change", slideIndex: index }));
+    }
+  }
+}
+
+/**
+ * Viewer side of the realtime channel. Auto-reconnects with backoff; on each
+ * (re)connect the server immediately sends the current slide snapshot, so a
+ * late joiner or a viewer recovering from a drop lands on the right slide.
+ */
+export class ViewerSocket extends ReconnectingSocket {
+  private readonly handlers: ViewerSocketHandlers;
+
+  constructor(sessionId: string, handlers: ViewerSocketHandlers | ((index: number) => void), rand: () => number = Math.random) {
+    super(`${realtimeBase()}/viewer?session=${sessionId}`, rand);
+    // Backwards-compatible: a bare callback is treated as onSlideChange.
+    this.handlers = typeof handlers === "function" ? { onSlideChange: handlers } : handlers;
+    this.start();
+  }
+
+  protected onMessage(data: unknown): void {
+    const index = parseSlideChange(data);
+    if (index !== null) this.handlers.onSlideChange(index);
+  }
+
+  protected onStatus(status: ViewerStatus): void {
+    this.handlers.onStatus?.(status);
   }
 }


### PR DESCRIPTION
## 概要
P2 課題のうち最も効く2点に絞って対応した。

1. **realtime WS の自動再接続＋指数バックオフ**（ViewerSocket / PresenterSocket）
2. **遅参 viewer の初期同期**（参加直後に現在スライドを即受信）

複数 presenter 排他・session 参加認可は本PRのスコープ外（次PRに回す）。

## 変更点

### 遅参 viewer の初期同期（サーバ側）
- `services/realtime` の `Session` に最後の slide-change フレーム `lastState` を保持。
- viewer 接続時に `lastState` を即送信し、次の slide-change を待たず現在スライドへ着地させる。
- prior state が無いセッションでは何も送らない（0枚目への stray frame を防止）。

### 自動再接続＋指数バックオフ（クライアント側）
- `ViewerSocket` / `PresenterSocket` を共通の `ReconnectingSocket` に統一。
- 切断（close/error）を検知すると指数バックオフ（500ms→1s→2s→4s… 上限10s、最大30%ジッタ）で自動再接続。意図的な `destroy()` では再接続しない。
- 同一 dead socket からの重複 close/error は再接続を二重スケジュールしないようハンドラを即 detach。
- 再接続時:
  - `PresenterSocket` は記憶した現在スライドを再送 → サーバ再起動・presenter 再接続後も snapshot が最新に保たれる。
  - `ViewerSocket` はサーバの late-join snapshot を受け取り現在スライドへ復帰。
- view ページのステータス表示を「切断 — 再接続中（手動操作可）」に更新。

## テスト
- `services/realtime`: late-join snapshot / prior state 無しで snapshot 無し、を追加。`go build` / `go vet` / `go test -race` green。
- `web`: `backoffDelay`（指数・上限・ジッタ）、再接続スケジュール、バックオフ漸増、重複 close 抑止、destroy 後の再接続停止、presenter の現在スライド再送、を追加。
- `npx vitest run` 全123テスト green、`npx tsc --noEmit` clean、`npm run build` green、`npm run lint` 既存warningのみ（0 error）。

## スコープ・サイズ注記
本体変更は小さいが、`presenter.ts` を再接続対応で構造化リライトしたため diff は約320行（うちテスト約180行）。サーバ/クライアントは機能的に相互依存（クライアント再接続がサーバ snapshot に依存）するため、分割せず1つのまとまった単位とした。

## 次のP2残り
- 複数 presenter 排他
- session 参加認可