### PR TITLE
要素アニメに遅延/順序の authoring UI を追加

### DIFF
--- a/web/src/features/editor/components/Ribbon/AnimationTab.tsx
+++ b/web/src/features/editor/components/Ribbon/AnimationTab.tsx
@@ -64,11 +64,35 @@ function targetIdFor(_canvas: NonNullable<ReturnType<typeof useEditorStore.getSt
   return ensureObjectId(obj as Parameters<typeof ensureObjectId>[0]);
 }
 
+/**
+ * Replace (or insert) the animation for `targetId` in `existing`, merging the
+ * given patch onto it. Order/delay authoring edits go through here so the rest
+ * of the list is preserved and the target keeps a single animation. A fresh
+ * animation defaults to a fade-in entrance at the end of the play order.
+ */
+export function upsertAnimation(
+  existing: ElementAnimation[],
+  targetId: string,
+  patch: Partial<Omit<ElementAnimation, "targetId">>,
+): ElementAnimation[] {
+  const others = existing.filter((a) => a.targetId !== targetId);
+  const current = existing.find((a) => a.targetId === targetId);
+  const base: ElementAnimation = current ?? {
+    targetId,
+    type: "fadeIn",
+    order: others.length,
+    durationMs: ANIMATION_DURATION_MS,
+  };
+  return [...others, { ...base, ...patch, targetId }];
+}
+
 export function AnimationTab() {
   const { canvas, activeSlideId, presentationId } = useEditorStore();
   const { slides, updateSlideMeta } = useSlideStore();
   const { accessToken } = useAuthStore();
   const [selected, setSelected] = useState<AnimChoice>("none");
+  const [delayMs, setDelayMs] = useState(0);
+  const [order, setOrder] = useState(0);
 
   // Reflect the saved animation of whatever object is currently selected, the
   // same way TransitionTab reflects the active slide's transition. Without this
@@ -79,12 +103,16 @@ export function AnimationTab() {
       const obj = canvas.getActiveObject();
       if (!obj) {
         setSelected("none");
+        setDelayMs(0);
+        setOrder(0);
         return;
       }
       const id = (obj as { id?: string }).id;
       const anims = slides.find((s) => s.id === activeSlideId)?.animations ?? [];
       const match = id ? anims.find((a) => a.targetId === id) : undefined;
       setSelected(fromModelAnimation(match?.type));
+      setDelayMs(match?.delayMs ?? 0);
+      setOrder(match?.order ?? 0);
     };
     sync();
     canvas.on("selection:created", sync);
@@ -97,6 +125,23 @@ export function AnimationTab() {
     };
   }, [canvas, activeSlideId, slides]);
 
+  // Persist an updated animation list to the store and (if signed in) the API.
+  async function persist(animations: ElementAnimation[]) {
+    if (!activeSlideId) return;
+    updateSlideMeta(activeSlideId, { animations });
+    if (accessToken && presentationId) {
+      await slidesApi.updateMeta(accessToken, presentationId, activeSlideId, { animations });
+    }
+  }
+
+  // Stable target id of the active object, or null if nothing is selected.
+  function activeTargetId(): string | null {
+    if (!canvas) return null;
+    const obj = canvas.getActiveObject();
+    if (!obj) return null;
+    return targetIdFor(canvas, obj);
+  }
+
   async function apply(type: AnimChoice) {
     setSelected(type);
     if (type === "none" || !canvas) return;
@@ -104,24 +149,22 @@ export function AnimationTab() {
     if (!obj) return;
     void animateEntrance(canvas, obj, type);
 
-    if (!activeSlideId) return;
-    const targetId = targetIdFor(canvas, obj);
+    const targetId = activeTargetId();
     if (targetId === null) return;
-
-    // Replace any existing animation for this target, keep order ascending.
     const existing = slides.find((s) => s.id === activeSlideId)?.animations ?? [];
-    const others = existing.filter((a) => a.targetId !== targetId);
-    const next: ElementAnimation = {
-      targetId,
-      type: toModelAnimation(type),
-      order: others.length,
-      durationMs: ANIMATION_DURATION_MS,
-    };
-    const animations = [...others, next];
-    updateSlideMeta(activeSlideId, { animations });
-    if (accessToken && presentationId) {
-      await slidesApi.updateMeta(accessToken, presentationId, activeSlideId, { animations });
-    }
+    await persist(upsertAnimation(existing, targetId, { type: toModelAnimation(type) }));
+  }
+
+  // Update the timing (delay / play order) of the selected object's animation.
+  // Only meaningful once an animation exists; upsert seeds a fade-in otherwise
+  // so timing can be authored before picking a motion.
+  async function patchTiming(patch: { delayMs?: number; order?: number }) {
+    if (patch.delayMs !== undefined) setDelayMs(patch.delayMs);
+    if (patch.order !== undefined) setOrder(patch.order);
+    const targetId = activeTargetId();
+    if (targetId === null) return;
+    const existing = slides.find((s) => s.id === activeSlideId)?.animations ?? [];
+    await persist(upsertAnimation(existing, targetId, patch));
   }
 
   function preview() {
@@ -158,6 +201,62 @@ export function AnimationTab() {
           title="選択したアニメーションを再生"
         />
       </RibbonGroup>
+      <RibbonDivider />
+
+      <RibbonGroup label="タイミング">
+        <div className="flex items-center gap-3 px-1">
+          <TimingField
+            label="遅延 (ms)"
+            value={delayMs}
+            min={0}
+            step={100}
+            disabled={!canvas || selected === "none"}
+            onCommit={(v) => void patchTiming({ delayMs: v })}
+            title="再生開始までの待ち時間（ミリ秒）"
+          />
+          <TimingField
+            label="順序"
+            value={order}
+            min={0}
+            step={1}
+            disabled={!canvas || selected === "none"}
+            onCommit={(v) => void patchTiming({ order: v })}
+            title="スライド内での再生順（小さいほど先に再生）"
+          />
+        </div>
+      </RibbonGroup>
     </div>
+  );
+}
+
+// A compact labeled number input used for animation timing (delay / order).
+// Commits on change; clamps to `min` so negative values can't be persisted.
+function TimingField({
+  label, value, min, step, disabled, onCommit, title,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  step: number;
+  disabled?: boolean;
+  onCommit: (value: number) => void;
+  title?: string;
+}) {
+  return (
+    <label className="flex flex-col items-start gap-0.5" title={title}>
+      <span className="text-[10px] leading-none text-[#605E5C]">{label}</span>
+      <input
+        type="number"
+        min={min}
+        step={step}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          onCommit(Number.isFinite(n) ? Math.max(min, n) : min);
+        }}
+        className="h-7 w-16 rounded border border-border bg-white px-1.5 text-xs text-content-primary disabled:opacity-40"
+      />
+    </label>
   );
 }

