### PR TITLE
デザインシステム統一: トークン徹底とプリミティブ整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ e2e/node_modules/
 e2e/test-results/
 e2e/playwright-report/
 e2e/.playwright/
+
+# Local dev runtime (docker-compose volumes)
+.localdb/
+.locallogs/
+.localuploads/

--- a/web/docs/design-system.md
+++ b/web/docs/design-system.md
@@ -1,0 +1,146 @@
+# PresentsAI Design System
+
+A single source of truth for colors, typography, spacing, and UI primitives.
+The goal is one consistent look across every screen — dashboard, editor, auth,
+and the side panels. **Never hardcode hex colors or raw Tailwind palette
+classes (`gray-*`, `blue-*`, `purple-*`, …) in feature code.** Use the tokens
+and primitives below.
+
+---
+
+## 1. Design Tokens
+
+Tokens live in two places that must stay in sync:
+
+- **`web/tailwind.config.ts`** — the canonical token values (colors, shadows, radii).
+- **`web/src/app/globals.css`** — the `@layer components` recipes (`.btn`, `.input`, `.card`, …) built from those tokens.
+
+### Color
+
+Reference tokens by their semantic name, not by a palette number.
+
+| Token | Use for |
+|---|---|
+| `primary-50 … primary-900` | Brand (indigo). Buttons, active states, focus. `primary-600` is the default action color. |
+| `surface` / `surface-subtle` / `surface-muted` | Page/card backgrounds. `surface` = white, `surface-subtle` = app background, `surface-muted` = hover/inset fills. |
+| `border` / `border-strong` / `border-focus` | Dividers and outlines. Default to `border-border`. |
+| `content-primary` | Primary text (`#0F172A`). |
+| `content-secondary` | Secondary/label text. |
+| `content-tertiary` | Muted text, placeholders, timestamps. |
+| `content-disabled` / `content-inverse` / `content-link` | Disabled / on-dark / link text. |
+| `success` / `warning` / `error` / `info` | Status. Each has `.light` (bg) and `.dark` (text) variants. |
+
+Do:  `text-content-secondary`, `bg-surface-subtle`, `border-border`, `bg-primary-600`
+Don't: `text-gray-600`, `bg-slate-50`, `border-gray-200`, `bg-blue-600`
+
+> **Exception:** the presenter/viewer screens (`/present`, `/view`) and the
+> slide-canvas color pickers intentionally use a dark theme / literal hex
+> values — those are *content* colors, not UI chrome, and are out of scope for
+> tokenization.
+
+### Typography
+
+- Font: **Inter** (`font-sans`), loaded in `globals.css`.
+- Scale (Tailwind defaults): `text-xs` (12) · `text-sm` (14, default body) · `text-base` (16) · `text-lg` (18) · `text-xl` (20) · `text-2xl` (24) · `text-4xl` (36, hero).
+- Weights: `font-medium` (labels/buttons), `font-semibold` (panel titles), `font-bold` (headings).
+
+### Spacing & Radius
+
+- Spacing: Tailwind 4px scale (`gap-2`, `p-3`, `px-6`, …). Panels use `p-3`; modals use `p-6`.
+- Radius: `rounded-lg` (controls), `rounded-xl` (cards/list rows), `rounded-2xl` (modals), `rounded-full` (pills/avatars).
+
+### Elevation
+
+| Shadow | Use |
+|---|---|
+| `shadow-card` | Resting cards. |
+| `shadow-card-hover` | Hovered interactive cards. |
+| `shadow-modal` | Modals, popovers, dropdowns. |
+
+### z-index
+
+`z-10` sticky headers / outside-click catchers · `z-20` dropdown menus · `z-50` modal backdrops · `1000` portal popovers.
+
+---
+
+## 2. Component recipe classes (`globals.css`)
+
+Plain HTML elements can opt into the system with these classes:
+
+| Class | Element |
+|---|---|
+| `.btn` + `.btn-{sm,md,lg}` + `.btn-{primary,secondary,ghost,danger}` | `<button>` |
+| `.input` | `<input>` |
+| `.textarea` | `<textarea>` |
+| `.select` | `<select>` |
+| `.card` | container |
+| `.badge` | status pill |
+| `.modal-backdrop` / `.modal-panel` | dialog scaffolding |
+| `.side-panel` / `.side-panel-header` / `.side-panel-title` | editor docked panels |
+
+Prefer the React primitives below — they wrap these classes and add a11y/state handling.
+
+---
+
+## 3. UI Primitives (`web/src/shared/components/ui`)
+
+Import from the barrel: `import { Button, Modal, Select } from "@shared/components/ui";`
+
+| Primitive | Key props | Notes |
+|---|---|---|
+| `Button` | `variant` (primary/secondary/ghost/danger), `size` (sm/md/lg), `loading` | Includes spinner + disabled handling. |
+| `Input` | `label`, `error`, `hint` | Labelled field with error/hint slots. |
+| `Textarea` | native + `.textarea` | Multiline input. |
+| `Select` | native `<select>` + `.select` | Styled dropdown. |
+| `Card` | `interactive` | Surface container; `interactive` adds hover elevation. |
+| `Modal` | `open`, `onClose`, `title`, `subtitle`, `size` | Backdrop + Escape/click-out close. |
+| `Badge` | `variant` (default/primary/success/warning/error/info) | Status pill. |
+| `RoleBadge` | `role` (owner/editor/viewer) | Canonical collaborator role pill (shared by ShareModal + MembersPanel). |
+| `Avatar` | `name`, `size` | Deterministic color-from-name initials. |
+| `Popover` | `trigger`, `align` | Portal-positioned floating panel. |
+
+### Usage example
+
+```tsx
+import { Button, Modal, Input, Select, RoleBadge } from "@shared/components/ui";
+
+<Modal open={open} onClose={close} title="共有設定" subtitle={title}>
+  <div className="p-6 space-y-4">
+    <Input label="メールアドレス" type="email" />
+    <Select value={role} onChange={…}>
+      <option value="viewer">閲覧者</option>
+    </Select>
+    <RoleBadge role="owner" />
+    <Button variant="primary">招待</Button>
+  </div>
+</Modal>
+```
+
+---
+
+## 4. Do / Don't
+
+| Do | Don't |
+|---|---|
+| `<Button variant="primary">` | `<button className="bg-blue-600 text-white …">` |
+| `bg-surface-subtle` | `bg-gray-50` |
+| `text-content-tertiary` | `text-gray-400` |
+| `<RoleBadge role={r} />` | redefining a local `ROLE_BADGE` color map |
+| `.side-panel` on editor asides | `flex flex-col border-l bg-white` |
+| `<Modal>` | hand-rolled `fixed inset-0 bg-black/40 …` |
+
+---
+
+## 5. Coverage status
+
+Migrated to the system in the `feature/design-system` work:
+
+- ✅ Dashboard, Login (already on-system; verified)
+- ✅ Editor header & docked aside panels (`editor/[id]/page.tsx`)
+- ✅ ShareModal, ShareButton
+- ✅ MembersPanel, CommentsPanel, VersionHistoryPanel
+
+Not yet migrated (tracked as follow-up — still functional, just off-token):
+
+- ⬜ `ProofreadPanel`, `PropertyPanel/*`, `Toolbar/*`, `Ribbon/*` (large editor surfaces)
+- ⬜ `/present` and `/view` (intentional dark theme — needs a dark-token decision first)

