### PR TITLE
アニメ模型型ズレ解消: zoomIn はズーム/bounce は独自型に対応付け

### DIFF
--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { Square, Sparkles, ArrowRightToLine, ArrowDownToLine, Play } from "lucide-react";
+import { Square, Sparkles, ArrowRightToLine, ArrowDownToLine, ZoomIn, Play } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useSlideStore } from "../../stores/slideStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
@@ -19,16 +19,19 @@ const ANIMATIONS: { type: AnimChoice; label: string; icon: React.ReactNode }[] =
   { type: "none", label: "なし", icon: <Square /> },
   { type: "fade-in", label: "フェードイン", icon: <Sparkles /> },
   { type: "fly-in-left", label: "スライドイン", icon: <ArrowRightToLine /> },
+  { type: "zoom-in", label: "ズームイン", icon: <ZoomIn /> },
   { type: "bounce", label: "バウンス", icon: <ArrowDownToLine /> },
 ];
 
-// Map the preview-level entrance to the persisted model animation type.
-// "bounce" has no model equivalent yet and stores as the closest entrance.
+// Map the preview-level entrance to the persisted model animation type. Each
+// entrance now has a matching model type, so the stored type reflects the motion
+// actually played (no more "bounce stored as zoomIn" mismatch).
 export function toModelAnimation(t: EntranceType): ElementAnimationType {
   switch (t) {
     case "fade-in": return "fadeIn";
     case "fly-in-left": return "slideIn";
-    case "bounce": return "zoomIn";
+    case "zoom-in": return "zoomIn";
+    case "bounce": return "bounce";
   }
 }
 
@@ -46,6 +49,8 @@ export function fromModelAnimation(t: ElementAnimationType | undefined): AnimCho
       return "fly-in-left";
     case "zoomIn":
     case "zoomOut":
+      return "zoom-in";
+    case "bounce":
       return "bounce";
     default:
       return "none";

--- a/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
+++ b/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
@@ -30,25 +30,28 @@ describe("animation type mapping", () => {
   it("maps preview entrance types to persisted model animation types", () => {
     expect(toModelAnimation("fade-in")).toBe("fadeIn");
     expect(toModelAnimation("fly-in-left")).toBe("slideIn");
-    expect(toModelAnimation("bounce")).toBe("zoomIn");
+    expect(toModelAnimation("zoom-in")).toBe("zoomIn");
+    expect(toModelAnimation("bounce")).toBe("bounce");
   });
 
   it("restores the UI selection from a persisted model animation type", () => {
     expect(fromModelAnimation(undefined)).toBe("none");
     expect(fromModelAnimation("fadeIn")).toBe("fade-in");
     expect(fromModelAnimation("slideIn")).toBe("fly-in-left");
-    expect(fromModelAnimation("zoomIn")).toBe("bounce");
+    expect(fromModelAnimation("zoomIn")).toBe("zoom-in");
+    expect(fromModelAnimation("bounce")).toBe("bounce");
   });
 
   it("maps the 'Out' variants back to the matching entrance choice", () => {
     expect(fromModelAnimation("fadeOut")).toBe("fade-in");
     expect(fromModelAnimation("slideOut")).toBe("fly-in-left");
-    expect(fromModelAnimation("zoomOut")).toBe("bounce");
+    expect(fromModelAnimation("zoomOut")).toBe("zoom-in");
   });
 
   it("round-trips every entrance choice through the model and back", () => {
     expect(fromModelAnimation(toModelAnimation("fade-in"))).toBe("fade-in");
     expect(fromModelAnimation(toModelAnimation("fly-in-left"))).toBe("fly-in-left");
+    expect(fromModelAnimation(toModelAnimation("zoom-in"))).toBe("zoom-in");
     expect(fromModelAnimation(toModelAnimation("bounce"))).toBe("bounce");
   });
 });

--- a/web/src/lib/fabric/animation.ts
+++ b/web/src/lib/fabric/animation.ts
@@ -2,7 +2,7 @@ import type { Canvas, FabricObject } from "fabric";
 
 export type TransitionType = "none"|"fade"|"slide-left"|"slide-right"|"zoom";
 
