### PR TITLE
nginx: client_max_body_size を 25m に拡大(PPTX大容量スライド対策)

### DIFF
--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -3,6 +3,12 @@ events {
 }
 
 http {
+    # Imported PPTX slides embed images as base64 data URLs inside the slide
+    # content JSON, so a single PUT /api/presentations/.../slides/... body can be
+    # several MB. nginx's 1MB default rejected those with 413 (the import then
+    # surfaced a generic "インポートに失敗しました"). Allow large slide payloads.
+    client_max_body_size 25m;
+
     upstream api_upstream    { server api:8080; }
     upstream collab_upstream { server collab:8081; }
     upstream rt_upstream     { server realtime:8082; }


### PR DESCRIPTION
## What
開発用 nginx の `client_max_body_size` を 1MB(デフォルト) -> 25m に引き上げる。

## Why
インポートした PPTX スライドは画像を base64 data URL としてスライド content JSON に埋め込むため、`PUT /api/presentations/.../slides/...` の body が数MBになる。nginx のデフォルト 1MB が 413 で弾き、UI には汎用の「インポートに失敗しました」が出ていた。

## Scope
- 変更: `infra/nginx/nginx.dev.conf` のみ(6行追加、コメント込み)
- PR #124(PPTXインポート機能+根治)とは独立。無関係変更を混ぜないため別PRに分離。

## Test
設定のみの変更でアプリのビルド/型/テストに影響なし。413 解消は実機(docker compose)起動時に確認する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)