### PR TITLE
P2排他: 複数presenterを禁止し2人目を1008で拒否、クライアントに通知

### DIFF
--- a/services/realtime/cmd/realtime/exclusion_test.go
+++ b/services/realtime/cmd/realtime/exclusion_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// resetSessions clears the global session registry so exclusion tests start
+// from a clean slate regardless of test ordering.
+func resetSessions() {
+	sessionsMu.Lock()
+	sessions = make(map[string]*Session)
+	sessionsMu.Unlock()
+}
+
+// TestSecondPresenterRejectedWith1008: with one presenter already connected, a
+// second presenter on the same session is closed with PolicyViolation (1008)
+// and the documented reason, while the first stays connected.
+func TestSecondPresenterRejectedWith1008(t *testing.T) {
+	resetSessions()
+	withAuth(t, authConfig{}) // verification disabled; focus on exclusion
+	srv := authServer()
+	defer srv.Close()
+
+	first, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=excl"), nil)
+	if err != nil {
+		t.Fatalf("first presenter dial: %v", err)
+	}
+	defer first.Close()
+	// Let the server register the first presenter before the second connects.
+	time.Sleep(50 * time.Millisecond)
+
+	second, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=excl"), nil)
+	if err != nil {
+		t.Fatalf("second presenter dial (handshake should still succeed): %v", err)
+	}
+	defer second.Close()
+
+	// The second connection must receive a 1008 close with the reason.
+	var gotCode int
+	var gotReason string
+	second.SetCloseHandler(func(code int, text string) error {
+		gotCode = code
+		gotReason = text
+		return nil
+	})
+	second.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := second.ReadMessage(); err == nil {
+		t.Fatal("expected second presenter to be closed")
+	}
+	if gotCode != websocket.ClosePolicyViolation {
+		t.Fatalf("close code = %d, want %d", gotCode, websocket.ClosePolicyViolation)
+	}
+	if gotReason != "presenter already connected" {
+		t.Fatalf("close reason = %q, want %q", gotReason, "presenter already connected")
+	}
+
+	// The incumbent presenter must still be the session's presenter.
+	sessionsMu.RLock()
+	sess := sessions["excl"]
+	sessionsMu.RUnlock()
+	sess.mu.RLock()
+	stillPresent := sess.presenter != nil
+	sess.mu.RUnlock()
+	if !stillPresent {
+		t.Fatal("incumbent presenter was cleared by the rejected second connection")
+	}
+}
+
+// TestPresenterSlotFreedAfterDisconnect: once the first presenter disconnects,
+// a new presenter can claim the slot.
+func TestPresenterSlotFreedAfterDisconnect(t *testing.T) {
+	resetSessions()
+	withAuth(t, authConfig{})
+	srv := authServer()
+	defer srv.Close()
+
+	first, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=reclaim"), nil)
+	if err != nil {
+		t.Fatalf("first presenter dial: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	first.Close()
+	// Wait for the server-side read loop to observe the close and free the slot.
+	time.Sleep(100 * time.Millisecond)
+
+	second, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/presenter?session=reclaim"), nil)
+	if err != nil {
+		t.Fatalf("replacement presenter dial: %v", err)
+	}
+	defer second.Close()
+
+	// It must NOT be rejected: no close frame should arrive promptly.
+	second.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if _, _, err := second.ReadMessage(); err == nil {
+		t.Fatal("replacement presenter unexpectedly received a frame")
+	} else if ce, ok := err.(*websocket.CloseError); ok && ce.Code == websocket.ClosePolicyViolation {
+		t.Fatal("replacement presenter was rejected though the slot was free")
+	}
+}
+
+// TestExclusionDoesNotAffectViewers: viewers are unaffected by presenter
+// exclusion — multiple viewers coexist.
+func TestExclusionDoesNotAffectViewers(t *testing.T) {
+	resetSessions()
+	withAuth(t, authConfig{})
+	srv := authServer()
+	defer srv.Close()
+
+	for i := 0; i < 3; i++ {
+		v, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL, "/viewer?session=many"), nil)
+		if err != nil {
+			t.Fatalf("viewer %d dial: %v", i, err)
+		}
+		defer v.Close()
+	}
+	time.Sleep(50 * time.Millisecond)
+	sessionsMu.RLock()
+	sess := sessions["many"]
+	sessionsMu.RUnlock()
+	sess.mu.RLock()
+	n := len(sess.viewers)
+	sess.mu.RUnlock()
+	if n != 3 {
+		t.Fatalf("viewer count = %d, want 3", n)
+	}
+}

--- a/services/realtime/cmd/realtime/main.go
+++ b/services/realtime/cmd/realtime/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/joho/godotenv"
@@ -59,12 +60,31 @@ func handlePresenter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sess := getSession(sessionID)
+	// Single-presenter exclusion (first-come wins): atomically claim the
+	// presenter slot. If another presenter is already connected, this second
+	// connection is rejected with a PolicyViolation close (1008) carrying a
+	// reason the client surfaces, then closed without entering the read loop —
+	// so it never clears the incumbent's slot.
 	sess.mu.Lock()