--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -151,13 +151,13 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
             {notesVisible && <SpeakerNotesPanel />}
           </main>
           {showLayers && <LayersPanel moveObject={moveObject} />}
-          <aside className="flex w-56 shrink-0 flex-col border-l bg-white overflow-y-auto">
+          <aside className="side-panel w-56 overflow-y-auto">
             <StylePanel />
             <TokenPanel />
             <ImagePanel />
           </aside>
           {aiTab && (
-            <aside className="flex w-64 shrink-0 flex-col border-l bg-white overflow-y-auto">
+            <aside className="side-panel w-64 overflow-y-auto">
               {aiTab === "ai" ? <AIPanel /> : <RealtimeCoach />}
             </aside>
           )}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -63,4 +63,33 @@
   .badge {
     @apply inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium;
   }
+
+  /* Select — matches .input but for native <select> */
+  .select {
+    @apply rounded-lg border border-border bg-surface px-2.5 py-2 text-sm text-content-primary transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 disabled:bg-surface-muted disabled:text-content-disabled;
+  }
+
+  /* Textarea — matches .input, vertical only */
+  .textarea {
+    @apply w-full resize-y rounded-lg border border-border bg-surface px-3 py-2 text-sm text-content-primary placeholder:text-content-tertiary transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 disabled:bg-surface-muted disabled:text-content-disabled;
+  }
+
+  /* Modal — backdrop + panel */
+  .modal-backdrop {
+    @apply fixed inset-0 z-50 flex items-center justify-center bg-content-primary/40 p-4;
+  }
+  .modal-panel {
+    @apply w-full rounded-2xl bg-surface shadow-modal;
+  }
+
+  /* Side panel — the editor's right/left docked aside panels */
+  .side-panel {
+    @apply flex shrink-0 flex-col border-l border-border bg-surface;
+  }
+  .side-panel-header {
+    @apply flex items-center justify-between border-b border-border px-3 py-2;
+  }
+  .side-panel-title {
+    @apply text-xs font-semibold text-content-secondary;
+  }
 }

