### PR TITLE
AnimationTab: 選択オブジェクトの保存済みアニメを反映

### DIFF
--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Square, Sparkles, ArrowRightToLine, ArrowDownToLine, Play } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useSlideStore } from "../../stores/slideStore";
@@ -32,6 +32,26 @@ export function toModelAnimation(t: EntranceType): ElementAnimationType {
   }
 }
 
+// Reverse mapping: restore the UI selection from a persisted model animation
+// type so the tab reflects what is already applied to the selected object.
+// The "Out" variants reuse the matching entrance choice because the editor
+// only ever writes the "In" variants (see playback in slidePlayback.ts).
+export function fromModelAnimation(t: ElementAnimationType | undefined): AnimChoice {
+  switch (t) {
+    case "fadeIn":
+    case "fadeOut":
+      return "fade-in";
+    case "slideIn":
+    case "slideOut":
+      return "fly-in-left";
+    case "zoomIn":
+    case "zoomOut":
+      return "bounce";
+    default:
+      return "none";
+  }
+}
+
 // Resolve a stable target id for an active object. Unlike the object's index
 // (which shifts on add/remove/reorder), this id is persisted with the object
 // and survives save/load, so playback can reliably find the same element.
@@ -44,6 +64,33 @@ export function AnimationTab() {
   const { slides, updateSlideMeta } = useSlideStore();
   const { accessToken } = useAuthStore();
   const [selected, setSelected] = useState<AnimChoice>("none");
+
+  // Reflect the saved animation of whatever object is currently selected, the
+  // same way TransitionTab reflects the active slide's transition. Without this
+  // the tab always showed "none" even when the object already had an animation.
+  useEffect(() => {
+    if (!canvas) return;
+    const sync = () => {
+      const obj = canvas.getActiveObject();
+      if (!obj) {
+        setSelected("none");
+        return;
+      }
+      const id = (obj as { id?: string }).id;
+      const anims = slides.find((s) => s.id === activeSlideId)?.animations ?? [];
+      const match = id ? anims.find((a) => a.targetId === id) : undefined;
+      setSelected(fromModelAnimation(match?.type));
+    };
+    sync();
+    canvas.on("selection:created", sync);
+    canvas.on("selection:updated", sync);
+    canvas.on("selection:cleared", sync);
+    return () => {
+      canvas.off("selection:created", sync);
+      canvas.off("selection:updated", sync);
+      canvas.off("selection:cleared", sync);
+    };
+  }, [canvas, activeSlideId, slides]);
 
   async function apply(type: AnimChoice) {
     setSelected(type);

--- a/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
+++ b/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toModelTransition, fromModelTransition } from "./TransitionTab";
-import { toModelAnimation } from "./AnimationTab";
+import { toModelAnimation, fromModelAnimation } from "./AnimationTab";
 
 describe("transition type mapping", () => {
   it("maps preview transition types to persisted model types", () => {
@@ -31,5 +31,24 @@ describe("animation type mapping", () => {
     expect(toModelAnimation("fade-in")).toBe("fadeIn");
     expect(toModelAnimation("fly-in-left")).toBe("slideIn");
     expect(toModelAnimation("bounce")).toBe("zoomIn");
+  });
+
+  it("restores the UI selection from a persisted model animation type", () => {
+    expect(fromModelAnimation(undefined)).toBe("none");
+    expect(fromModelAnimation("fadeIn")).toBe("fade-in");
+    expect(fromModelAnimation("slideIn")).toBe("fly-in-left");
+    expect(fromModelAnimation("zoomIn")).toBe("bounce");
+  });
+
+  it("maps the 'Out' variants back to the matching entrance choice", () => {
+    expect(fromModelAnimation("fadeOut")).toBe("fade-in");
+    expect(fromModelAnimation("slideOut")).toBe("fly-in-left");
+    expect(fromModelAnimation("zoomOut")).toBe("bounce");
+  });
+
+  it("round-trips every entrance choice through the model and back", () => {
+    expect(fromModelAnimation(toModelAnimation("fade-in"))).toBe("fade-in");
+    expect(fromModelAnimation(toModelAnimation("fly-in-left"))).toBe("fly-in-left");
+    expect(fromModelAnimation(toModelAnimation("bounce"))).toBe("bounce");
   });
 });


### PR DESCRIPTION
## 概要

`AnimationTab` が、選択中のオブジェクトに既に適用されているアニメーションをタブ表示に反映するようにした。`TransitionTab` がアクティブスライドの画面切り替えを反映するのと同じ挙動を、要素アニメーション側にも揃える。

### 背景 / 問題
これまで `AnimationTab` の選択状態はローカル `useState` のみで、オブジェクトを選び直してもスライドを切り替えても常に「なし」表示だった。そのため「この要素に既にどのアニメが付いているか」がUIから分からなかった（`TransitionTab` は `useEffect` で保存値を復元済みで、挙動が非対称だった）。

### 変更
- `fromModelAnimation()`: 永続化モデル型（`fadeIn`/`slideIn`/`zoomIn` 等）→ UI選択（`fade-in`/`fly-in-left`/`bounce`）の逆引きを追加。`Out` 変種は再生側（`slidePlayback.ts`）と同じく対応するエントランスに寄せる
- `selection:created` / `selection:updated` / `selection:cleared` を購読し、選択オブジェクトの保存済みアニメをタブに追従させる
- 逆引き・`Out`変種・往復のユニットテストを追加

## テスト
- `npm run lint`: 0 errors（既存warningのみ、増加なし）
- `npm run type-check` (tsc --noEmit): exit 0
- `npm run test`: 171 passed（+3 新規）

## 影響範囲
編集機能のRibbon「アニメーション」タブのみ。永続化スキーマ・再生ロジックは無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)