### PR TITLE
エディタ内メンバー/権限パネルを追加

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -30,6 +30,7 @@ import { RealtimeCoach } from "@features/ai/components/RealtimeCoach";
 import { SpeakerNotesPanel } from "@features/editor/components/SpeakerNotes";
 import { LayersPanel } from "@features/editor/components/LayersPanel";
 import { CommentsPanel } from "@features/editor/components/CommentsPanel";
+import { MembersPanel } from "@features/editor/components/MembersPanel";
 import type { Slide } from "@shared/types/slide";
 
 type AITab = "ai" | "coach" | null;
@@ -38,7 +39,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { id } = use(params);
   const router = useRouter();
   const { accessToken } = useAuthStore();
-  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas, showLayers, showComments } = useEditorStore();
+  const { setPresentationId, setActiveSlide, activeTool, notesVisible, viewMode, activeSlideId, canvas, showLayers, showComments, showMembers } = useEditorStore();
   const { setSlides, slides } = useSlideStore();
   const [aiTab, setAiTab] = useState<AITab>(null);
   const [title, setTitle] = useState("Untitled");
@@ -159,6 +160,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
             </aside>
           )}
           {showComments && <CommentsPanel />}
+          {showMembers && <MembersPanel peers={peers} />}
         </div>
       )}
 