--- a/web/src/features/dashboard/components/ShareButton.tsx
+++ b/web/src/features/dashboard/components/ShareButton.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useState } from "react";
+import { Share2 } from "lucide-react";
+import { Button } from "@shared/components/ui";
 import { ShareModal } from "./ShareModal";
 
 interface ShareButtonProps {
@@ -12,12 +14,10 @@ export function ShareButton({ presentationId, presentationTitle }: ShareButtonPr
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className="rounded-lg border px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-      >
-        🔗 共有
-      </button>
+      <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+        <Share2 className="h-3.5 w-3.5" />
+        共有
+      </Button>
       {open && (
         <ShareModal
           presentationId={presentationId}

--- a/web/src/features/dashboard/components/ShareModal.tsx
+++ b/web/src/features/dashboard/components/ShareModal.tsx
@@ -2,24 +2,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { membersApi, type Member, type MemberRole } from "@shared/api/members";
+import { Avatar, Button, Modal, RoleBadge, Select } from "@shared/components/ui";
 
 interface ShareModalProps {
   presentationId: string;
   presentationTitle: string;
   onClose: () => void;
 }
-
-const ROLE_LABELS: Record<MemberRole, string> = {
-  owner: "オーナー",
-  editor: "編集者",
-  viewer: "閲覧者",
-};
-
-const ROLE_BADGE: Record<MemberRole, string> = {
-  owner: "bg-purple-100 text-purple-700",
-  editor: "bg-blue-100 text-blue-700",
-  viewer: "bg-gray-100 text-gray-600",
-};
 
 export function ShareModal({ presentationId, presentationTitle, onClose }: ShareModalProps) {
   const { accessToken } = useAuthStore();
@@ -82,137 +71,106 @@ export function ShareModal({ presentationId, presentationTitle, onClose }: Share
   }
 
   return (
-    // Modal backdrop
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
-      <div
-        className="w-full max-w-lg rounded-2xl bg-white shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b px-6 py-4">
-          <div>
-            <h2 className="text-base font-bold text-gray-900">共有設定</h2>
-            <p className="text-xs text-gray-500 mt-0.5 truncate max-w-72">{presentationTitle}</p>
-          </div>
-          <button onClick={onClose} className="rounded-full p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600">✕</button>
+    <Modal open onClose={onClose} title="共有設定" subtitle={presentationTitle} size="lg">
+      <div className="p-6 space-y-6">
+        {/* Invite form */}
+        <div>
+          <p className="text-sm font-semibold text-content-secondary mb-3">ユーザーを招待</p>
+          <form onSubmit={handleInvite} className="flex gap-2">
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="メールアドレスを入力..."
+              className="input flex-1"
+              required
+            />
+            <Select value={role} onChange={e => setRole(e.target.value as MemberRole)}>
+              <option value="viewer">閲覧者</option>
+              <option value="editor">編集者</option>
+            </Select>
+            <Button type="submit" variant="primary" disabled={inviting || !email.trim()} className="whitespace-nowrap">
+              {inviting ? "招待中..." : "招待"}
+            </Button>
+          </form>
+          {error && <p className="mt-2 text-xs text-error">{error}</p>}
         </div>
 
-        <div className="p-6 space-y-6">
-          {/* Invite form */}
-          <div>
-            <p className="text-sm font-semibold text-gray-700 mb-3">ユーザーを招待</p>
-            <form onSubmit={handleInvite} className="flex gap-2">
-              <input
-                type="email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                placeholder="メールアドレスを入力..."
-                className="flex-1 rounded-lg border px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                required
-              />
-              <select
-                value={role}
-                onChange={e => setRole(e.target.value as MemberRole)}
-                className="rounded-lg border px-2 py-2 text-sm focus:border-blue-500 focus:outline-none"
-              >
-                <option value="viewer">閲覧者</option>
-                <option value="editor">編集者</option>
-              </select>
-              <button
-                type="submit"
-                disabled={inviting || !email.trim()}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
-              >
-                {inviting ? "招待中..." : "招待"}
-              </button>
-            </form>
-            {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
-          </div>
-
-          {/* Members list */}
-          <div>
-            <p className="text-sm font-semibold text-gray-700 mb-3">メンバー ({members.length})</p>
-            {loading ? (
-              <p className="text-xs text-gray-400">読み込み中...</p>
-            ) : members.length === 0 ? (
-              <div className="rounded-xl bg-gray-50 py-6 text-center">
-                <p className="text-sm text-gray-400">まだ共有されていません</p>
-                <p className="text-xs text-gray-400 mt-1">メールアドレスを入力して招待しましょう</p>
-              </div>
-            ) : (
-              <ul className="space-y-2 max-h-52 overflow-y-auto">
-                {members.map(member => (
-                  <li key={member.userId} className="flex items-center gap-3 rounded-xl border p-3 hover:bg-gray-50">
-                    {/* Avatar */}
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700">
-                      {(member.displayName || member.email).charAt(0).toUpperCase()}
-                    </div>
-
-                    {/* Name / email */}
-                    <div className="flex-1 min-w-0">
-                      {member.displayName && (
-                        <p className="text-sm font-medium text-gray-800 truncate">{member.displayName}</p>
-                      )}
-                      <p className="text-xs text-gray-500 truncate">{member.email}</p>
-                    </div>
-
-                    {/* Role */}
-                    {member.role === "owner" ? (
-                      <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${ROLE_BADGE[member.role]}`}>
-                        {ROLE_LABELS[member.role]}
-                      </span>
-                    ) : (
-                      <select
-                        value={member.role}
-                        onChange={e => handleRoleChange(member, e.target.value as MemberRole)}
-                        className="rounded-lg border px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
-                      >
-                        <option value="viewer">閲覧者</option>
-                        <option value="editor">編集者</option>
-                      </select>
-                    )}
-
-                    {/* Remove */}
-                    {member.role !== "owner" && (
-                      <button
-                        onClick={() => handleRemove(member)}
-                        className="rounded-full p-1 text-gray-300 hover:bg-red-50 hover:text-red-500"
-                        title="削除"
-                      >
-                        ✕
-                      </button>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-
-          {/* Public links */}
-          <div>
-            <p className="text-sm font-semibold text-gray-700 mb-3">公開リンク</p>
-            <div className="space-y-2">
-              {[
-                { label: "閲覧用（認証不要）", url: viewUrl, type: "view" as const, color: "border-gray-200" },
-                { label: "プレゼンター用", url: presentUrl, type: "present" as const, color: "border-gray-200" },
-              ].map(({ label, url, type, color }) => (
-                <div key={type} className={`flex items-center gap-2 rounded-xl border ${color} p-3`}>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs font-medium text-gray-600">{label}</p>
-                    <p className="text-xs text-gray-400 truncate mt-0.5">{url}</p>
-                  </div>
-                  <button
-                    onClick={() => copyLink(url, type)}
-                    className="shrink-0 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-200"
-                  >
-                    {copied === type ? "✓ コピー済み" : "コピー"}
-                  </button>
-                </div>
-              ))}
+        {/* Members list */}
+        <div>
+          <p className="text-sm font-semibold text-content-secondary mb-3">メンバー ({members.length})</p>
+          {loading ? (
+            <p className="text-xs text-content-tertiary">読み込み中...</p>
+          ) : members.length === 0 ? (
+            <div className="rounded-xl bg-surface-subtle py-6 text-center">
+              <p className="text-sm text-content-tertiary">まだ共有されていません</p>
+              <p className="text-xs text-content-tertiary mt-1">メールアドレスを入力して招待しましょう</p>
             </div>
+          ) : (
+            <ul className="space-y-2 max-h-52 overflow-y-auto">
+              {members.map(member => (
+                <li key={member.userId} className="flex items-center gap-3 rounded-xl border border-border p-3 hover:bg-surface-subtle">
+                  <Avatar name={member.displayName || member.email} size="sm" className="shrink-0" />
+
+                  {/* Name / email */}
+                  <div className="flex-1 min-w-0">
+                    {member.displayName && (
+                      <p className="text-sm font-medium text-content-primary truncate">{member.displayName}</p>
+                    )}
+                    <p className="text-xs text-content-secondary truncate">{member.email}</p>
+                  </div>
+
+                  {/* Role */}
+                  {member.role === "owner" ? (
+                    <RoleBadge role={member.role} />
+                  ) : (
+                    <Select
+                      value={member.role}
+                      onChange={e => handleRoleChange(member, e.target.value as MemberRole)}
+                      className="px-2 py-1 text-xs"
+                    >
+                      <option value="viewer">閲覧者</option>
+                      <option value="editor">編集者</option>
+                    </Select>
+                  )}
+
+                  {/* Remove */}
+                  {member.role !== "owner" && (
+                    <button
+                      onClick={() => handleRemove(member)}
+                      className="rounded-full p-1 text-content-tertiary hover:bg-error-light hover:text-error"
+                      title="削除"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Public links */}
+        <div>
+          <p className="text-sm font-semibold text-content-secondary mb-3">公開リンク</p>
+          <div className="space-y-2">
+            {[
+              { label: "閲覧用（認証不要）", url: viewUrl, type: "view" as const },
+              { label: "プレゼンター用", url: presentUrl, type: "present" as const },
+            ].map(({ label, url, type }) => (
+              <div key={type} className="flex items-center gap-2 rounded-xl border border-border p-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium text-content-secondary">{label}</p>
+                  <p className="text-xs text-content-tertiary truncate mt-0.5">{url}</p>
+                </div>
+                <Button variant="secondary" size="sm" onClick={() => copyLink(url, type)} className="shrink-0">
+                  {copied === type ? "✓ コピー済み" : "コピー"}
+                </Button>
+              </div>
+            ))}
           </div>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/web/src/features/editor/components/CommentsPanel/CommentsPanel.tsx
+++ b/web/src/features/editor/components/CommentsPanel/CommentsPanel.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { commentsApi } from "@shared/api/comments";
+import { Button, Textarea } from "@shared/components/ui";
 import type { Comment } from "@shared/types/comment";
 
 // Presentation-level comments. Slide/object anchoring is intentionally out of
@@ -44,27 +45,27 @@ export function CommentsPanel() {
   }, [body, accessToken, presentationId, posting]);
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-l bg-white">
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <p className="text-xs font-semibold text-gray-600">コメント</p>
-        {loading && <span className="text-xs text-gray-400">読み込み中...</span>}
+    <aside className="side-panel w-64">
+      <div className="side-panel-header">
+        <p className="side-panel-title">コメント</p>
+        {loading && <span className="text-xs text-content-tertiary">読み込み中...</span>}
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto p-3">
         {comments.length === 0 && !loading ? (
-          <p className="text-xs text-gray-400">まだコメントはありません。</p>
+          <p className="text-xs text-content-tertiary">まだコメントはありません。</p>
         ) : (
           comments.map((c) => (
-            <div key={c.ID} className="rounded-lg border bg-gray-50 p-2">
+            <div key={c.ID} className="rounded-lg border border-border bg-surface-subtle p-2">
               <div className="mb-0.5 flex items-center justify-between">
-                <span className="text-xs font-medium text-gray-700">
+                <span className="text-xs font-medium text-content-secondary">
                   {c.AuthorName || "匿名"}
                 </span>
-                <span className="text-[10px] text-gray-400">
+                <span className="text-[10px] text-content-tertiary">
                   {c.CreatedAt ? new Date(c.CreatedAt).toLocaleString() : ""}
                 </span>
               </div>
-              <p className="whitespace-pre-wrap break-words text-xs text-gray-700">
+              <p className="whitespace-pre-wrap break-words text-xs text-content-secondary">
                 {c.Body}
               </p>
             </div>
@@ -72,20 +73,22 @@ export function CommentsPanel() {
         )}
       </div>
 
-      <div className="border-t p-3">
-        <textarea
+      <div className="border-t border-border p-3">
+        <Textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
           placeholder="コメントを追加..."
-          className="w-full h-16 resize-none rounded-lg border p-2 text-xs text-gray-700 focus:border-blue-400 focus:outline-none"
+          className="h-16 resize-none text-xs"
         />
-        <button
+        <Button
+          variant="primary"
+          size="sm"
           onClick={submit}
           disabled={!body.trim() || posting}
-          className="mt-2 w-full rounded-lg bg-blue-600 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mt-2 w-full"
         >
           {posting ? "投稿中..." : "投稿"}
-        </button>
+        </Button>
       </div>
     </aside>
   );

--- a/web/src/features/editor/components/MembersPanel/MembersPanel.tsx
+++ b/web/src/features/editor/components/MembersPanel/MembersPanel.tsx
@@ -3,20 +3,9 @@ import { useCallback, useEffect, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { membersApi, type Member, type MemberRole } from "@shared/api/members";
+import { Avatar, RoleBadge, Select } from "@shared/components/ui";
 import type { RemotePresence } from "@lib/collab/presence";
 import { isMemberOnline } from "./presenceMatch";
-
-const ROLE_LABELS: Record<MemberRole, string> = {
-  owner: "オーナー",
-  editor: "編集者",
-  viewer: "閲覧者",
-};
-
-const ROLE_BADGE: Record<MemberRole, string> = {
-  owner: "bg-purple-100 text-purple-700",
-  editor: "bg-blue-100 text-blue-700",
-  viewer: "bg-gray-100 text-gray-600",
-};
 
 /**
  * In-editor roster: lists collaborators with their role (editable for
@@ -69,36 +58,34 @@ export function MembersPanel({ peers }: { peers: RemotePresence[] }) {
   const onlineCount = members.filter((m) => isMemberOnline(m, peers)).length;
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-l bg-white">
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <p className="text-xs font-semibold text-gray-600">メンバー ({members.length})</p>
+    <aside className="side-panel w-64">
+      <div className="side-panel-header">
+        <p className="side-panel-title">メンバー ({members.length})</p>
         {loading ? (
-          <span className="text-xs text-gray-400">読み込み中...</span>
+          <span className="text-xs text-content-tertiary">読み込み中...</span>
         ) : (
-          <span className="text-[10px] text-gray-400">{onlineCount} 人がオンライン</span>
+          <span className="text-[10px] text-content-tertiary">{onlineCount} 人がオンライン</span>
         )}
       </div>
 
       <div className="flex-1 space-y-2 overflow-y-auto p-3">
         {members.length === 0 && !loading ? (
-          <p className="text-xs text-gray-400">まだ共有されていません。</p>
+          <p className="text-xs text-content-tertiary">まだ共有されていません。</p>
         ) : (
           members.map((member) => {
             const online = isMemberOnline(member, peers);
             return (
               <div
                 key={member.userId}
-                className="flex items-center gap-2 rounded-lg border bg-gray-50 p-2"
+                className="flex items-center gap-2 rounded-lg border border-border bg-surface-subtle p-2"
               >
                 {/* Avatar with online indicator */}
                 <div className="relative shrink-0">
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">
-                    {(member.displayName || member.email).charAt(0).toUpperCase()}
-                  </div>
+                  <Avatar name={member.displayName || member.email} size="sm" />
                   <span
                     aria-label={online ? "オンライン" : "オフライン"}
-                    className={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-white ${
-                      online ? "bg-green-500" : "bg-gray-300"
+                    className={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-surface ${
+                      online ? "bg-success" : "bg-content-tertiary"
                     }`}
                   />
                 </div>
@@ -106,30 +93,26 @@ export function MembersPanel({ peers }: { peers: RemotePresence[] }) {
                 {/* Name / email */}
                 <div className="min-w-0 flex-1">
                   {member.displayName && (
-                    <p className="truncate text-xs font-medium text-gray-800">
+                    <p className="truncate text-xs font-medium text-content-primary">
                       {member.displayName}
                     </p>
                   )}
-                  <p className="truncate text-[10px] text-gray-500">{member.email}</p>
+                  <p className="truncate text-[10px] text-content-secondary">{member.email}</p>
                 </div>
 
                 {/* Role */}
                 {member.role === "owner" ? (
-                  <span
-                    className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ROLE_BADGE[member.role]}`}
-                  >
-                    {ROLE_LABELS[member.role]}
-                  </span>
+                  <RoleBadge role={member.role} className="shrink-0" />
                 ) : (
-                  <select
+                  <Select
                     aria-label={`${member.displayName || member.email} の役割`}
                     value={member.role}
                     onChange={(e) => changeRole(member, e.target.value as MemberRole)}
-                    className="shrink-0 rounded border px-1 py-0.5 text-[10px] text-gray-700 focus:border-blue-400 focus:outline-none"
+                    className="shrink-0 px-1.5 py-0.5 text-[10px]"
                   >
                     <option value="viewer">閲覧者</option>
                     <option value="editor">編集者</option>
-                  </select>
+                  </Select>
                 )}
               </div>
             );

--- a/web/src/features/editor/components/VersionHistoryPanel/VersionHistoryPanel.tsx
+++ b/web/src/features/editor/components/VersionHistoryPanel/VersionHistoryPanel.tsx
@@ -5,6 +5,7 @@ import { History, RotateCcw, Save } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { versionsApi } from "@shared/api/versions";
+import { Button } from "@shared/components/ui";
 import { replaceSlideContent } from "@lib/collab/schema";
 import type { SlideVersion } from "@shared/types/version";
 
@@ -83,50 +84,54 @@ export function VersionHistoryPanel({ doc }: VersionHistoryPanelProps) {
   );
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-l bg-white">
-      <div className="flex items-center justify-between border-b px-3 py-2">
+    <aside className="side-panel w-64">
+      <div className="side-panel-header">
         <div className="flex items-center gap-1.5">
-          <History className="h-3.5 w-3.5 text-gray-500" />
-          <p className="text-xs font-semibold text-gray-600">バージョン履歴</p>
+          <History className="h-3.5 w-3.5 text-content-tertiary" />
+          <p className="side-panel-title">バージョン履歴</p>
         </div>
-        {loading && <span className="text-xs text-gray-400">読み込み中...</span>}
+        {loading && <span className="text-xs text-content-tertiary">読み込み中...</span>}
       </div>
 
-      <div className="border-b p-3">
-        <button
+      <div className="border-b border-border p-3">
+        <Button
+          variant="primary"
+          size="sm"
           onClick={snapshot}
           disabled={saving || !activeSlideId || !canvas}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="w-full"
         >
           <Save className="h-3.5 w-3.5" />
           {saving ? "保存中..." : "現在の状態を保存"}
-        </button>
+        </Button>
       </div>
 
       <div className="flex-1 space-y-2 overflow-y-auto p-3">
         {versions.length === 0 && !loading ? (
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-content-tertiary">
             このスライドの保存済みバージョンはありません。
           </p>
         ) : (
           versions.map((v) => (
-            <div key={v.ID} className="rounded-lg border bg-gray-50 p-2">
+            <div key={v.ID} className="rounded-lg border border-border bg-surface-subtle p-2">
               <div className="mb-1 flex items-center justify-between">
-                <span className="text-xs font-medium text-gray-700">
+                <span className="text-xs font-medium text-content-secondary">
                   バージョン {v.Version}
                 </span>
-                <span className="text-[10px] text-gray-400">
+                <span className="text-[10px] text-content-tertiary">
                   {v.CreatedAt ? new Date(v.CreatedAt).toLocaleString() : ""}
                 </span>
               </div>
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => restore(v)}
                 disabled={restoringId !== null}
-                className="flex w-full items-center justify-center gap-1.5 rounded-md border border-gray-300 py-1 text-[11px] font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                className="w-full text-[11px]"
               >
                 <RotateCcw className="h-3 w-3" />
                 {restoringId === v.ID ? "復元中..." : "このバージョンに復元"}
-              </button>
+              </Button>
             </div>
           ))
         )}

--- a/web/src/shared/components/ui/Card.tsx
+++ b/web/src/shared/components/ui/Card.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { clsx } from "clsx";
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Adds a hover elevation transition (use for clickable cards). */
+  interactive?: boolean;
+}
+
+/** Surface container styled with the `.card` token class. */
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ interactive, className, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={clsx(
+        "card",
+        interactive && "cursor-pointer transition-shadow hover:shadow-card-hover",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+);
+Card.displayName = "Card";

--- a/web/src/shared/components/ui/Modal.tsx
+++ b/web/src/shared/components/ui/Modal.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useEffect, type ReactNode } from "react";
+import { clsx } from "clsx";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Optional header title. Renders the standard header row with a close button. */
+  title?: ReactNode;
+  /** Secondary line under the title (e.g. the document name). */
+  subtitle?: ReactNode;
+  children: ReactNode;
+  /** Tailwind max-width class for the panel. Defaults to `max-w-lg`. */
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const sizeClass: Record<NonNullable<ModalProps["size"]>, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+};
+
+/**
+ * Token-driven modal: a dimmed backdrop (`.modal-backdrop`) plus a surface
+ * panel (`.modal-panel`). Closes on backdrop click and Escape. Replaces the
+ * ad-hoc `fixed inset-0 bg-black/40 ... bg-white shadow-2xl` markup that was
+ * duplicated across feature dialogs.
+ */
+export function Modal({ open, onClose, title, subtitle, children, size = "lg", className }: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={clsx("modal-panel", sizeClass[size], className)}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title !== undefined && (
+          <div className="flex items-center justify-between border-b border-border px-6 py-4">
+            <div className="min-w-0">
+              <h2 className="text-base font-bold text-content-primary">{title}</h2>
+              {subtitle !== undefined && (
+                <p className="mt-0.5 max-w-72 truncate text-xs text-content-secondary">{subtitle}</p>
+              )}
+            </div>
+            <button
+              onClick={onClose}
+              aria-label="閉じる"
+              className="rounded-full p-1.5 text-content-tertiary transition-colors hover:bg-surface-muted hover:text-content-secondary"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/shared/components/ui/RoleBadge.tsx
+++ b/web/src/shared/components/ui/RoleBadge.tsx
@@ -1,0 +1,28 @@
+import { Badge } from "./Badge";
+
+export type Role = "owner" | "editor" | "viewer";
+
+export const ROLE_LABELS: Record<Role, string> = {
+  owner: "オーナー",
+  editor: "編集者",
+  viewer: "閲覧者",
+};
+
+const ROLE_VARIANT = {
+  owner: "primary",
+  editor: "info",
+  viewer: "default",
+} as const;
+
+/**
+ * Canonical role pill shared by the dashboard ShareModal and the editor
+ * MembersPanel, so collaborator roles look identical everywhere. Maps each
+ * role onto a token-based {@link Badge} variant.
+ */
+export function RoleBadge({ role, className }: { role: Role; className?: string }) {
+  return (
+    <Badge variant={ROLE_VARIANT[role]} className={className}>
+      {ROLE_LABELS[role]}
+    </Badge>
+  );
+}

--- a/web/src/shared/components/ui/Select.tsx
+++ b/web/src/shared/components/ui/Select.tsx
@@ -1,0 +1,14 @@
+import { forwardRef, type SelectHTMLAttributes } from "react";
+import { clsx } from "clsx";
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+/** Native select styled with the `.select` token class. */
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select ref={ref} className={clsx("select", className)} {...props}>
+      {children}
+    </select>
+  ),
+);
+Select.displayName = "Select";

--- a/web/src/shared/components/ui/Textarea.tsx
+++ b/web/src/shared/components/ui/Textarea.tsx
@@ -1,0 +1,12 @@
+import { forwardRef, type TextareaHTMLAttributes } from "react";
+import { clsx } from "clsx";
+
+type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+/** Multiline text input styled with the `.textarea` token class. */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea ref={ref} className={clsx("textarea", className)} {...props} />
+  ),
+);
+Textarea.displayName = "Textarea";

--- a/web/src/shared/components/ui/index.ts
+++ b/web/src/shared/components/ui/index.ts
@@ -1,5 +1,10 @@
 export { Button } from "./Button";
 export { Input } from "./Input";
+export { Textarea } from "./Textarea";
+export { Select } from "./Select";
 export { Avatar } from "./Avatar";
 export { Badge } from "./Badge";
+export { Card } from "./Card";
+export { Modal } from "./Modal";
 export { Popover } from "./Popover";
+export { RoleBadge, ROLE_LABELS, type Role } from "./RoleBadge";


### PR DESCRIPTION
## 背景
ユーザー評価「機能は良いが、アプリのデザインが統一されていない」を受け、デザインシステムを徹底する。

## 監査でわかったこと
- トークン基盤（`tailwind.config.ts` のカラー/シャドウ/角丸 + `globals.css` の `.btn/.input/.card/.badge`）と一部プリミティブ（Button/Input/Badge/Avatar/Popover）は**既に存在し良質**。
- **ダッシュボード / ログイン**は既にトークン準拠でクリーン。
- **不統一の本体はエディタのサイドパネル群**：`gray/blue/purple/green` の生 Tailwind クラスや、モーダル/ボタン/セレクト/テキストエリアの自前マークアップが散在。役割バッジの色マップが2箇所で重複。

## 変更（見た目の統一のみ・ロジック変更なし）
### 追加（トークン/プリミティブ）
- `globals.css`: `.select` `.textarea` `.modal-backdrop` `.modal-panel` `.side-panel*` レシピを追加（全て既存トークン由来）。
- プリミティブ: `Modal`（`role="dialog"`/`aria-modal`/Escapeで閉じる）、`Select`、`Textarea`、`Card`、`RoleBadge`（重複していた役割ピルを一本化）。

### 適用した画面
- ✅ ShareModal / ShareButton
- ✅ MembersPanel / CommentsPanel / VersionHistoryPanel
- ✅ エディタヘッダのドック型 aside（`bg-white` → `.side-panel`）
- ✅ ダッシュボード・ログイン（既に準拠・確認のみ）

### 残り（正直に明記・別PR）
- ⬜ ProofreadPanel / PropertyPanel* / Toolbar* / Ribbon*（大きいエディタ面）
- ⬜ `/present`・`/view`（意図的なダークテーマ。ダークトークン方針を決めてから）

### ドキュメント
- `web/docs/design-system.md`（トークン一覧・プリミティブ・do/don't・カバレッジ）。

### 雑務
- `.localdb/.locallogs/.localuploads`（docker volume）を `.gitignore` に追加。

## 検証
- `tsc --noEmit`: パス（エラーなし）
- `npm run build`: 成功（既存の無関係 warning 2件のみ）
- `npm test`: 168/168 パス

## 確認ポイント（http://localhost:8888）
1. **共有モーダル**（ダッシュボードのカードメニュー → 共有、またはエディタ右上「共有」）: ボタン/入力/役割ピルがトークン配色に統一。Escape で閉じる。
2. **エディタのサイドパネル**: コメント / メンバー / バージョン履歴を開き、白背景＋ヘッダ＋ボーダーが揃っているか。役割バッジ（オーナー=primary, 編集者=info）。
3. ダッシュボード・ログインに見た目の退行がないこと。

**視覚変更のため自動マージしない**（ユーザー確認待ち）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)