### PR TITLE
退場アニメをスライド再生に結線(present/view)

### DIFF
--- a/web/src/app/(auth)/present/[id]/page.tsx
+++ b/web/src/app/(auth)/present/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
 import { createCanvas, loadFromJSON, SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
 import { playTransition } from "@lib/fabric/animation";
-import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
+import { modelTransitionToPreview, playSlideAnimations, playSlideExitAnimations, isExitAnimation } from "@lib/fabric/slidePlayback";
 import { PresenterSocket, type ViewerStatus } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
@@ -20,6 +20,10 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const presenterRef = useRef<PresenterSocket | null>(null);
+  // The slide currently shown on the canvas. Used so that when `cur` changes we
+  // can play the outgoing slide's exit ("Out") animations before swapping in
+  // the next slide's content.
+  const shownSlideRef = useRef<Slide | null>(null);
 
   useEffect(() => {
     if (!accessToken) return;
@@ -34,15 +38,27 @@ export default function PresentPage({ params }: { params: Promise<{ id: string }
     if (!canvasRef.current || !slide) return;
     const c = createCanvas(canvasRef.current, { width: SLIDE_WIDTH / 2, height: SLIDE_HEIGHT / 2 });
     let cancelled = false;
-    // Play the saved slide-level transition, then the per-element entrance
-    // animations once the content is loaded. Guarded so an unmount mid-play
-    // does not touch a disposed canvas.
+    // If we're moving away from a slide that had exit ("Out") animations, render
+    // that outgoing slide on the fresh canvas and play its exits first, so the
+    // audience sees the elements leave before the next slide loads. Then play the
+    // slide-level transition, load the new content, and play its entrances.
+    // Guarded so an unmount mid-play does not touch a disposed canvas.
     (async () => {
+      const outgoing = shownSlideRef.current;
+      const hasExit = outgoing?.animations?.some((a) => isExitAnimation(a.type));
+      if (outgoing && outgoing.id !== slide.id && hasExit) {
+        await loadFromJSON(c, outgoing.content);
+        if (cancelled) return;
+        await playSlideExitAnimations(c, outgoing.animations);
+      }
+      if (cancelled) return;
       if (stageRef.current) {
         await playTransition(stageRef.current, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
       }
       await loadFromJSON(c, slide.content);
-      if (!cancelled) await playSlideAnimations(c, slide.animations);
+      if (cancelled) return;
+      shownSlideRef.current = slide;
+      await playSlideAnimations(c, slide.animations);
     })();
     return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);

--- a/web/src/app/view/[id]/page.tsx
+++ b/web/src/app/view/[id]/page.tsx
@@ -2,7 +2,7 @@
 import { use, useEffect, useRef, useState, useCallback } from "react";
 import { createCanvas, loadFromJSON, fitToContainer } from "@lib/fabric/canvas";
 import { playTransition } from "@lib/fabric/animation";
-import { modelTransitionToPreview, playSlideAnimations } from "@lib/fabric/slidePlayback";
+import { modelTransitionToPreview, playSlideAnimations, playSlideExitAnimations, isExitAnimation } from "@lib/fabric/slidePlayback";
 import { ViewerSocket, type ViewerStatus } from "@lib/realtime/presenter";
 import type { Slide } from "@shared/types/slide";
 
@@ -22,6 +22,9 @@ export default function ViewPage({ params }: { params: Promise<{ id: string }> }
   const [status, setStatus] = useState<ViewerStatus>("connecting");
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  // The slide currently shown, so we can play its exit animations when the
+  // presenter advances to the next slide (mirrors the presenter view).
+  const shownSlideRef = useRef<Slide | null>(null);
 
   useEffect(() => {
     fetch(`/api/presentations/${id}/slides`).then(r=>r.json()).then((d:{items:Slide[]})=>setSlides(d.items??[]));
@@ -46,13 +49,24 @@ export default function ViewPage({ params }: { params: Promise<{ id: string }> }
     const c = createCanvas(canvasRef.current);
     fitToContainer(c, containerRef.current.clientWidth);
     let cancelled = false;
-    // Same playback the presenter sees: slide-level transition first, then the
-    // per-element entrance animations once the content is loaded.
+    // Same playback the presenter sees: when leaving a slide that has exit
+    // animations, render it and play the exits first, then the slide-level
+    // transition, then load the new content and play its entrance animations.
     (async () => {
+      const outgoing = shownSlideRef.current;
+      const hasExit = outgoing?.animations?.some((a) => isExitAnimation(a.type));
+      if (outgoing && outgoing.id !== slide.id && hasExit) {
+        await loadFromJSON(c, outgoing.content);
+        if (cancelled) return;
+        await playSlideExitAnimations(c, outgoing.animations);
+      }
+      if (cancelled) return;
       const stage = c.wrapperEl;
       if (stage) await playTransition(stage, modelTransitionToPreview(slide.transition?.type), slide.transition?.durationMs);
       await loadFromJSON(c, slide.content);
-      if (!cancelled) await playSlideAnimations(c, slide.animations);
+      if (cancelled) return;
+      shownSlideRef.current = slide;
+      await playSlideAnimations(c, slide.animations);
     })();
     return () => { cancelled = true; c.dispose(); };
   }, [cur, slides]);


### PR DESCRIPTION
## 概要
PR #120 の再生実体（`playSlideExitAnimations`）と #121 の authoring UI を、実際のスライド再生に結線。発表者ビュー（present）・視聴者ビュー（view）の両方で、スライドを離れる際に退場アニメが再生されるようにした。

## 変更点
- スライド切替時、離れるスライドに退場（Out）アニメを持つ要素があれば、そのスライドを再描画して `playSlideExitAnimations` を実行 → 画面切り替え → 次スライド読込 → 入場、の順に再生。
- `shownSlideRef` で現在表示中スライドを保持し、`cur` 変化時に退場の要否を判定（`isExitAnimation`）。退場が無いスライドは従来通り即座に遷移（挙動不変）。
- 各 `await` 後に `cancelled` ガードを追加し、アンマウント／高速操作時に dispose 済み canvas を触らないようにした。
- present / view に対称適用。

## テスト
- 全 181 テスト green（ページコンポーネントはリアルタイム依存のため既存方針通り単体テスト対象外）。tsc / eslint 通過。

## 動作確認
- `npx tsc --noEmit` … エラー 0
- `npx vitest run` … 24 files / 181 tests passed
- `npx eslint`（対象2ファイル）… エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)