-export type EntranceType = "fade-in"|"fly-in-left"|"bounce";
+export type EntranceType = "fade-in"|"fly-in-left"|"bounce"|"zoom-in";
 
 // Animate a single object as an entrance preview on the canvas.
 // Restores the object's original properties when done so it is non-destructive.
@@ -29,6 +29,13 @@ export async function animateEntrance(
     obj.animate(
       { scaleX: targetScaleX, scaleY: targetScaleY },
       { duration, easing: easeOutBounce, onChange: render },
+    );
+  } else if (type === "zoom-in") {
+    obj.set({ scaleX: targetScaleX * 0.2, scaleY: targetScaleY * 0.2 });
+    render();
+    obj.animate(
+      { scaleX: targetScaleX, scaleY: targetScaleY },
+      { duration, easing: easeOutCubic, onChange: render },
     );
   }
   await delay(duration);

--- a/web/src/lib/fabric/slidePlayback.test.ts
+++ b/web/src/lib/fabric/slidePlayback.test.ts
@@ -41,8 +41,9 @@ describe("modelAnimationToEntrance", () => {
     expect(modelAnimationToEntrance("fadeOut")).toBe("fade-in");
     expect(modelAnimationToEntrance("slideIn")).toBe("fly-in-left");
     expect(modelAnimationToEntrance("slideOut")).toBe("fly-in-left");
-    expect(modelAnimationToEntrance("zoomIn")).toBe("bounce");
-    expect(modelAnimationToEntrance("zoomOut")).toBe("bounce");
+    expect(modelAnimationToEntrance("zoomIn")).toBe("zoom-in");
+    expect(modelAnimationToEntrance("zoomOut")).toBe("zoom-in");
+    expect(modelAnimationToEntrance("bounce")).toBe("bounce");
   });
 });
 

--- a/web/src/lib/fabric/slidePlayback.ts
+++ b/web/src/lib/fabric/slidePlayback.ts
@@ -41,6 +41,8 @@ export function modelAnimationToEntrance(t: ElementAnimationType): EntranceType 
       return "fly-in-left";
     case "zoomIn":
     case "zoomOut":
+      return "zoom-in";
+    case "bounce":
       return "bounce";
   }
 }

--- a/web/src/shared/types/slide.ts
+++ b/web/src/shared/types/slide.ts
@@ -63,7 +63,8 @@ export type ElementAnimationType =
   | "slideIn"
   | "slideOut"
   | "zoomIn"
-  | "zoomOut";
+  | "zoomOut"
+  | "bounce";
 
 export type FabricObject = Record<string, unknown>;
 


### PR DESCRIPTION
## 概要
`bounce` エントランスが `zoomIn` として保存され、`zoomIn` 模型型がバウンス動作で再生される **型と意味の不一致** を解消する。再生側は既存挙動を維持しつつ、保存される型が実際に再生される動作と一致するようにした。

## 変更点
- `ElementAnimationType` に `"bounce"` を追加（API 側は animation type を自由文字列で保持しており enum 検証がないため、フロントのみで完結・後方互換）
- `EntranceType` に clean な `"zoom-in"`（ease-out scale、バウンスとは別の素直なズーム）を追加
- 再生/UI のマッピングを統一: `zoomIn`/`zoomOut` ↔ `zoom-in`、`bounce` ↔ `bounce`
- AnimationTab に「ズームイン」選択肢を追加し、「バウンス」と別物として選べるようにした
- 対応するマッピングテストを更新

## 検証
- `npm run type-check`: pass（エラーなし）
- `npm run test`: 171 passed (24 files)
- `npm run lint`: 0 errors（既存の warning 6件は本 PR 非対象ファイル）

## 後方互換
既存データに `zoomIn` が保存されていても、UI は「ズームイン」として復元され、再生はズーム動作になる（従来はバウンス再生だったため、意味どおりに改善）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)