--- a/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
+++ b/web/src/features/editor/components/Ribbon/transitionMapping.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
+import type { ElementAnimation } from "@shared/types/slide";
 import { toModelTransition, fromModelTransition } from "./TransitionTab";
-import { toModelAnimation, fromModelAnimation } from "./AnimationTab";
+import { toModelAnimation, fromModelAnimation, upsertAnimation } from "./AnimationTab";
 
 describe("transition type mapping", () => {
   it("maps preview transition types to persisted model types", () => {
@@ -53,5 +54,39 @@ describe("animation type mapping", () => {
     expect(fromModelAnimation(toModelAnimation("fly-in-left"))).toBe("fly-in-left");
     expect(fromModelAnimation(toModelAnimation("zoom-in"))).toBe("zoom-in");
     expect(fromModelAnimation(toModelAnimation("bounce"))).toBe("bounce");
+  });
+});
+
+describe("upsertAnimation", () => {
+  const a: ElementAnimation = { targetId: "a", type: "fadeIn", order: 0, durationMs: 600 };
+  const b: ElementAnimation = { targetId: "b", type: "slideIn", order: 1, durationMs: 600 };
+
+  it("seeds a fade-in entrance when the target has no animation yet", () => {
+    const next = upsertAnimation([a], "b", { delayMs: 200 });
+    expect(next).toHaveLength(2);
+    const created = next.find((x) => x.targetId === "b")!;
+    expect(created.type).toBe("fadeIn");
+    expect(created.order).toBe(1); // appended after the one existing animation
+    expect(created.delayMs).toBe(200);
+    expect(created.durationMs).toBe(600);
+  });
+
+  it("merges the patch onto the existing animation, preserving other fields", () => {
+    const next = upsertAnimation([a, b], "a", { delayMs: 300, order: 2 });
+    const updated = next.find((x) => x.targetId === "a")!;
+    expect(updated.type).toBe("fadeIn"); // unchanged
+    expect(updated.delayMs).toBe(300);
+    expect(updated.order).toBe(2);
+  });
+
+  it("leaves other targets untouched", () => {
+    const next = upsertAnimation([a, b], "a", { order: 5 });
+    expect(next.find((x) => x.targetId === "b")).toEqual(b);
+  });
+
+  it("never duplicates the target", () => {
+    const next = upsertAnimation([a, b], "a", { type: "zoomIn" });
+    expect(next.filter((x) => x.targetId === "a")).toHaveLength(1);
+    expect(next.find((x) => x.targetId === "a")!.type).toBe("zoomIn");
   });
 });


### PR DESCRIPTION
## 概要
再生側 `playSlideAnimations` は既に `delayMs` を尊重し `order` 昇順で再生するが、エディタ UI からはどちらも設定できなかった。AnimationTab に「タイミング」グループを追加し、選択オブジェクトのアニメに対して **遅延 (ms)** と **再生順序** を編集・保存できるようにする。

## 変更点
- `upsertAnimation` ヘルパーを切り出し（既存アニメ配列に patch を merge / 対象が未設定なら fade-in を seed / 同一 target を重複させない）。`apply()` も同ヘルパー経由に統一
- `delayMs` / `order` の state を選択オブジェクトの保存値と同期（選択切り替えで反映）
- 数値入力コンポーネント `TimingField` を追加（`min` クランプ・アニメ未選択時は無効化）
- `upsertAnimation` のユニットテストを追加（seed / merge / 他 target 不変 / 重複なし）

## 検証
- `npm run type-check`: pass（エラーなし）
- `npm run test`: 175 passed (24 files、新規4件)
- `npm run lint`: 0 errors（既存 warning 6件は本 PR 非対象ファイル）

## スコープ外（意図的）
退場 (Out) アニメの authoring は本 PR に含めない。再生層 (`modelAnimationToEntrance`) は現状 Out variant を入場モーションとして再生する（真の退場プリミティブが未実装）ため、退場 UI を出すと挙動と乖離する。退場は再生層に exit モーションを足すフォローアップで対応するのが安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)