--- a/web/src/features/editor/components/MembersPanel/MembersPanel.tsx
+++ b/web/src/features/editor/components/MembersPanel/MembersPanel.tsx
@@ -1,0 +1,141 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { useEditorStore } from "../../stores/editorStore";
+import { useAuthStore } from "@features/dashboard/stores/authStore";
+import { membersApi, type Member, type MemberRole } from "@shared/api/members";
+import type { RemotePresence } from "@lib/collab/presence";
+import { isMemberOnline } from "./presenceMatch";
+
+const ROLE_LABELS: Record<MemberRole, string> = {
+  owner: "オーナー",
+  editor: "編集者",
+  viewer: "閲覧者",
+};
+
+const ROLE_BADGE: Record<MemberRole, string> = {
+  owner: "bg-purple-100 text-purple-700",
+  editor: "bg-blue-100 text-blue-700",
+  viewer: "bg-gray-100 text-gray-600",
+};
+
+/**
+ * In-editor roster: lists collaborators with their role (editable for
+ * non-owners) and a live online/offline dot derived from the presence peers.
+ * Mirrors the side-panel shape of {@link CommentsPanel}; role changes go
+ * through the same `membersApi` the dashboard ShareModal uses (JWT via
+ * `apiClient`). Read-only viewing of the roster degrades gracefully when the
+ * presentation has not been shared yet (empty list).
+ */
+export function MembersPanel({ peers }: { peers: RemotePresence[] }) {
+  const presentationId = useEditorStore((s) => s.presentationId);
+  const { accessToken } = useAuthStore();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!accessToken || !presentationId) return;
+    setLoading(true);
+    try {
+      const res = await membersApi.list(accessToken, presentationId);
+      setMembers(res.items ?? []);
+    } catch {
+      /* not yet shared — an empty roster is fine */
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, presentationId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const changeRole = useCallback(
+    async (member: Member, role: MemberRole) => {
+      if (!accessToken || !presentationId || role === "owner") return;
+      const prev = member.role;
+      // Optimistic: reflect immediately, roll back if the request fails.
+      setMembers((ms) => ms.map((m) => (m.userId === member.userId ? { ...m, role } : m)));
+      try {
+        await membersApi.updateRole(accessToken, presentationId, member.userId, role);
+      } catch {
+        setMembers((ms) =>
+          ms.map((m) => (m.userId === member.userId ? { ...m, role: prev } : m)),
+        );
+      }
+    },
+    [accessToken, presentationId],
+  );
+
+  const onlineCount = members.filter((m) => isMemberOnline(m, peers)).length;
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-l bg-white">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <p className="text-xs font-semibold text-gray-600">メンバー ({members.length})</p>
+        {loading ? (
+          <span className="text-xs text-gray-400">読み込み中...</span>
+        ) : (
+          <span className="text-[10px] text-gray-400">{onlineCount} 人がオンライン</span>
+        )}
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto p-3">
+        {members.length === 0 && !loading ? (
+          <p className="text-xs text-gray-400">まだ共有されていません。</p>
+        ) : (
+          members.map((member) => {
+            const online = isMemberOnline(member, peers);
+            return (
+              <div
+                key={member.userId}
+                className="flex items-center gap-2 rounded-lg border bg-gray-50 p-2"
+              >
+                {/* Avatar with online indicator */}
+                <div className="relative shrink-0">
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">
+                    {(member.displayName || member.email).charAt(0).toUpperCase()}
+                  </div>
+                  <span
+                    aria-label={online ? "オンライン" : "オフライン"}
+                    className={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-white ${
+                      online ? "bg-green-500" : "bg-gray-300"
+                    }`}
+                  />
+                </div>
+
+                {/* Name / email */}
+                <div className="min-w-0 flex-1">
+                  {member.displayName && (
+                    <p className="truncate text-xs font-medium text-gray-800">
+                      {member.displayName}
+                    </p>
+                  )}
+                  <p className="truncate text-[10px] text-gray-500">{member.email}</p>
+                </div>
+
+                {/* Role */}
+                {member.role === "owner" ? (
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ROLE_BADGE[member.role]}`}
+                  >
+                    {ROLE_LABELS[member.role]}
+                  </span>
+                ) : (
+                  <select
+                    aria-label={`${member.displayName || member.email} の役割`}
+                    value={member.role}
+                    onChange={(e) => changeRole(member, e.target.value as MemberRole)}
+                    className="shrink-0 rounded border px-1 py-0.5 text-[10px] text-gray-700 focus:border-blue-400 focus:outline-none"
+                  >
+                    <option value="viewer">閲覧者</option>
+                    <option value="editor">編集者</option>
+                  </select>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/web/src/features/editor/components/MembersPanel/index.ts
+++ b/web/src/features/editor/components/MembersPanel/index.ts
@@ -1,0 +1,1 @@
+export { MembersPanel } from "./MembersPanel";

--- a/web/src/features/editor/components/MembersPanel/presenceMatch.test.ts
+++ b/web/src/features/editor/components/MembersPanel/presenceMatch.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import type { RemotePresence } from "@lib/collab/presence";
+import type { Member } from "@shared/api/members";
+import { isMemberOnline, onlineNames } from "./presenceMatch";
+
+function member(over: Partial<Member>): Member {
+  return {
+    id: "m1",
+    presentationId: "p1",
+    userId: "u1",
+    email: "alice@example.com",
+    displayName: "Alice",
+    role: "editor",
+    createdAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+function peer(name: string): RemotePresence {
+  return { clientId: 1, name, color: "#000", slideId: null, selectedId: null, cursor: null };
+}
+
+describe("presenceMatch", () => {
+  it("matches a member to a peer by display name", () => {
+    expect(isMemberOnline(member({ displayName: "Alice" }), [peer("Alice")])).toBe(true);
+  });
+
+  it("matches case-insensitively and ignores surrounding whitespace", () => {
+    expect(isMemberOnline(member({ displayName: "Alice" }), [peer("  alice ")])).toBe(true);
+  });
+
+  it("falls back to the email local part when display name is empty", () => {
+    const m = member({ displayName: "", email: "bob@example.com" });
+    expect(isMemberOnline(m, [peer("bob")])).toBe(true);
+  });
+
+  it("reports offline when no peer matches", () => {
+    expect(isMemberOnline(member({ displayName: "Alice" }), [peer("Carol")])).toBe(false);
+  });
+
+  it("reports offline with no peers", () => {
+    expect(isMemberOnline(member({ displayName: "Alice" }), [])).toBe(false);
+  });
+
+  it("onlineNames normalizes every peer name", () => {
+    const names = onlineNames([peer(" Alice "), peer("BOB")]);
+    expect(names.has("alice")).toBe(true);
+    expect(names.has("bob")).toBe(true);
+  });
+});

--- a/web/src/features/editor/components/MembersPanel/presenceMatch.ts
+++ b/web/src/features/editor/components/MembersPanel/presenceMatch.ts
@@ -1,0 +1,32 @@
+import type { RemotePresence } from "@lib/collab/presence";
+import type { Member } from "@shared/api/members";
+
+/**
+ * Online matching between roster members and live presence peers.
+ *
+ * Presence is ephemeral and identifies peers only by a display name (ADR-0011);
+ * the roster is keyed by user id / email. We therefore bridge the two by name:
+ * a member counts as online when some connected peer broadcasts a name equal to
+ * the member's display name (or, lacking one, the local part of their email).
+ * Matching is case-insensitive and trims surrounding whitespace so cosmetic
+ * differences don't read as "offline".
+ */
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/** The name a member is expected to broadcast as a presence peer. */
+function memberPresenceName(member: Member): string {
+  if (member.displayName.trim()) return member.displayName;
+  return member.email.split("@")[0] ?? member.email;
+}
+
+/** Set of normalized names currently present (one per connected peer). */
+export function onlineNames(peers: RemotePresence[]): Set<string> {
+  return new Set(peers.map((p) => normalize(p.name)));
+}
+
+/** Whether a roster member matches any connected presence peer. */
+export function isMemberOnline(member: Member, peers: RemotePresence[]): boolean {
+  return onlineNames(peers).has(normalize(memberPresenceName(member)));
+}

--- a/web/src/features/editor/components/Ribbon/ReviewTab.tsx
+++ b/web/src/features/editor/components/Ribbon/ReviewTab.tsx
@@ -1,14 +1,17 @@
 "use client";
-import { SpellCheck, MessageSquare, Bot } from "lucide-react";
+import { SpellCheck, MessageSquare, Bot, Users } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { RibbonGroup, RibbonDivider, RibbonBigButton } from "./ribbonPrimitives";
 
 // Spell-check / AI proofreading have no backend yet, so those stay as titled
 // "次のアップデートで実装" placeholders. The comment button is wired to the
-// presentation-level comments panel (toggles the side panel).
+// presentation-level comments panel (toggles the side panel). The members
+// button toggles the in-editor roster / role-management panel.
 export function ReviewTab() {
   const showComments = useEditorStore((s) => s.showComments);
   const toggleComments = useEditorStore((s) => s.toggleComments);
+  const showMembers = useEditorStore((s) => s.showMembers);
+  const toggleMembers = useEditorStore((s) => s.toggleMembers);
   return (
     <div className="flex h-full items-stretch">
       <RibbonGroup label="文章校正">
@@ -24,6 +27,15 @@ export function ReviewTab() {
           icon={<MessageSquare />} label="コメント"
           active={showComments} onClick={toggleComments}
           title="コメントパネルを開く"
+        />
+      </RibbonGroup>
+      <RibbonDivider />
+
+      <RibbonGroup label="共有">
+        <RibbonBigButton
+          icon={<Users />} label="メンバー"
+          active={showMembers} onClick={toggleMembers}
+          title="メンバーと権限パネルを開く"
         />
       </RibbonGroup>
       <RibbonDivider />

--- a/web/src/features/editor/stores/editorStore.test.ts
+++ b/web/src/features/editor/stores/editorStore.test.ts
@@ -39,4 +39,17 @@ describe("useEditorStore", () => {
     useEditorStore.getState().setZoom(1.5);
     expect(useEditorStore.getState().zoom).toBe(1.5);
   });
+
+  it("toggleMembers flips the members panel visibility", () => {
+    useEditorStore.setState({ showMembers: false });
+    useEditorStore.getState().toggleMembers();
+    expect(useEditorStore.getState().showMembers).toBe(true);
+    useEditorStore.getState().toggleMembers();
+    expect(useEditorStore.getState().showMembers).toBe(false);
+  });
+
+  it("setShowMembers sets the members panel visibility directly", () => {
+    useEditorStore.getState().setShowMembers(true);
+    expect(useEditorStore.getState().showMembers).toBe(true);
+  });
 });

--- a/web/src/features/editor/stores/editorStore.ts
+++ b/web/src/features/editor/stores/editorStore.ts
@@ -16,6 +16,7 @@ interface EditorState {
   showRuler: boolean;
   showLayers: boolean;
   showComments: boolean;
+  showMembers: boolean;
 
   setCanvas: (canvas: Canvas | null) => void;
   setActiveTool: (tool: EditorTool) => void;
@@ -32,6 +33,8 @@ interface EditorState {
   setShowLayers: (show: boolean) => void;
   toggleComments: () => void;
   setShowComments: (show: boolean) => void;
+  toggleMembers: () => void;
+  setShowMembers: (show: boolean) => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -46,6 +49,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
   showRuler: false,
   showLayers: false,
   showComments: false,
+  showMembers: false,
 
   setCanvas: (canvas) => set({ canvas }),
   setActiveTool: (activeTool) => set({ activeTool }),
@@ -62,4 +66,6 @@ export const useEditorStore = create<EditorState>()((set) => ({
   setShowLayers: (showLayers) => set({ showLayers }),
   toggleComments: () => set((s) => ({ showComments: !s.showComments })),
   setShowComments: (showComments) => set({ showComments }),
+  toggleMembers: () => set((s) => ({ showMembers: !s.showMembers })),
+  setShowMembers: (showMembers) => set({ showMembers }),
 }));


### PR DESCRIPTION
## 概要

エディタ内に共同編集者の **メンバー一覧 / 役割管理 / 在席（presence）表示** を統合した側パネルを追加します。Dashboard の `ShareModal` が使う既存の `membersApi` をエディタ側でも再利用し、`ReviewTab` の「共有」グループからトグルで開閉できます。

## 変更内容

- `editorStore` に `showMembers` / `toggleMembers` / `setShowMembers` を追加（`showComments` / `showRuler` と同パターン）
- `MembersPanel`（`features/editor/components/MembersPanel/`）を新規追加
  - `CommentsPanel` のサイドパネル構造を踏襲（`w-64` の `aside`）
  - メンバー一覧、役割バッジ/役割変更 `select`、オンライン/オフラインのドット表示
  - 役割変更は既存 `membersApi.updateRole`（JWT は `apiClient` のトークン機構に委譲）で**楽観的更新**（失敗時はロールバック）
  - owner は役割固定・変更不可（既存 ShareModal と同方針）
- presence 統合: 純粋関数 `presenceMatch.ts`（`isMemberOnline` / `onlineNames`）でメンバー名簿と `usePresence` の peers を**名前で照合**。エディタページから `peers` をパネルへ渡す
- `ReviewTab` に「共有 → メンバー」トグルボタンを配線、`editor/[id]/page.tsx` に `{showMembers && <MembersPanel peers={peers} />}` をマウント

## presence 統合の方法

presence は ephemeral（ADR-0011）で peer を **表示名のみ**で識別し、名簿は userId/email キーです。両者を名前でブリッジします: メンバーの `displayName`（無ければ email のローカル部）を、接続中の peer 名と**大文字小文字・前後空白を無視**して照合し、一致すればオンライン。照合ロジックは純粋関数に切り出して単体テスト済みです。

## テスト

- `presenceMatch.test.ts` 新規（6 ケース: 名前一致 / 大小無視 / email フォールバック / 不一致 / peer なし / 正規化）
- `editorStore.test.ts` に `toggleMembers` / `setShowMembers` の 2 ケース追加
- 全体: type-check ✓ / lint ✓（0 errors、既存 warning のみ）/ vitest 146 passed (22 files) ✓ / build ✓

## 残課題

- presence の `name` は現状 `usePresence` 側で identity 未指定だと匿名名（`ゲスト N`）になり得るため、ログインユーザーの表示名を identity に流す配線は別 PR 推奨。現実装は名前一致でオンライン判定するため、表示名が presence に流れていればそのまま機能します。
- メンバーの招待/削除はエディタ内パネルには含めず（ShareModal の責務）、エディタ内は閲覧+役割変更に限定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)