### PR TITLE
P2認可: realtime/collab WS接続をJWTで認可しCheckOriginをallowlist化

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,8 @@ services:
     environment:
       PORT: "8081"
       DATABASE_URL: postgres://presentsai:presentsai@postgres:5432/presentsai?sslmode=disable
+      # Same secret as the API so access tokens minted there verify here.
+      JWT_SECRET: dev-jwt-secret-change-in-prod
     ports:
       - "8081:8081"
     depends_on:
@@ -52,6 +54,9 @@ services:
       dockerfile: Dockerfile
     environment:
       PORT: "8082"
+      # Same secret as the API so presenter tokens verify here. Viewers (public
+      # audience) connect without a token; only presenters are gated.
+      JWT_SECRET: dev-jwt-secret-change-in-prod
     ports:
       - "8082:8082"
 

--- a/services/collab/cmd/collab/auth.go
+++ b/services/collab/cmd/collab/auth.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// authConfig captures the WS-connection authorization policy, resolved once at
+// startup. It mirrors the API's verification method
+// (services/api/.../middleware/auth.go): HMAC-signed JWT, `sub` claim required.
+//
+// Collaborative editing is an authenticated-only feature, so — unlike the
+// realtime audience path — collab requires a valid token whenever a secret is
+// configured. y-websocket forwards the token as the `token` query param (set
+// via the provider's `params` option).
+type authConfig struct {
+	// jwtSecret is the shared HMAC secret. Empty disables verification (dev /
+	// existing tests); production must set JWT_SECRET on every service.
+	jwtSecret string
+	// allowedOrigins is the CheckOrigin allowlist; empty accepts all (dev).
+	allowedOrigins []string
+}
+
+func loadAuthConfig() authConfig {
+	var origins []string
+	if raw := os.Getenv("ALLOWED_ORIGINS"); raw != "" {
+		for _, o := range strings.Split(raw, ",") {
+			if t := strings.TrimSpace(o); t != "" {
+				origins = append(origins, t)
+			}
+		}
+	}
+	return authConfig{
+		jwtSecret:      os.Getenv("JWT_SECRET"),
+		allowedOrigins: origins,
+	}
+}
+
+// checkOrigin enforces the configured allowlist. Empty allowlist accepts all
+// (dev); a missing Origin header (non-browser / same-origin) is always allowed.
+func (c authConfig) checkOrigin(r *http.Request) bool {
+	if len(c.allowedOrigins) == 0 {
+		return true
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	for _, allowed := range c.allowedOrigins {
+		if origin == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// authorized reports whether the request carries a valid token. When no secret
+// is configured, verification is skipped and the request is always authorized.
+func (c authConfig) authorized(r *http.Request) bool {
+	if c.jwtSecret == "" {
+		return true // verification disabled
+	}
+	raw := r.URL.Query().Get("token")
+	if raw == "" {
+		return false
+	}
+	token, err := jwt.Parse(raw, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return []byte(c.jwtSecret), nil
+	})
+	if err != nil || !token.Valid {
+		return false
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return false
+	}
+	sub, ok := claims["sub"].(string)
+	return ok && sub != ""
+}

--- a/services/collab/cmd/collab/auth_test.go
+++ b/services/collab/cmd/collab/auth_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+
+	"github.com/ko-tarou/presentsai/services/collab/internal/hub"
+)
+
+const testSecret = "test-secret"
+
+func signToken(t *testing.T, secret, sub string) string {
+	t.Helper()
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": sub,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+// withAuth swaps the global auth config for a test and restores it after.
+func withAuth(t *testing.T, cfg authConfig) {
+	t.Helper()
+	prev := auth
+	auth = cfg
+	t.Cleanup(func() { auth = prev })
+}
+
+func authServer() *httptest.Server {
+	return httptest.NewServer(makeHandler(hub.New(nil)))
+}
+
+func wsURL(base, pathQuery string) string {
+	return "ws" + base[len("http"):] + pathQuery
+}
+
+// TestRejectsMissingToken: with a secret configured, a connection without a
+// token is refused at the handshake (HTTP 401).
+func TestRejectsMissingToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/deck"), nil)
+	if err == nil {
+		t.Fatal("expected dial without token to fail")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %v", resp)
+	}
+}
+
+// TestRejectsInvalidToken: a token signed with the wrong secret fails.
+func TestRejectsInvalidToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	bad := signToken(t, "wrong-secret", "user-1")
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/deck?token="+bad), nil)
+	if err == nil {
+		t.Fatal("expected dial with invalid token to fail")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %v", resp)
+	}
+}
+
+// TestAcceptsValidToken: a properly signed token connects.
+func TestAcceptsValidToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	good := signToken(t, testSecret, "user-1")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/deck?token="+good), nil)
+	if err != nil {
+		t.Fatalf("expected dial with valid token to succeed: %v", err)
+	}
+	conn.Close()
+}
+
+// TestVerificationDisabledWithoutSecret: with no JWT_SECRET, connections are
+// allowed without a token — preserving local/dev behaviour.
+func TestVerificationDisabledWithoutSecret(t *testing.T) {
+	withAuth(t, authConfig{})
+	srv := authServer()
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/deck"), nil)
+	if err != nil {
+		t.Fatalf("expected dial to succeed with verification disabled: %v", err)
+	}
+	conn.Close()
+}
+
+// TestCheckOriginAllowlist exercises the origin policy directly.
+func TestCheckOriginAllowlist(t *testing.T) {
+	cfg := authConfig{allowedOrigins: []string{"https://app.example.com"}}
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"https://app.example.com", true},
+		{"https://evil.example.com", false},
+		{"", true},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/deck", nil)
+		if c.origin != "" {
+			r.Header.Set("Origin", c.origin)
+		}
+		if got := cfg.checkOrigin(r); got != c.want {
+			t.Errorf("origin %q: got %v want %v", c.origin, got, c.want)
+		}
+	}
+}

