### PR TITLE
レイヤー/オブジェクト一覧パネル(Selection Pane)を追加

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -28,6 +28,7 @@ import { StylePanel, TokenPanel, ImagePanel } from "@features/editor/components/
 import { AIPanel } from "@features/ai/components/AIPanel";
 import { RealtimeCoach } from "@features/ai/components/RealtimeCoach";
 import { SpeakerNotesPanel } from "@features/editor/components/SpeakerNotes";
+import { LayersPanel } from "@features/editor/components/LayersPanel";
 import type { Slide } from "@shared/types/slide";
 
 type AITab = "ai" | "coach" | null;
@@ -36,14 +37,14 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { id } = use(params);
   const router = useRouter();
   const { accessToken } = useAuthStore();
-  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas } = useEditorStore();
+  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas, showLayers } = useEditorStore();
   const { setSlides, slides } = useSlideStore();
   const [aiTab, setAiTab] = useState<AITab>(null);
   const [title, setTitle] = useState("Untitled");
 
   // Open the collaboration room and bind the active slide's canvas to it.
   const { provider, doc } = useCollaboration(id ?? null, accessToken);
-  useObjectBinding(doc, canvas, activeSlideId);
+  const { moveObject } = useObjectBinding(doc, canvas, activeSlideId);
   // Live presence: publish/read other editors' slide + selection (ephemeral).
   const { peers } = usePresence(provider, canvas, activeSlideId);
   // Collaborative slide-list structure (add / remove / move) + JSONB projection.
@@ -145,6 +146,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
             </div>
             {notesVisible && <SpeakerNotesPanel />}
           </main>
+          {showLayers && <LayersPanel moveObject={moveObject} />}
           <aside className="flex w-56 shrink-0 flex-col border-l bg-white overflow-y-auto">
             <StylePanel />
             <TokenPanel />

