### PR TITLE
コメント機能のフロントUIを実装

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -28,6 +28,7 @@ import { StylePanel, TokenPanel, ImagePanel } from "@features/editor/components/
 import { AIPanel } from "@features/ai/components/AIPanel";
 import { RealtimeCoach } from "@features/ai/components/RealtimeCoach";
 import { SpeakerNotesPanel } from "@features/editor/components/SpeakerNotes";
+import { CommentsPanel } from "@features/editor/components/CommentsPanel";
 import type { Slide } from "@shared/types/slide";
 
 type AITab = "ai" | "coach" | null;
@@ -36,7 +37,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { id } = use(params);
   const router = useRouter();
   const { accessToken } = useAuthStore();
-  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas } = useEditorStore();
+  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas, showComments } = useEditorStore();
   const { setSlides, slides } = useSlideStore();
   const [aiTab, setAiTab] = useState<AITab>(null);
   const [title, setTitle] = useState("Untitled");
@@ -155,6 +156,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
               {aiTab === "ai" ? <AIPanel /> : <RealtimeCoach />}
             </aside>
           )}
+          {showComments && <CommentsPanel />}
         </div>
       )}
 

--- a/web/src/features/editor/components/CommentsPanel/CommentsPanel.tsx
+++ b/web/src/features/editor/components/CommentsPanel/CommentsPanel.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useState, useEffect, useCallback } from "react";
+import { useEditorStore } from "../../stores/editorStore";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { commentsApi } from "@shared/api/comments";
+import type { Comment } from "@shared/types/comment";
+
+// Presentation-level comments. Slide/object anchoring is intentionally out of
+// scope for this panel and tracked as a follow-up PR.
+export function CommentsPanel() {
+  const presentationId = useEditorStore((s) => s.presentationId);
+  const { accessToken } = useAuthStore();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [body, setBody] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [posting, setPosting] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!accessToken || !presentationId) return;
+    setLoading(true);
+    try {
+      const res = await commentsApi.list(accessToken, presentationId);
+      setComments(res.items ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, presentationId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const submit = useCallback(async () => {
+    const text = body.trim();
+    if (!text || !accessToken || !presentationId || posting) return;
+    setPosting(true);
+    try {
+      const created = await commentsApi.create(accessToken, presentationId, { body: text });
+      setComments((prev) => [...prev, created]);
+      setBody("");
+    } finally {
+      setPosting(false);
+    }
+  }, [body, accessToken, presentationId, posting]);
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-l bg-white">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <p className="text-xs font-semibold text-gray-600">コメント</p>
+        {loading && <span className="text-xs text-gray-400">読み込み中...</span>}
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto p-3">
+        {comments.length === 0 && !loading ? (
+          <p className="text-xs text-gray-400">まだコメントはありません。</p>
+        ) : (
+          comments.map((c) => (
+            <div key={c.ID} className="rounded-lg border bg-gray-50 p-2">
+              <div className="mb-0.5 flex items-center justify-between">
+                <span className="text-xs font-medium text-gray-700">
+                  {c.AuthorName || "匿名"}
+                </span>
+                <span className="text-[10px] text-gray-400">
+                  {c.CreatedAt ? new Date(c.CreatedAt).toLocaleString() : ""}
+                </span>
+              </div>
+              <p className="whitespace-pre-wrap break-words text-xs text-gray-700">
+                {c.Body}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="border-t p-3">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="コメントを追加..."
+          className="w-full h-16 resize-none rounded-lg border p-2 text-xs text-gray-700 focus:border-blue-400 focus:outline-none"
+        />
+        <button
+          onClick={submit}
+          disabled={!body.trim() || posting}
+          className="mt-2 w-full rounded-lg bg-blue-600 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {posting ? "投稿中..." : "投稿"}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/features/editor/components/CommentsPanel/index.ts
+++ b/web/src/features/editor/components/CommentsPanel/index.ts
@@ -1,0 +1,1 @@
+export { CommentsPanel } from "./CommentsPanel";

--- a/web/src/features/editor/components/Ribbon/ReviewTab.tsx
+++ b/web/src/features/editor/components/Ribbon/ReviewTab.tsx
@@ -1,10 +1,14 @@
 "use client";
 import { SpellCheck, MessageSquare, Bot } from "lucide-react";
+import { useEditorStore } from "../../stores/editorStore";
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
 
-// No comments API/spell-check backend exists yet, so this tab mirrors
-// PowerPoint's structure with titled present buttons ("次のアップデートで実装").
+// Spell-check / AI proofreading have no backend yet, so those stay as titled
+// "次のアップデートで実装" placeholders. The comment button is wired to the
+// presentation-level comments panel (toggles the side panel).
 export function ReviewTab() {
+  const showComments = useEditorStore((s) => s.showComments);
+  const toggleComments = useEditorStore((s) => s.toggleComments);
   return (
     <div className="flex h-full items-stretch">
       <RibbonGroup label="文章校正">
@@ -17,8 +21,9 @@ export function ReviewTab() {
 
       <RibbonGroup label="コメント">
         <RibbonBigButton
-          icon={<MessageSquare />} label="新しいコメント"
-          title="新しいコメント — 次のアップデートで実装"
+          icon={<MessageSquare />} label="コメント"
+          active={showComments} onClick={toggleComments}
+          title="コメントパネルを開く"
         />
       </RibbonGroup>
       <RibbonDivider />

--- a/web/src/features/editor/stores/editorStore.ts
+++ b/web/src/features/editor/stores/editorStore.ts
@@ -14,6 +14,7 @@ interface EditorState {
   notesVisible: boolean;
   viewMode: ViewMode;
   showRuler: boolean;
+  showComments: boolean;
 
   setCanvas: (canvas: Canvas | null) => void;
   setActiveTool: (tool: EditorTool) => void;
@@ -26,6 +27,8 @@ interface EditorState {
   setViewMode: (mode: ViewMode) => void;
   toggleRuler: () => void;
   setShowRuler: (show: boolean) => void;
+  toggleComments: () => void;
+  setShowComments: (show: boolean) => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -38,6 +41,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
   notesVisible: true,
   viewMode: "normal",
   showRuler: false,
+  showComments: false,
 
   setCanvas: (canvas) => set({ canvas }),
   setActiveTool: (activeTool) => set({ activeTool }),
@@ -50,4 +54,6 @@ export const useEditorStore = create<EditorState>()((set) => ({
   setViewMode: (viewMode) => set({ viewMode }),
   toggleRuler: () => set((s) => ({ showRuler: !s.showRuler })),
   setShowRuler: (showRuler) => set({ showRuler }),
+  toggleComments: () => set((s) => ({ showComments: !s.showComments })),
+  setShowComments: (showComments) => set({ showComments }),
 }));

--- a/web/src/shared/api/comments.test.ts
+++ b/web/src/shared/api/comments.test.ts
@@ -1,0 +1,46 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const { get, post } = vi.hoisted(() => ({
+  get: vi.fn(() => Promise.resolve({ items: [] })),
+  post: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock("./api-client", () => ({
+  apiClient: { get, post },
+}));
+
+import { commentsApi } from "./comments";
+
+const TOKEN = "tok-abc";
+const PID = "pres-1";
+const auth = { headers: { Authorization: `Bearer ${TOKEN}` } };
+
+describe("commentsApi", () => {
+  beforeEach(() => {
+    get.mockClear();
+    post.mockClear();
+  });
+
+  it("list calls GET /presentations/:pid/comments with auth header", () => {
+    commentsApi.list(TOKEN, PID);
+    expect(get).toHaveBeenCalledWith(`/presentations/${PID}/comments`, auth);
+  });
+
+  it("create calls POST with {body} and auth header", () => {
+    commentsApi.create(TOKEN, PID, { body: "hello" });
+    expect(post).toHaveBeenCalledWith(
+      `/presentations/${PID}/comments`,
+      { body: "hello" },
+      auth
+    );
+  });
+
+  it("create forwards an optional slideId in the body", () => {
+    commentsApi.create(TOKEN, PID, { body: "hi", slideId: "slide-9" });
+    expect(post).toHaveBeenCalledWith(
+      `/presentations/${PID}/comments`,
+      { body: "hi", slideId: "slide-9" },
+      auth
+    );
+  });
+});

--- a/web/src/shared/api/comments.ts
+++ b/web/src/shared/api/comments.ts
@@ -1,0 +1,18 @@
+import { apiClient } from "./api-client";
+import type { Comment, CreateCommentInput } from "@shared/types/comment";
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export const commentsApi = {
+  list: (token: string, presentationId: string) =>
+    apiClient.get<{ items: Comment[] }>(`/presentations/${presentationId}/comments`, {
+      headers: authHeaders(token),
+    }),
+
+  create: (token: string, presentationId: string, input: CreateCommentInput) =>
+    apiClient.post<Comment>(`/presentations/${presentationId}/comments`, input, {
+      headers: authHeaders(token),
+    }),
+};

--- a/web/src/shared/types/comment.ts
+++ b/web/src/shared/types/comment.ts
@@ -1,0 +1,19 @@
+// Mirrors the backend `postgres.CommentModel` returned by
+// GET/POST /presentations/:id/comments. That struct carries no JSON tags, so
+// Go serializes the Go field names verbatim (PascalCase) — keep these keys
+// aligned with services/api/internal/infrastructure/postgres/models.go.
+export interface Comment {
+  ID: string;
+  PresentationID: string;
+  SlideID: string;
+  AuthorID: string;
+  AuthorName: string;
+  Body: string;
+  CreatedAt: string;
+}
+
+// Request body for creating a comment (decoded by HandleCreate, json-tagged).
+export interface CreateCommentInput {
+  body: string;
+  slideId?: string;
+}


### PR DESCRIPTION
## 概要
レビュー用コメント機能のフロント UI を実装。バックエンド（`GET/POST /presentations/{id}/comments`）は既存・完備のため、**UI とその配線のみを追加**する。

- **presentation 単位のコメント**を対象（特定スライド/オブジェクトへの紐付けは**将来 PR に切り出し**、本 PR ではスコープ外）。

## 変更内容
### 1. API クライアント・型・テスト
- `web/src/shared/types/comment.ts` — backend `CommentModel` に対応する型。`CommentModel` は json タグを持たないため、Go のフィールド名がそのまま（PascalCase）でシリアライズされる点に合わせている。
- `web/src/shared/api/comments.ts` — `commentsApi.list` / `create`。`members.ts` と同じ流儀で既存 `apiClient`（トークン自動リフレッシュ機構）に乗せている。
- `web/src/shared/api/comments.test.ts` — `members.test.ts` を手本に vitest で list/create の呼び出しを検証。

### 2. コメントサイドパネル UI
- `web/src/features/editor/components/CommentsPanel/CommentsPanel.tsx` — 一覧表示＋投稿フォーム。`SpeakerNotesPanel` のパネル構造・スタイルを踏襲。

### 3. 配線
- `editorStore.ts` に `showComments` フラグ（既存 `showRuler` と同じパターン）を追加。
- `ReviewTab.tsx` のスタブ「次のアップデートで実装」ボタンをパネル開閉トグルに置換。
- エディタページ（`editor/[id]/page.tsx`）に `CommentsPanel` をマウント。

## テスト
- `npm run type-check`: pass
- `npm run lint`: 0 errors（既存 warning 6 件のみ、本 PR の追加分には無し）
- `npm test`: 21 files / 133 tests すべて pass（新規 comments.test.ts 3件含む）
- `npm run build`: success

## 残課題（将来 PR）
- 特定スライド/オブジェクトへのコメント紐付け（backend は `SlideID` を受け付け済み。本 PR では送らない）。
- コメントの編集・削除・解決（resolve）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)