--- a/services/collab/cmd/collab/main.go
+++ b/services/collab/cmd/collab/main.go
@@ -25,7 +25,11 @@ import (
 	"github.com/ko-tarou/presentsai/services/collab/internal/store"
 )
 
-var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+// auth holds the connection authorization policy (JWT verification + origin
+// allowlist), resolved from the environment in main. upgrader delegates its
+// CheckOrigin to it so the allowlist is enforced before the WS handshake.
+var auth authConfig
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return auth.checkOrigin(r) }}
 
 // wsClient adapts a websocket connection to hub.Client. Outbound frames are
 // queued on a buffered channel and written by a single writer goroutine, so
@@ -76,6 +80,12 @@ func makeHandler(h *hub.Hub) http.HandlerFunc {
 			http.Error(w, "room required", http.StatusBadRequest)
 			return
 		}
+		// Collaborative editing is authenticated-only: reject before the WS
+		// handshake when the token is missing or invalid (HTTP 401, like the API).
+		if !auth.authorized(r) {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -122,6 +132,10 @@ func newStore() store.Store {
 
 func main() {
 	godotenv.Load()
+	auth = loadAuthConfig()
+	if auth.jwtSecret == "" {
+		log.Printf("collab: JWT_SECRET unset, WS token verification DISABLED (dev mode)")
+	}
 	h := hub.New(newStore())
 
 	mux := http.NewServeMux()

--- a/services/collab/go.mod
+++ b/services/collab/go.mod
@@ -7,3 +7,5 @@ require github.com/joho/godotenv v1.5.1
 require github.com/gorilla/websocket v1.5.3
 
 require github.com/lib/pq v1.10.9
+
+require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/services/collab/go.sum
+++ b/services/collab/go.sum
@@ -1,3 +1,5 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/services/realtime/cmd/realtime/auth.go
+++ b/services/realtime/cmd/realtime/auth.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// authConfig captures the WS-connection authorization policy, resolved once at
+// startup from the environment. It is shared by realtime and mirrors the API's
+// verification method (services/api/.../middleware/auth.go): HMAC-signed JWT,
+// `sub` claim required.
+type authConfig struct {
+	// jwtSecret is the shared HMAC secret. When empty, token verification is
+	// DISABLED so local/dev and the existing test suite keep working without a
+	// configured secret; production must set JWT_SECRET on every service.
+	jwtSecret string
+	// allowedOrigins is the CheckOrigin allowlist. When empty, every origin is
+	// accepted (dev). When set, only listed origins (and origin-less,
+	// non-browser/same-origin requests) connect.
+	allowedOrigins []string
+}
+
+func loadAuthConfig() authConfig {
+	var origins []string
+	if raw := os.Getenv("ALLOWED_ORIGINS"); raw != "" {
+		for _, o := range strings.Split(raw, ",") {
+			if t := strings.TrimSpace(o); t != "" {
+				origins = append(origins, t)
+			}
+		}
+	}
+	return authConfig{
+		jwtSecret:      os.Getenv("JWT_SECRET"),
+		allowedOrigins: origins,
+	}
+}
+
+// checkOrigin enforces the configured allowlist. An empty allowlist accepts
+// everything (dev). A missing Origin header (non-browser clients, same-origin)
+// is always allowed; browsers always send Origin for cross-origin WS.
+func (c authConfig) checkOrigin(r *http.Request) bool {
+	if len(c.allowedOrigins) == 0 {
+		return true
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	for _, allowed := range c.allowedOrigins {
+		if origin == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// authError distinguishes "no token supplied" from "token present but invalid"
+// so callers can apply path-specific policy (e.g. viewer tolerates the former).
+type authError int
+
+const (
+	authOK authError = iota
+	authMissing
+	authInvalid
+)
+
+// verifyToken checks the `token` query param against the shared secret. When no
+// secret is configured, verification is skipped and authOK is returned (the
+// connection is always allowed). The userID (sub claim) is returned on success.
+func (c authConfig) verifyToken(r *http.Request) (userID string, result authError) {
+	if c.jwtSecret == "" {
+		return "", authOK // verification disabled
+	}
+	raw := r.URL.Query().Get("token")
+	if raw == "" {
+		return "", authMissing
+	}
+	token, err := jwt.Parse(raw, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return []byte(c.jwtSecret), nil
+	})
+	if err != nil || !token.Valid {
+		return "", authInvalid
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", authInvalid
+	}
+	sub, ok := claims["sub"].(string)
+	if !ok || sub == "" {
+		return "", authInvalid
+	}
+	return sub, authOK
+}

--- a/services/realtime/cmd/realtime/auth_test.go
+++ b/services/realtime/cmd/realtime/auth_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+)
+
+const testSecret = "test-secret"
+
+// signToken mints an HS256 token mirroring the API's access-token shape.
+func signToken(t *testing.T, secret, sub string) string {
+	t.Helper()
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": sub,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+// withAuth swaps the global auth config for a test and restores it after.
+func withAuth(t *testing.T, cfg authConfig) {
+	t.Helper()
+	prev := auth
+	auth = cfg
+	t.Cleanup(func() { auth = prev })
+}
+
+func authServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/presenter", handlePresenter)
+	mux.HandleFunc("/viewer", handleViewer)
+	return httptest.NewServer(mux)
+}
+
+// TestPresenterRejectsMissingToken: with a secret configured, a presenter
+// without a token is refused at the handshake (HTTP 401).
+func TestPresenterRejectsMissingToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=r1"), nil)
+	if err == nil {
+		t.Fatal("expected presenter dial without token to fail")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %v", resp)
+	}
+}
+
+// TestPresenterRejectsInvalidToken: a token signed with the wrong secret fails.
+func TestPresenterRejectsInvalidToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	bad := signToken(t, "wrong-secret", "user-1")
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=r1&token="+bad), nil)
+	if err == nil {
+		t.Fatal("expected presenter dial with invalid token to fail")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %v", resp)
+	}
+}
+
+// TestPresenterAcceptsValidToken: a properly signed token connects.
+func TestPresenterAcceptsValidToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	good := signToken(t, testSecret, "user-1")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=r1&token="+good), nil)
+	if err != nil {
+		t.Fatalf("expected presenter dial with valid token to succeed: %v", err)
+	}
+	conn.Close()
+}
+
+// TestViewerAllowsMissingToken: viewers are the public audience path, so no
+// token is required even when a secret is configured.
+func TestViewerAllowsMissingToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/viewer?session=r1"), nil)
+	if err != nil {
+		t.Fatalf("expected anonymous viewer dial to succeed: %v", err)
+	}
+	conn.Close()
+}
+
+// TestViewerRejectsInvalidToken: a supplied-but-forged token is refused.
+func TestViewerRejectsInvalidToken(t *testing.T) {
+	withAuth(t, authConfig{jwtSecret: testSecret})
+	srv := authServer()
+	defer srv.Close()
+
+	bad := signToken(t, "wrong-secret", "user-1")
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/viewer?session=r1&token="+bad), nil)
+	if err == nil {
+		t.Fatal("expected viewer dial with invalid token to fail")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %v", resp)
+	}
+}
+
+// TestVerificationDisabledWithoutSecret: with no JWT_SECRET, all connections
+// (token or not) are allowed — preserving local/dev behaviour.
+func TestVerificationDisabledWithoutSecret(t *testing.T) {
+	withAuth(t, authConfig{}) // no secret
+	srv := authServer()
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=r1"), nil)
+	if err != nil {
+		t.Fatalf("expected presenter dial to succeed with verification disabled: %v", err)
+	}
+	conn.Close()
+}
+
+// TestCheckOriginAllowlist exercises the origin policy directly.
+func TestCheckOriginAllowlist(t *testing.T) {
+	cfg := authConfig{allowedOrigins: []string{"https://app.example.com"}}
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"https://app.example.com", true},
+		{"https://evil.example.com", false},
+		{"", true}, // origin-less (non-browser / same-origin) allowed
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/presenter", nil)
+		if c.origin != "" {
+			r.Header.Set("Origin", c.origin)
+		}
+		if got := cfg.checkOrigin(r); got != c.want {
+			t.Errorf("origin %q: got %v want %v", c.origin, got, c.want)
+		}
+	}
+
+	// Empty allowlist accepts everything.
+	open := authConfig{}
+	r := httptest.NewRequest(http.MethodGet, "/presenter", nil)
+	r.Header.Set("Origin", "https://anything.example.com")
+	if !open.checkOrigin(r) {
+		t.Error("empty allowlist should accept any origin")
+	}
+}

