### PR TITLE
fix(editor): スライド追加時のクラッシュを修正(stale closure)

### DIFF
--- a/web/src/features/editor/components/SlidePanel/SlidePanel.test.tsx
+++ b/web/src/features/editor/components/SlidePanel/SlidePanel.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useSlideStore } from "../../stores/slideStore";
+import { useEditorStore } from "../../stores/editorStore";
+import type { Slide } from "@shared/types/slide";
+
+// SlidePanel only needs SLIDE_WIDTH/HEIGHT from the canvas module; mock it so the
+// module's fabric side effects (applyPowerPointControls) don't run under jsdom.
+vi.mock("@lib/fabric/canvas", () => ({ SLIDE_WIDTH: 1280, SLIDE_HEIGHT: 720 }));
+
+vi.mock("@features/dashboard/stores/authStore", () => ({
+  useAuthStore: Object.assign(
+    () => ({ accessToken: "tok" }),
+    { getState: () => ({ accessToken: "tok" }) },
+  ),
+}));
+
+// slidesApi.create returns the freshly created slide (server-assigned id).
+const createSpy = vi.fn(
+  async (): Promise<Slide> => ({
+    id: "new-slide",
+    presentationId: "p1",
+    position: 1,
+    content: { version: "6.0.0", objects: [] },
+    createdAt: "",
+    updatedAt: "",
+  }),
+);
+vi.mock("@shared/api/slides", () => ({
+  slidesApi: {
+    create: (...args: unknown[]) => createSpy(...(args as [])),
+    updateContent: vi.fn(async () => ({})),
+  },
+}));
+
+import { SlidePanel } from "./SlidePanel";
+
+function existingSlide(): Slide {
+  return {
+    id: "s1",
+    presentationId: "p1",
+    position: 0,
+    content: { version: "6.0.0", objects: [] },
+    createdAt: "",
+    updatedAt: "",
+  };
+}
+
+describe("SlidePanel — add slide regression", () => {
+  beforeEach(() => {
+    createSpy.mockClear();
+    useSlideStore.setState({ slides: [existingSlide()], currentIndex: 0 });
+    useEditorStore.setState({ activeSlideId: "s1", presentationId: "p1" });
+  });
+
+  // Regression: handleAdd used handleSelect(slides.length) where `slides` was the
+  // render-time snapshot (length 1). slides[1] was undefined, so reading `.id`
+  // threw "Cannot read properties of undefined (reading 'id')" the moment a new
+  // slide was added. The fix selects by the created slide's id instead.
+  it("adds a slide and makes it active without throwing", async () => {
+    render(<SlidePanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: /スライドを追加/ }));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      // The newly created slide is appended and selected.
+      expect(useSlideStore.getState().slides.map((s) => s.id)).toEqual([
+        "s1",
+        "new-slide",
+      ]);
+      expect(useEditorStore.getState().activeSlideId).toBe("new-slide");
+      expect(useSlideStore.getState().currentIndex).toBe(1);
+    });
+  });
+});

--- a/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
+++ b/web/src/features/editor/components/SlidePanel/SlidePanel.tsx
@@ -28,6 +28,15 @@ export function SlidePanel() {
     setActiveSlide(slides[i].id);
   }
 
+  // Select a slide we just appended. We can't reuse handleSelect(slides.length)
+  // here because `slides` is the render-time snapshot — addSlide updates the
+  // store but this closure still sees the pre-add array, so slides[slides.length]
+  // is undefined and reading `.id` throws. Select by the created id directly.
+  function selectAppended(slideId: string) {
+    setCurrentIndex(slides.length);
+    setActiveSlide(slideId);
+  }
+
   async function handleAdd() {
     if (!accessToken || !presentationId || adding) return;
     setAdding(true);
@@ -36,7 +45,7 @@ export function SlidePanel() {
       addSlide(s as Slide);
       // Mirror the new slide into the shared doc so peers see it too.
       structure.addSlide((s as Slide).id);
-      handleSelect(slides.length);
+      selectAppended((s as Slide).id);
     } finally { setAdding(false); }
   }
 
@@ -51,7 +60,7 @@ export function SlidePanel() {
       // Mirror the duplicated slide into the shared doc; its objects sync via
       // the per-slide ObjectBinding / projection autosave.
       structure.addSlide(created.id);
-      handleSelect(slides.length);
+      selectAppended(created.id);
     } finally { setAdding(false); }
   }
 


### PR DESCRIPTION
## 概要
「新しくスライドを追加/開いたらエラーが出る」報告の修正。

## 原因
`SlidePanel` の `handleAdd` / `handleDuplicate` が `handleSelect(slides.length)` を呼んでいた。`handleSelect(i)` は `setActiveSlide(slides[i].id)` を実行するが、ここで参照する `slides` は**レンダー時点のスナップショット**。`addSlide`（zustand）はストアを更新するだけでこのクロージャが捕捉している配列は伸びないため、`slides[slides.length]` が `undefined` となり、`.id` 参照で次の例外が出ていた:

```
TypeError: Cannot read properties of undefined (reading 'id')
```

退場アニメ機能(#120-122)とは無関係で、`SlidePanel` の add パスに以前から潜んでいた stale-closure バグ（退場アニメ側の `.animations` アクセスは全て `?.` / 早期 return でガード済みであることを確認済み）。

## 修正
作成済みスライドの `id` を直接使って選択する `selectAppended(id)` に置き換え、`NewSlideButton`（既に `created.id` で安全に選択している）と同じ方式に統一。`currentIndex` は追加前の `slides.length` がそのまま新インデックスになるため従来どおり。

## テスト
- 回帰テスト `SlidePanel.test.tsx` を追加：スライド追加が例外なく新スライドをアクティブにすることを検証
- `npm run test`: 190 passed (25 files) ※既存189 + 新規1
- `npm run type-check`: エラー0
- `npm run lint`: エラー0（既存の警告6件のみ・本PR非該当ファイル）

## レビュー
マルチ人格レビュー（#6 TS/React・#2 フルスタック）実施、[must] なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)