--- a/web/src/features/editor/components/LayersPanel/LayersPanel.tsx
+++ b/web/src/features/editor/components/LayersPanel/LayersPanel.tsx
@@ -1,0 +1,184 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { Canvas, FabricObject } from "fabric";
+import {
+  Type,
+  Square,
+  Circle,
+  Image as ImageIcon,
+  Minus,
+  Pencil,
+  Layers,
+  type LucideIcon,
+} from "lucide-react";
+import { useEditorStore } from "../../stores/editorStore";
+import { ensureObjectId } from "@lib/fabric/objectId";
+
+/** One row of the selection pane: a stable id plus what we render for it. */
+interface LayerRow {
+  id: string;
+  label: string;
+  Icon: LucideIcon;
+}
+
+const ICONS: Record<string, LucideIcon> = {
+  textbox: Type,
+  "i-text": Type,
+  text: Type,
+  rect: Square,
+  triangle: Square,
+  circle: Circle,
+  ellipse: Circle,
+  image: ImageIcon,
+  line: Minus,
+  path: Pencil,
+};
+
+const LABELS: Record<string, string> = {
+  textbox: "テキスト",
+  "i-text": "テキスト",
+  text: "テキスト",
+  rect: "四角形",
+  triangle: "三角形",
+  circle: "円",
+  ellipse: "楕円",
+  image: "画像",
+  line: "線",
+  path: "フリーハンド",
+  group: "グループ",
+  "active-selection": "選択範囲",
+};
+
+function describe(obj: FabricObject): { label: string; Icon: LucideIcon } {
+  const type = (obj.type ?? "object").toLowerCase();
+  return { label: LABELS[type] ?? type, Icon: ICONS[type] ?? Layers };
+}
+
+/**
+ * Reads the canvas's z-ordered object list into display rows. Fabric stores
+ * index 0 at the *back*; the panel lists front-most first (Figma/PowerPoint
+ * convention), so we reverse.
+ */
+function readRows(canvas: Canvas): LayerRow[] {
+  return canvas
+    .getObjects()
+    .map((obj) => {
+      const { label, Icon } = describe(obj);
+      return { id: ensureObjectId(obj), label, Icon };
+    })
+    .reverse();
+}
+
+/**
+ * Selection pane (layers / object list) for the active slide.
+ *
+ * Lists the active slide's Fabric objects front-to-back, keyed by their stable
+ * round-tripped id (commit #96). Clicking a row selects that object on the
+ * canvas; dragging a row reorders z-index. Reordering is delegated to
+ * `moveObject` (see {@link useObjectBinding}) so the change flows through the
+ * Yjs binding and stays consistent across collaborators.
+ *
+ * Visibility / lock toggles and group nesting are intentionally out of scope
+ * (future PR).
+ */
+export function LayersPanel({
+  moveObject,
+}: {
+  moveObject: (id: string, toIndex: number) => void;
+}) {
+  const canvas = useEditorStore((s) => s.canvas);
+  const [rows, setRows] = useState<LayerRow[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [dragId, setDragId] = useState<string | null>(null);
+
+  // Track the canvas object list and current selection.
+  useEffect(() => {
+    if (!canvas) {
+      setRows([]);
+      setActiveId(null);
+      return;
+    }
+    const refresh = () => setRows(readRows(canvas));
+    const syncSelection = () => {
+      const active = canvas.getActiveObject() as (FabricObject & { id?: string }) | null;
+      setActiveId(active?.id ?? null);
+    };
+    refresh();
+    syncSelection();
+
+    const events = [
+      "object:added",
+      "object:removed",
+      "object:modified",
+      "selection:created",
+      "selection:updated",
+      "selection:cleared",
+    ] as const;
+    const onAny = () => {
+      refresh();
+      syncSelection();
+    };
+    events.forEach((e) => canvas.on(e, onAny));
+    return () => events.forEach((e) => canvas.off(e, onAny));
+  }, [canvas]);
+
+  function select(id: string) {
+    if (!canvas) return;
+    const obj = canvas
+      .getObjects()
+      .find((o) => (o as FabricObject & { id?: string }).id === id);
+    if (!obj) return;
+    canvas.setActiveObject(obj);
+    canvas.requestRenderAll();
+    setActiveId(id);
+  }
+
+  function onDrop(targetId: string) {
+    if (!dragId || dragId === targetId || !canvas) {
+      setDragId(null);
+      return;
+    }
+    // Rows are front-first; translate the drop target to a Fabric (back-first)
+    // z-index by mirroring across the list length.
+    const total = canvas.getObjects().length;
+    const targetRow = rows.findIndex((r) => r.id === targetId);
+    const zIndex = total - 1 - targetRow;
+    moveObject(dragId, zIndex);
+    setDragId(null);
+  }
+
+  if (!canvas) return null;
+
+  return (
+    <div className="flex h-full w-56 shrink-0 flex-col border-l border-border bg-surface">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-xs font-semibold text-content-secondary">
+        <Layers className="h-3.5 w-3.5" />
+        レイヤー
+      </div>
+      <div className="flex-1 overflow-y-auto py-1">
+        {rows.length === 0 ? (
+          <p className="px-3 py-2 text-xs text-content-tertiary">オブジェクトがありません</p>
+        ) : (
+          rows.map(({ id, label, Icon }) => (
+            <div
+              key={id}
+              draggable
+              onDragStart={() => setDragId(id)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => onDrop(id)}
+              onClick={() => select(id)}
+              className={`flex cursor-pointer items-center gap-2 px-3 py-1.5 text-xs transition-colors ${
+                id === activeId
+                  ? "bg-primary-100 text-primary-700"
+                  : "text-content-secondary hover:bg-surface-muted"
+              } ${dragId === id ? "opacity-50" : ""}`}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{label}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/editor/components/LayersPanel/index.ts
+++ b/web/src/features/editor/components/LayersPanel/index.ts
@@ -1,0 +1,1 @@
+export { LayersPanel } from "./LayersPanel";

--- a/web/src/features/editor/components/Ribbon/ViewTab.tsx
+++ b/web/src/features/editor/components/Ribbon/ViewTab.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { useRef, useState } from "react";
-import { Monitor, Grid3x3, LayoutGrid, Ruler, Magnet, Maximize, FileText } from "lucide-react";
+import { Monitor, Grid3x3, LayoutGrid, Ruler, Magnet, Maximize, FileText, Layers } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { toggleGrid, enableSnap } from "@lib/fabric/grid";
 import { fitToContainer } from "@lib/fabric/canvas";
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
 
 export function ViewTab() {
-  const { canvas, setZoom, notesVisible, toggleNotes, viewMode, setViewMode, showRuler, toggleRuler } = useEditorStore();
+  const { canvas, setZoom, notesVisible, toggleNotes, viewMode, setViewMode, showRuler, toggleRuler, showLayers, toggleLayers } = useEditorStore();
   const [grid, setGrid] = useState(false);
   const [snap, setSnap] = useState(false);
   const snapEnabled = useRef(false);
@@ -61,6 +61,7 @@ export function ViewTab() {
         <RibbonBigButton icon={<Grid3x3 />} label="グリッド線" active={grid} onClick={onToggleGrid} />
         <RibbonBigButton icon={<Magnet />} label="スナップ" active={snap} onClick={onToggleSnap} />
         <RibbonBigButton icon={<Ruler />} label="ルーラー" active={showRuler} onClick={toggleRuler} title="ルーラー" />
+        <RibbonBigButton icon={<Layers />} label="レイヤー" active={showLayers} onClick={toggleLayers} title="レイヤー（オブジェクト一覧）" />
         <RibbonBigButton icon={<FileText />} label="ノート" active={notesVisible} onClick={toggleNotes} title="ノート" />
       </RibbonGroup>
       <RibbonDivider />

--- a/web/src/features/editor/hooks/useObjectBinding.ts
+++ b/web/src/features/editor/hooks/useObjectBinding.ts
@@ -1,10 +1,20 @@
 "use client";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { Canvas, FabricObject } from "fabric";
 import * as Y from "yjs";
 import { getSlides, SLIDE_FIELDS, type YObjectMap } from "@lib/collab/schema";
 import { ObjectBinding, type ObjectJSON } from "@lib/collab/binding";
 import { FabricCanvasAdapter } from "@lib/collab/fabricAdapter";
+import { findObjectById } from "@lib/fabric/objectId";
+
+/** Restack a Fabric object to an absolute z-index, keeping the canvas in sync. */
+function restackFabric(canvas: Canvas, id: string, toIndex: number): void {
+  const obj = findObjectById(canvas, id);
+  if (!obj) return;
+  const max = canvas.getObjects().length - 1;
+  canvas.moveObjectTo(obj, Math.max(0, Math.min(toIndex, max)));
+  canvas.requestRenderAll();
+}
 
 /**
  * Wires the active slide's Fabric canvas to its `objects` Y.Array, both ways.
@@ -13,12 +23,20 @@ import { FabricCanvasAdapter } from "@lib/collab/fabricAdapter";
  * mutation events are routed to the binding (Fabric -> Yjs); the binding's own
  * observer pushes remote edits onto the canvas (Yjs -> Fabric). Loop prevention
  * is handled inside {@link ObjectBinding} (origin tag + re-entrancy guard).
+ *
+ * Returns a `moveObject(id, toIndex)` callback used by the layers panel to change
+ * z-order. It mutates the doc through the binding (so collaborators stay in sync;
+ * the Y.Array order *is* the z-order) and restacks the local Fabric canvas to
+ * match, since local-origin writes do not bounce back through the observer.
  */
 export function useObjectBinding(
   doc: Y.Doc | null,
   canvas: Canvas | null,
   activeSlideId: string | null,
 ) {
+  const bindingRef = useRef<ObjectBinding | null>(null);
+  const canvasRef = useRef<Canvas | null>(null);
+
   useEffect(() => {
     if (!doc || !canvas || !activeSlideId) return;
 
@@ -32,6 +50,8 @@ export function useObjectBinding(
 
     const adapter = new FabricCanvasAdapter(canvas);
     const binding = new ObjectBinding(doc, objects, adapter);
+    bindingRef.current = binding;
+    canvasRef.current = canvas;
     binding.observe();
     // Seed the canvas from whatever the doc already holds for this slide.
     binding.reconcileToCanvas();
@@ -54,6 +74,15 @@ export function useObjectBinding(
       canvas.off("object:modified", onModified);
       canvas.off("object:removed", onRemoved);
       binding.unobserve();
+      bindingRef.current = null;
+      canvasRef.current = null;
     };
   }, [doc, canvas, activeSlideId]);
+
+  const moveObject = useCallback((id: string, toIndex: number) => {
+    bindingRef.current?.moveObject(id, toIndex);
+    if (canvasRef.current) restackFabric(canvasRef.current, id, toIndex);
+  }, []);
+
+  return { moveObject };
 }

--- a/web/src/features/editor/stores/editorStore.ts
+++ b/web/src/features/editor/stores/editorStore.ts
@@ -14,6 +14,7 @@ interface EditorState {
   notesVisible: boolean;
   viewMode: ViewMode;
   showRuler: boolean;
+  showLayers: boolean;
 
   setCanvas: (canvas: Canvas | null) => void;
   setActiveTool: (tool: EditorTool) => void;
@@ -26,6 +27,8 @@ interface EditorState {
   setViewMode: (mode: ViewMode) => void;
   toggleRuler: () => void;
   setShowRuler: (show: boolean) => void;
+  toggleLayers: () => void;
+  setShowLayers: (show: boolean) => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -38,6 +41,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
   notesVisible: true,
   viewMode: "normal",
   showRuler: false,
+  showLayers: false,
 
   setCanvas: (canvas) => set({ canvas }),
   setActiveTool: (activeTool) => set({ activeTool }),
@@ -50,4 +54,6 @@ export const useEditorStore = create<EditorState>()((set) => ({
   setViewMode: (viewMode) => set({ viewMode }),
   toggleRuler: () => set((s) => ({ showRuler: !s.showRuler })),
   setShowRuler: (showRuler) => set({ showRuler }),
+  toggleLayers: () => set((s) => ({ showLayers: !s.showLayers })),
+  setShowLayers: (showLayers) => set({ showLayers }),
 }));

--- a/web/src/lib/collab/binding.test.ts
+++ b/web/src/lib/collab/binding.test.ts
@@ -125,6 +125,56 @@ describe("ObjectBinding: Fabric -> Yjs", () => {
   });
 });
 
+describe("ObjectBinding: z-order (moveObject)", () => {
+  let doc: Y.Doc;
+  let objects: Y.Array<YObjectMap>;
+  let binding: ObjectBinding;
+
+  beforeEach(() => {
+    doc = new Y.Doc();
+    const slide = seedSlide(doc, [
+      { id: "a", type: "rect" },
+      { id: "b", type: "circle" },
+      { id: "c", type: "textbox" },
+    ]);
+    objects = objectsArray(slide);
+    binding = new ObjectBinding(doc, objects, new FakeCanvas());
+  });
+
+  const ids = () => objects.map((m) => m.get("id"));
+
+  it("moves an object to a later z-index, preserving its props", () => {
+    doc.transact(() => objects.get(0).set("left", 7));
+    binding.moveObject("a", 2);
+    expect(ids()).toEqual(["b", "c", "a"]);
+    // The cloned Y.Map keeps the moved object's properties.
+    expect(objects.get(2).get("left")).toBe(7);
+  });
+
+  it("moves an object to an earlier z-index", () => {
+    binding.moveObject("c", 0);
+    expect(ids()).toEqual(["c", "a", "b"]);
+  });
+
+  it("clamps an out-of-range target index", () => {
+    binding.moveObject("a", 99);
+    expect(ids()).toEqual(["b", "c", "a"]);
+  });
+
+  it("is a no-op for an unknown id or an unchanged position", () => {
+    binding.moveObject("zzz", 0);
+    binding.moveObject("a", 0);
+    expect(ids()).toEqual(["a", "b", "c"]);
+  });
+
+  it("tags the reorder with LOCAL_ORIGIN so it does not bounce back", () => {
+    const origins: unknown[] = [];
+    doc.on("afterTransaction", (txn) => origins.push(txn.origin));
+    binding.moveObject("a", 2);
+    expect(origins).toContain(LOCAL_ORIGIN);
+  });
+});
+
 describe("ObjectBinding: Yjs -> Fabric", () => {
   it("reconciles a remote property patch onto the canvas", () => {
     const doc = new Y.Doc();

--- a/web/src/lib/collab/binding.ts
+++ b/web/src/lib/collab/binding.ts
@@ -142,6 +142,28 @@ export class ObjectBinding {
     }, LOCAL_ORIGIN);
   }
 
+  /**
+   * Reorder an object within the slide (z-order). The Y.Array order *is* the
+   * z-order — {@link reconcileToCanvas} re-adds objects in array index order —
+   * so reordering must mutate the array, not just the Fabric stack. We detach +
+   * clone the Y.Map (a Y type cannot live in two places) and re-insert it at
+   * `toIndex`, mirroring {@link SlideStructureBinding.moveSlide}. The write runs
+   * under {@link LOCAL_ORIGIN} so it propagates to collaborators without bouncing
+   * back into our own canvas; the caller restacks Fabric locally to match.
+   */
+  moveObject(id: string, toIndex: number): void {
+    if (this.applyingRemote) return;
+    this.doc.transact(() => {
+      const from = this.indexOfId(id);
+      if (from === -1) return;
+      const dest = Math.max(0, Math.min(toIndex, this.objects.length - 1));
+      if (from === dest) return;
+      const clone = objectToYMap(this.objects.get(from).toJSON());
+      this.objects.delete(from, 1);
+      this.objects.insert(dest, [clone]);
+    }, LOCAL_ORIGIN);
+  }
+
   // ---- Yjs -> Fabric ------------------------------------------------------
 
   /**


### PR DESCRIPTION
## 概要

Canva / Figma / PowerPoint 共通の基本機能である **レイヤー/オブジェクト一覧パネル（Selection Pane）** を実装しました。現在のスライドの Fabric オブジェクトを一覧表示し、行クリックで選択、ドラッグで重なり順（z順）の入れ替えができます。

View リボンタブの「レイヤー」トグルで開閉します（既存の「ルーラー」と同じパターン）。

## 変更点

| ファイル | 役割 |
|---|---|
| `LayersPanel/LayersPanel.tsx` | 新規。スライドのオブジェクトを前面→背面の順に一覧表示。安定ID（commit #96 でround-trip対応済み）を行のキーに使用。クリックで canvas selection と同期、ドラッグで z順入れ替え |
| `LayersPanel/index.ts` | 新規。バレル |
| `lib/collab/binding.ts` | `ObjectBinding.moveObject(id, toIndex)` を追加 |
| `hooks/useObjectBinding.ts` | `moveObject` コールバックを公開（Yjs + ローカルFabricの両方を更新） |
| `stores/editorStore.ts` | `showLayers` フラグ + `toggleLayers` を追加（`showRuler` と同パターン） |
| `Ribbon/ViewTab.tsx` | View タブにレイヤートグルボタンを配線 |
| `editor/[id]/page.tsx` | `showLayers` 時にパネルをマウント |
| `lib/collab/binding.test.ts` | `moveObject` のテスト5件を追加 |

## 【重要】Yjsバインディング経由でz順を同期させた根拠（共同編集でズレない）

ADR-0011 の二層モデル（Yjs doc = 真実源 / slides.content JSONB = 投影）に従い、z順変更は **必ず Yjs doc を経由** させています。

- `reconcileToCanvas` は `objects` Y.Array を **配列インデックス順** で canvas に積み直す。つまり **Y.Array の順序そのものが z順** である
- Fabric の `bringObjectForward` 等は canvas 内部スタックを並べ替えるだけで `object:modified` 等のバインディングイベントを **発火しない** → 既存イベント経路では z順が Yjs に伝播しない
- そこで `ObjectBinding.moveObject(id, toIndex)` を追加。Y.Map を clone + 再挿入で Y.Array を並べ替え、`LOCAL_ORIGIN` タグ付きトランザクションで実行（既存 `SlideStructureBinding.moveSlide` と同じ手法）。これにより並べ替えが他参加者へ伝播し、かつ自分の observer には跳ね返らない
- ローカルユーザー向けには `useObjectBinding` 側で Fabric canvas を `moveObjectTo` で同じ順に積み直し、即時反映する

→ 共同編集者間で z順がズレない。直接 Fabric だけ操作する経路は使っていない。

## 将来PRに分離した項目

- 可視（visible）/ ロック（lock）トグル
- グループ/ネスト表示

（200行死守のため意図的にスコープ外）

## テスト/lint/build

- `npm run type-check`: パス
- `npm run lint`: 0 errors（既存ファイルの warning 6件のみ、本PR分は0）
- `npm run test`: 135 passed（新規 moveObject テスト5件含む）
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)