+	if sess.presenter != nil {
+		sess.mu.Unlock()
+		conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "presenter already connected"),
+			time.Now().Add(time.Second),
+		)
+		conn.Close()
+		return
+	}
 	sess.presenter = conn
 	sess.mu.Unlock()
 	defer func() {
 		sess.mu.Lock()
-		sess.presenter = nil
+		// Only relinquish the slot if we still own it (defensive: a future
+		// takeover policy could swap it out from under us).
+		if sess.presenter == conn {
+			sess.presenter = nil
+		}
 		sess.mu.Unlock()
 		conn.Close()
 	}()

--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -5,7 +5,7 @@ import { slidesApi } from "@shared/api/slides";
 import { createCanvas, loadFromJSON, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
 import { playTransition } from "@lib/fabric/animation";
 import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
-import { PresenterSocket } from "@lib/realtime/presenter";
+import { PresenterSocket, type ViewerStatus } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
 export default function PresentPage({ params }: { params: Promise<{ id: string }> }) {
@@ -14,15 +14,19 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   const [slides, setSlides] = useState<Slide[]>([]);
   const [cur, setCur] = useState(0);
   const [elapsed, setElapsed] = useState(0);
+  // "rejected" means another presenter already holds this session (server
+  // enforces a single presenter); we surface a notice instead of reconnecting.
+  const [status, setStatus] = useState<ViewerStatus>("connecting");
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const presenterRef = useRef<PresenterSocket | null>(null);
 
   useEffect(() => {
     if (!accessToken) return;
+    let mounted = true;
     slidesApi.list(accessToken, id).then(r => setSlides(r.items as Slide[]));
-    presenterRef.current = new PresenterSocket(id, accessToken);
-    return () => { presenterRef.current?.destroy(); };
+    presenterRef.current = new PresenterSocket(id, accessToken, (s) => { if (mounted) setStatus(s); });
+    return () => { mounted = false; presenterRef.current?.destroy(); };
   }, [id, accessToken]);
 
   useEffect(() => {
@@ -79,6 +83,11 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
 
   return (
     <div className="flex h-screen bg-gray-900 text-white">
+      {status === "rejected" && (
+        <div className="absolute inset-x-0 top-0 z-10 bg-red-600/90 px-4 py-2 text-center text-sm">
+          既に別の発表者がこのセッションを操作中です。発表者は1人までです。
+        </div>
+      )}
       <div className="flex flex-1 flex-col items-center justify-center p-8">
         <div ref={stageRef} className="shadow-2xl rounded-lg overflow-hidden"><canvas ref={canvasRef} /></div>
         <div className="mt-4 flex items-center gap-6">

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -10,6 +10,9 @@ const STATUS_LABEL: Record<ViewerStatus, string> = {
   connecting: "接続中…",
   connected: "発表者に同期中",
   disconnected: "切断 — 再接続中（手動操作可）",
+  // Viewers are never rejected (the public audience path accepts anonymous
+  // connections); this branch exists only to satisfy the exhaustive Record.
+  rejected: "接続を拒否されました",
 };
 
 export default function ViewPage({ params }: { params: Promise<{ id: string }> }) {

--- a/web/src/lib/realtime/presenter.test.ts
+++ b/web/src/lib/realtime/presenter.test.ts
@@ -53,7 +53,7 @@ class FakeWebSocket {
   static OPEN = 1;
   static instances: FakeWebSocket[] = [];
   onopen: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((e?: { code?: number }) => void) | null = null;
   onerror: (() => void) | null = null;
   onmessage: ((e: { data: unknown }) => void) | null = null;
   readyState = 0;
@@ -181,8 +181,28 @@ describe("PresenterSocket", () => {
     expect(ws.sent).toContain(JSON.stringify({ type: "slide-change", slideIndex: 3 }));
   });
 
+  it("stops reconnecting and reports 'rejected' on a 1008 presenter-taken close", () => {
+    const statuses: ViewerStatus[] = [];
+    new PresenterSocket("s", null, (st) => statuses.push(st), () => 0);
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.onclose?.({ code: 1008 }); // server: presenter already connected
+    expect(statuses).toContain("rejected");
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.instances).toHaveLength(1); // no reconnect after rejection
+  });
+
+  it("still reconnects on a normal (non-1008) drop", () => {
+    new PresenterSocket("s", null, undefined, () => 0);
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.onclose?.({ code: 1006 }); // abnormal closure → transient
+    vi.advanceTimersByTime(500);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
   it("re-publishes the current slide on reconnect so the server snapshot stays accurate", () => {
-    const sock = new PresenterSocket("s", null, () => 0);
+    const sock = new PresenterSocket("s", null, undefined, () => 0);
     const ws1 = FakeWebSocket.instances[0];
     ws1.open();
     sock.sendSlideChange(7);

--- a/web/src/lib/realtime/presenter.ts
+++ b/web/src/lib/realtime/presenter.ts
@@ -1,5 +1,15 @@
-/** Connection lifecycle reported to the UI. */
-export type ViewerStatus = "connecting" | "connected" | "disconnected";
+/**
+ * Connection lifecycle reported to the UI. "rejected" is a terminal state: the
+ * server refused the connection (e.g. a presenter slot is already taken) and we
+ * stop reconnecting, unlike the transient "disconnected".
+ */
+export type ViewerStatus = "connecting" | "connected" | "disconnected" | "rejected";
+
+/**
+ * WebSocket close code the realtime server uses to reject a duplicate presenter
+ * (RFC 6455 PolicyViolation). Matches services/realtime FormatCloseMessage.
+ */
+export const PRESENTER_TAKEN_CODE = 1008;
 
 export interface ViewerSocketHandlers {
   onSlideChange: (index: number) => void;
@@ -84,16 +94,23 @@ class ReconnectingSocket {
       this.onOpen();
     };
     ws.onmessage = (e) => this.onMessage(e.data);
-    ws.onclose = () => this.handleDrop();
+    ws.onclose = (e) => this.handleDrop(e?.code);
     ws.onerror = () => this.handleDrop();
   }
 
-  private handleDrop() {
+  private handleDrop(code?: number) {
     if (this.closedByUs) return;
     // Detach so a duplicate close/error from the same dead socket cannot trigger
     // a second reconnect schedule.
     if (this.ws) {
       this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
+    }
+    // A close the subclass deems terminal (e.g. presenter slot taken) stops the
+    // reconnect loop entirely and reports the fatal status instead.
+    if (code !== undefined && !this.shouldReconnect(code)) {
+      this.closedByUs = true;
+      this.onStatus("rejected");
+      return;
     }
     this.onStatus("disconnected");
     const delay = backoffDelay(this.attempt++, this.rand);
@@ -118,6 +135,13 @@ class ReconnectingSocket {
   protected onOpen(): void {}
   protected onMessage(_data: unknown): void {}
   protected onStatus(_status: ViewerStatus): void {}
+  /**
+   * Whether to reconnect after a close with the given code. Default: always
+   * (transient drop). Subclasses override to treat specific codes as terminal.
+   */
+  protected shouldReconnect(_code: number): boolean {
+    return true;
+  }
 }
 
 /**
@@ -127,15 +151,33 @@ class ReconnectingSocket {
  */
 export class PresenterSocket extends ReconnectingSocket {
   private lastIndex = 0;
+  private readonly onStatusCb?: (status: ViewerStatus) => void;
 
-  constructor(sessionId: string, token?: string | null, rand: () => number = Math.random) {
+  constructor(
+    sessionId: string,
+    token?: string | null,
+    onStatus?: (status: ViewerStatus) => void,
+    rand: () => number = Math.random,
+  ) {
     super(withToken(`${realtimeBase()}/presenter?session=${sessionId}`, token), rand);
+    this.onStatusCb = onStatus;
     this.start();
   }
 
   protected onOpen(): void {
     // Re-publish current position so a freshly (re)connected server snapshots it.
     this.transmit(this.lastIndex);
+  }
+
+  protected onStatus(status: ViewerStatus): void {
+    this.onStatusCb?.(status);
+  }
+
+  // The realtime server enforces a single presenter: a second presenter is
+  // closed with PolicyViolation (1008). That is terminal — do not reconnect,
+  // surface "rejected" so the UI can tell the user someone else is presenting.
+  protected shouldReconnect(code: number): boolean {
+    return code !== PRESENTER_TAKEN_CODE;
   }
 
   sendSlideChange(index: number) {


### PR DESCRIPTION
## 概要
realtime セッションで `sess.presenter` が後勝ちで上書きされ複数 presenter が同時に操作できていた問題を解消。**単一presenter（先着優先）** を強制する。

## サーバ（realtime）
- `handlePresenter`: WS Upgrade 後、session ロック下で presenter スロットを **atomic に check-and-set**。
- 既に presenter がいれば 2人目を `ClosePolicyViolation(1008)` + 理由文字列 `"presenter already connected"` で close し、read loop に入らず即 return。
  - → 拒否された接続が incumbent のスロットを誤って消さない（defer は `sess.presenter == conn` のときだけ解放）。
- 先着 presenter が切断するとスロットが解放され、次の presenter が接続可能。

## クライアント（web）
- `ReconnectingSocket` に `shouldReconnect(code)` フックを追加。close code を `onclose` から受け取る。
- `PresenterSocket`: `1008`(`PRESENTER_TAKEN_CODE`) を **terminal** 扱いにし、再接続せず status `"rejected"` を通知。
- present 画面: `rejected` 時に「既に別の発表者がこのセッションを操作中です。発表者は1人までです。」バナーを表示。
- viewer / 通常の切断(1006等)は従来どおり自動再接続を継続。

## テスト
- Go(realtime): 2人目 presenter が 1008+理由で close され incumbent が維持される / 1人目切断後に再取得できる / viewer は排他の影響を受けない。`go build/vet/test -race` 全 green。
- web vitest: 1008 で再接続停止・`rejected` 通知、1006 等では再接続継続。130 tests green。
- `npm run build` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)