### PR TITLE
CI: Vitest カバレッジゲート(ラチェット式)を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Install web deps
         working-directory: web
         run: npm ci --legacy-peer-deps
-      - name: Run Vitest
+      - name: Run Vitest with coverage gate
         working-directory: web
-        run: npm run test
+        run: npm run test:coverage
 
   go-unit:
     name: Go Unit Tests

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -14,6 +14,18 @@ export default defineConfig({
       reporter: ["text", "html"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.{test,spec}.{ts,tsx}", "src/**/*.d.ts"],
+      // Ratchet floor: thresholds are set just below the current measured
+      // coverage so CI fails on any regression but does not break the build
+      // today. The codebase is still mostly untested React UI (pages/panels),
+      // so the 60% line target from the quality plan is reached by raising
+      // these numbers incrementally as tests are added. Do NOT lower them;
+      // only raise.
+      thresholds: {
+        lines: 20,
+        statements: 20,
+        functions: 50,
+        branches: 65,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## What
- `web/vitest.config.ts` に `coverage.thresholds` を追加
- CI の web-unit ジョブを `npm run test` -> `npm run test:coverage` に変更(`.github/workflows/ci.yml`)

これで全PRでカバレッジが強制される。

## 閾値の考え方(ラチェット floor)
現状の実測カバレッジ(201テスト)は以下の通り:

| 指標 | 実測 | 設定閾値 |
|---|---|---|
| Lines | 22.44% | 20% |
| Statements | 22.44% | 20% |
| Functions | 52.06% | 50% |
| Branches | 71.66% | 65% |

計画のPR2は「全体 lines 60% 下限」だが、コードベースの大半が未テストのReact UI(pages/panels)で**現状22.44%**。ここで60%を課すと**CIが即座に落ちて以後の全PRをブロック=ビルドを壊す**。

そこで計画の指示どおり「実測値の少し下に設定し段階的に上げる」方針を採用。閾値を**現状の少し下のラチェット floor**にすることで:
- カバレッジが**下がったら即CI失敗**(回帰防止)
- 今日のビルドは壊さない
- テスト追加で数値を**上げる方向にのみ**動かし、最終的に lines 60% を目指す

`thresholds` のコメントに「Do NOT lower them; only raise」と明記済み。

## Test(ローカル実出力で緑確認)
- `npx tsc --noEmit` -> exit 0
- `npm run lint` -> 0 error(既存warning 6件のみ)
- `npm run test:coverage` -> 28 files / 201 tests passed、閾値クリア(exit 0)
- `npm run build` -> 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)