--- a/services/realtime/cmd/realtime/main.go
+++ b/services/realtime/cmd/realtime/main.go
@@ -11,7 +11,11 @@ import (
 	"github.com/joho/godotenv"
 )
 
-var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+// auth holds the connection authorization policy (JWT verification + origin
+// allowlist), resolved from the environment in main. upgrader delegates its
+// CheckOrigin to it so the allowlist is enforced before the WS handshake.
+var auth authConfig
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return auth.checkOrigin(r) }}
 
 type Session struct {
 	mu        sync.RWMutex
@@ -42,6 +46,12 @@ func handlePresenter(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.URL.Query().Get("session")
 	if sessionID == "" {
 		http.Error(w, "session required", 400)
+		return
+	}
+	// Presenter is a privileged, authenticated role: reject before the WS
+	// handshake when the token is missing or invalid (HTTP 401, like the API).
+	if _, res := auth.verifyToken(r); res != authOK {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 		return
 	}
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -80,6 +90,13 @@ func handleViewer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session required", 400)
 		return
 	}
+	// Viewer is the public audience path: a token is optional so anonymous
+	// audiences can follow along. But if one is supplied it must be valid —
+	// a forged/expired token is rejected rather than silently downgraded.
+	if _, res := auth.verifyToken(r); res == authInvalid {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
@@ -109,6 +126,10 @@ func handleViewer(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	godotenv.Load()
+	auth = loadAuthConfig()
+	if auth.jwtSecret == "" {
+		log.Printf("realtime: JWT_SECRET unset, WS token verification DISABLED (dev mode)")
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/services/realtime/go.mod
+++ b/services/realtime/go.mod
@@ -5,3 +5,5 @@ go 1.23.4
 require github.com/joho/godotenv v1.5.1
 
 require github.com/gorilla/websocket v1.5.3
+
+require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/services/realtime/go.sum
+++ b/services/realtime/go.sum
@@ -1,3 +1,5 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -42,7 +42,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const [title, setTitle] = useState("Untitled");
 
   // Open the collaboration room and bind the active slide's canvas to it.
-  const { provider, doc } = useCollaboration(id ?? null);
+  const { provider, doc } = useCollaboration(id ?? null, accessToken);
   useObjectBinding(doc, canvas, activeSlideId);
   // Live presence: publish/read other editors' slide + selection (ephemeral).
   const { peers } = usePresence(provider, canvas, activeSlideId);

--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -21,7 +21,7 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   useEffect(() => {
     if (!accessToken) return;
     slidesApi.list(accessToken, id).then(r => setSlides(r.items as Slide[]));
-    presenterRef.current = new PresenterSocket(id);
+    presenterRef.current = new PresenterSocket(id, accessToken);
     return () => { presenterRef.current?.destroy(); };
   }, [id, accessToken]);
 

--- a/web/src/features/editor/hooks/useCollaboration.ts
+++ b/web/src/features/editor/hooks/useCollaboration.ts
@@ -11,13 +11,13 @@ import { CollabProvider } from "@lib/collab/provider";
  * @returns the live {@link CollabProvider} and its shared {@link Y.Doc} (both
  *          null before connect), kept in state so consumers re-render on connect.
  */
-export function useCollaboration(presentationId: string | null) {
+export function useCollaboration(presentationId: string | null, token: string | null = null) {
   const [provider, setProvider] = useState<CollabProvider | null>(null);
   const [doc, setDoc] = useState<Y.Doc | null>(null);
 
   useEffect(() => {
     if (!presentationId) return;
-    const p = new CollabProvider(presentationId);
+    const p = new CollabProvider(presentationId, new Y.Doc(), token);
     p.connect();
     setProvider(p);
     setDoc(p.doc);
@@ -26,7 +26,7 @@ export function useCollaboration(presentationId: string | null) {
       setProvider(null);
       setDoc(null);
     };
-  }, [presentationId]);
+  }, [presentationId, token]);
 
   return { provider, doc };
 }

--- a/web/src/lib/collab/provider.ts
+++ b/web/src/lib/collab/provider.ts
@@ -17,10 +17,15 @@ export class CollabProvider {
   readonly doc: Y.Doc;
   readonly roomId: string;
   private provider: WebsocketProvider | null = null;
+  // Access token for WS authorization. Forwarded to the collab server as a
+  // `token` query param (browsers cannot set WS Authorization headers), where
+  // it is verified against the shared JWT secret. null when unauthenticated.
+  private readonly token: string | null;
 
-  constructor(roomId: string, doc: Y.Doc = new Y.Doc()) {
+  constructor(roomId: string, doc: Y.Doc = new Y.Doc(), token: string | null = null) {
     this.roomId = roomId;
     this.doc = doc;
+    this.token = token;
   }
 
   /** Resolves the collab websocket endpoint (without the room segment). */
@@ -34,10 +39,14 @@ export class CollabProvider {
    */
   connect(): void {
     if (this.provider) return;
+    // y-websocket serializes `params` onto the handshake URL query string, so
+    // the token rides the same socket the relay already verifies.
+    const params = this.token ? { token: this.token } : undefined;
     this.provider = new WebsocketProvider(
       CollabProvider.endpoint(),
       this.roomId,
       this.doc,
+      { params },
     );
   }
 

--- a/web/src/lib/realtime/presenter.test.ts
+++ b/web/src/lib/realtime/presenter.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { parseSlideChange, backoffDelay, ViewerSocket, PresenterSocket, type ViewerStatus } from "./presenter";
+import { parseSlideChange, backoffDelay, withToken, ViewerSocket, PresenterSocket, type ViewerStatus } from "./presenter";
+
+describe("withToken", () => {
+  it("appends the token as a query param, preserving existing query", () => {
+    expect(withToken("ws://h/presenter?session=s", "abc")).toBe("ws://h/presenter?session=s&token=abc");
+    expect(withToken("ws://h/room", "abc")).toBe("ws://h/room?token=abc");
+  });
+  it("url-encodes the token", () => {
+    expect(withToken("ws://h/x", "a b/c")).toBe("ws://h/x?token=a%20b%2Fc");
+  });
+  it("leaves the URL untouched when no token is supplied", () => {
+    expect(withToken("ws://h/x?session=s")).toBe("ws://h/x?session=s");
+    expect(withToken("ws://h/x?session=s", null)).toBe("ws://h/x?session=s");
+    expect(withToken("ws://h/x?session=s", "")).toBe("ws://h/x?session=s");
+  });
+});
 
 describe("parseSlideChange", () => {
   it("returns the index for a well-formed slide-change frame", () => {
@@ -148,6 +163,16 @@ describe("PresenterSocket", () => {
     vi.unstubAllGlobals();
   });
 
+  it("includes the access token in the connection URL when supplied", () => {
+    new PresenterSocket("s", "tok-123");
+    expect(FakeWebSocket.instances[0].url).toContain("/presenter?session=s&token=tok-123");
+  });
+
+  it("omits the token query when none is supplied", () => {
+    new PresenterSocket("s");
+    expect(FakeWebSocket.instances[0].url).toBe("ws://localhost:8082/presenter?session=s");
+  });
+
   it("sends slide-change frames once open", () => {
     const sock = new PresenterSocket("s");
     const ws = FakeWebSocket.instances[0];
@@ -157,7 +182,7 @@ describe("PresenterSocket", () => {
   });
 
   it("re-publishes the current slide on reconnect so the server snapshot stays accurate", () => {
-    const sock = new PresenterSocket("s", () => 0);
+    const sock = new PresenterSocket("s", null, () => 0);
     const ws1 = FakeWebSocket.instances[0];
     ws1.open();
     sock.sendSlideChange(7);

--- a/web/src/lib/realtime/presenter.ts
+++ b/web/src/lib/realtime/presenter.ts
@@ -21,6 +21,19 @@ function realtimeBase(): string {
 }
 
 /**
+ * Append the access token as a `?token=` query param when present. WebSocket
+ * handshakes from the browser cannot carry an Authorization header, so the
+ * realtime/collab services read the token from the query string (matching the
+ * API's JWT verification). A null/empty token leaves the URL untouched — the
+ * viewer (public audience) path connects anonymously.
+ */
+export function withToken(url: string, token?: string | null): string {
+  if (!token) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
+/**
  * Parse a raw realtime message and return the slide index the viewer should
  * follow, or null if the message is not a usable slide-change. Pure so the
  * follow logic can be unit-tested without a live socket.
@@ -115,8 +128,8 @@ class ReconnectingSocket {
 export class PresenterSocket extends ReconnectingSocket {
   private lastIndex = 0;
 
-  constructor(sessionId: string, rand: () => number = Math.random) {
-    super(`${realtimeBase()}/presenter?session=${sessionId}`, rand);
+  constructor(sessionId: string, token?: string | null, rand: () => number = Math.random) {
+    super(withToken(`${realtimeBase()}/presenter?session=${sessionId}`, token), rand);
     this.start();
   }
 
@@ -145,8 +158,13 @@ export class PresenterSocket extends ReconnectingSocket {
 export class ViewerSocket extends ReconnectingSocket {
   private readonly handlers: ViewerSocketHandlers;
 
-  constructor(sessionId: string, handlers: ViewerSocketHandlers | ((index: number) => void), rand: () => number = Math.random) {
-    super(`${realtimeBase()}/viewer?session=${sessionId}`, rand);
+  constructor(
+    sessionId: string,
+    handlers: ViewerSocketHandlers | ((index: number) => void),
+    rand: () => number = Math.random,
+    token?: string | null,
+  ) {
+    super(withToken(`${realtimeBase()}/viewer?session=${sessionId}`, token), rand);
     // Backwards-compatible: a bare callback is treated as onSlideChange.
     this.handlers = typeof handlers === "function" ? { onSlideChange: handlers } : handlers;
     this.start();


### PR DESCRIPTION
## 概要
realtime(:8082) / collab(:8081) の WebSocket 接続が `CheckOrigin: true` で誰でも接続できていた問題を解消し、API と同一方式の JWT 検証で参加認可を行う。

## 認可方式（API の middleware/auth.go と同一）
- HMAC 署名(HS256)・`sub` claim 必須。共有秘密 `JWT_SECRET` で検証。
- token は WS ハンドシェイクのクエリ `?token=<accessToken>` で受領（ブラウザ WS は Authorization ヘッダを付けられないため）。collab は y-websocket の `params` 経由。
- **`JWT_SECRET` 未設定時は検証を無効化**（dev / 既存テスト互換）。compose で全サービスに API と同一の secret を配布し、本番相当でも認可を有効化。

## 拒否の挙動
| パス | 方針 | 無token | 不正token |
|---|---|---|---|
| realtime `/presenter` | 認証必須 | 401 | 401 |
| realtime `/viewer` | 公開audience(任意) | 接続可(匿名) | 401 |
| collab `/{room}` | 認証必須 | 401 | 401 |

- CheckOrigin: `ALLOWED_ORIGINS`(カンマ区切り) があれば照合、無ければ全許可(dev)。Origin 無し(非ブラウザ/同一オリジン)は許可。

## スコープ外（次段）
- presentationID 単位の細粒度認可（owner/member 照合）は WS サービスが DB 非依存のため本PR対象外。署名有効性+sub を「認証済み参加」とみなす。将来 API がスコープ付き WS トークン(pid/role claim)を発行して対応予定。
- 複数presenter排他は後続PR(feature/p2-presenter-exclusion)。

## テスト
- Go(realtime/collab): 無/不正tokenで presenter・collab が401、正tokenで接続、viewer匿名OK、secret未設定で全通過、CheckOrigin allowlist。`go build/vet/test -race` 全green。
- web vitest: `withToken` 純関数、PresenterSocket の URL に token 付与。128 tests green。
- `npm run build` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)