### PR TITLE
PR4: export lib unit tests (pptx/pdf/png) + coverage floor raise

### DIFF
--- a/web/src/lib/export/pdf.test.ts
+++ b/web/src/lib/export/pdf.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Slide, SlideContent } from "@shared/types/slide";
+
+// jsPDF is mocked to assert page orchestration without producing a real PDF.
+const addImage = vi.fn();
+const addPage = vi.fn();
+const save = vi.fn();
+const ctor = vi.fn();
+
+vi.mock("jspdf", () => ({
+  default: class {
+    constructor(opts: unknown) {
+      ctor(opts);
+    }
+    addImage = addImage;
+    addPage = addPage;
+    save = save;
+  },
+}));
+
+vi.mock("./renderSlides", () => ({
+  renderAllSlides: vi.fn(async (slides: Slide[]) =>
+    slides.map((_, i) => `data:image/png;base64,IMG${i}`),
+  ),
+}));
+
+import { exportToPDF } from "./pdf";
+import { renderAllSlides } from "./renderSlides";
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from "@lib/fabric/canvas";
+
+function makeSlide(id: string, position: number): Slide {
+  const content: SlideContent = { version: "6.0.0", objects: [] };
+  return {
+    id,
+    presentationId: "p1",
+    position,
+    content,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("exportToPDF", () => {
+  beforeEach(() => {
+    addImage.mockClear();
+    addPage.mockClear();
+    save.mockClear();
+    ctor.mockClear();
+    vi.mocked(renderAllSlides).mockClear();
+  });
+
+  it("adds one image per slide and a new page for every slide after the first", async () => {
+    const slides = [makeSlide("a", 0), makeSlide("b", 1), makeSlide("c", 2)];
+    await exportToPDF(slides, "deck");
+
+    // 3 slides -> 3 images, 2 extra pages (first page is implicit).
+    expect(addImage).toHaveBeenCalledTimes(3);
+    expect(addPage).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenCalledWith("deck.pdf");
+  });
+
+  it("sizes every image to the slide dimensions at the origin", async () => {
+    await exportToPDF([makeSlide("a", 0)], "one");
+    expect(addImage).toHaveBeenCalledWith(
+      "data:image/png;base64,IMG0",
+      "PNG",
+      0,
+      0,
+      SLIDE_WIDTH,
+      SLIDE_HEIGHT,
+    );
+  });
+
+  it("constructs a landscape PDF in pixel units", async () => {
+    await exportToPDF([makeSlide("a", 0)], "one");
+    expect(ctor).toHaveBeenCalledWith({
+      orientation: "landscape",
+      unit: "px",
+      format: [SLIDE_WIDTH, SLIDE_HEIGHT],
+    });
+  });
+
+  it("does nothing for an empty deck (no PDF created)", async () => {
+    await exportToPDF([], "empty");
+    expect(ctor).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("defaults the filename when no title is given", async () => {
+    await exportToPDF([makeSlide("a", 0)]);
+    expect(save).toHaveBeenCalledWith("presentation.pdf");
+  });
+});

--- a/web/src/lib/export/png.test.ts
+++ b/web/src/lib/export/png.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Slide, SlideContent } from "@shared/types/slide";
+
+vi.mock("./renderSlides", () => ({
+  renderAllSlides: vi.fn(async (slides: Slide[]) =>
+    slides.map((_, i) => `data:image/png;base64,IMG${i}`),
+  ),
+}));
+
+import {
+  exportAllSlidesToPNG,
+  exportToPNG,
+  exportToSVG,
+} from "./png";
+import { renderAllSlides } from "./renderSlides";
+
+function makeSlide(id: string, position: number): Slide {
+  const content: SlideContent = { version: "6.0.0", objects: [] };
+  return {
+    id,
+    presentationId: "p1",
+    position,
+    content,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+// Capture every anchor the exporter creates so we can assert href + download.
+interface FakeAnchor {
+  href: string;
+  download: string;
+  click: ReturnType<typeof vi.fn>;
+}
+
+let anchors: FakeAnchor[] = [];
+// Loosely typed so the typed createElement overloads don't fight the mock impl.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createElementSpy: any;
+
+beforeEach(() => {
+  anchors = [];
+  vi.mocked(renderAllSlides).mockClear();
+  const realCreate = document.createElement.bind(document);
+  createElementSpy = vi
+    .spyOn(document, "createElement")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation(((tag: string) => {
+      if (tag === "a") {
+        const a: FakeAnchor = { href: "", download: "", click: vi.fn() };
+        anchors.push(a);
+        return a as unknown as HTMLElement;
+      }
+      return realCreate(tag as "div");
+    }) as any);
+});
+
+afterEach(() => {
+  createElementSpy.mockRestore();
+});
+
+describe("exportAllSlidesToPNG", () => {
+  it("downloads one numbered PNG per slide in order", async () => {
+    const slides = [makeSlide("a", 0), makeSlide("b", 1), makeSlide("c", 2)];
+    await exportAllSlidesToPNG(slides, "shot");
+
+    expect(anchors).toHaveLength(3);
+    expect(anchors.map((a) => a.download)).toEqual([
+      "shot-1.png",
+      "shot-2.png",
+      "shot-3.png",
+    ]);
+    expect(anchors[0].href).toBe("data:image/png;base64,IMG0");
+    anchors.forEach((a) => expect(a.click).toHaveBeenCalledOnce());
+  });
+
+  it("defaults the filename prefix to 'slide'", async () => {
+    await exportAllSlidesToPNG([makeSlide("a", 0)]);
+    expect(anchors[0].download).toBe("slide-1.png");
+  });
+
+  it("downloads nothing for an empty deck", async () => {
+    await exportAllSlidesToPNG([]);
+    expect(anchors).toHaveLength(0);
+  });
+});
+
+describe("exportToPNG (single visible canvas)", () => {
+  it("rasterizes the canvas at 2x and downloads it", () => {
+    const toDataURL = vi.fn(() => "data:image/png;base64,SINGLE");
+    const canvas = { toDataURL } as unknown as Parameters<typeof exportToPNG>[0];
+
+    exportToPNG(canvas, "current");
+
+    expect(toDataURL).toHaveBeenCalledWith({ format: "png", multiplier: 2 });
+    expect(anchors[0].href).toBe("data:image/png;base64,SINGLE");
+    expect(anchors[0].download).toBe("current.png");
+    expect(anchors[0].click).toHaveBeenCalledOnce();
+  });
+});
+
+describe("exportToSVG", () => {
+  it("serializes the canvas to an SVG blob URL and downloads it", () => {
+    const createObjectURL = vi.fn(() => "blob:svg-url");
+    const revokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+    try {
+      const toSVG = vi.fn(() => "<svg></svg>");
+      const canvas = { toSVG } as unknown as Parameters<typeof exportToSVG>[0];
+
+      exportToSVG(canvas, "vector");
+
+      expect(toSVG).toHaveBeenCalledOnce();
+      expect(anchors[0].href).toBe("blob:svg-url");
+      expect(anchors[0].download).toBe("vector.svg");
+      expect(anchors[0].click).toHaveBeenCalledOnce();
+      // The object URL is revoked after the download is triggered.
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:svg-url");
+    } finally {
+      URL.createObjectURL = origCreate;
+      URL.revokeObjectURL = origRevoke;
+    }
+  });
+});

--- a/web/src/lib/export/pptx.test.ts
+++ b/web/src/lib/export/pptx.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Slide, SlideContent } from "@shared/types/slide";
+
+// --- Mocks -----------------------------------------------------------------
+// pptxgenjs is a heavy browser/Node lib; we only care that exportToPPTX wires
+// one PowerPoint slide per deck slide, each with the rasterized image, and
+// writes a file named after the title.
+const addImage = vi.fn();
+const addSlide = vi.fn(() => ({ addImage }));
+const writeFile = vi.fn(() => Promise.resolve("ok"));
+const defineLayout = vi.fn();
+
+vi.mock("pptxgenjs", () => {
+  return {
+    default: class {
+      defineLayout = defineLayout;
+      layout = "";
+      addSlide = addSlide;
+      writeFile = writeFile;
+    },
+  };
+});
+
+// Rasterizer is replaced so the test never touches a real Fabric canvas.
+vi.mock("./renderSlides", () => ({
+  renderAllSlides: vi.fn(async (slides: Slide[]) =>
+    slides.map((_, i) => `data:image/png;base64,IMG${i}`),
+  ),
+}));
+
+import { exportToPPTX } from "./pptx";
+import { renderAllSlides } from "./renderSlides";
+
+function makeSlide(id: string, position: number): Slide {
+  const content: SlideContent = { version: "6.0.0", objects: [] };
+  return {
+    id,
+    presentationId: "p1",
+    position,
+    content,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("exportToPPTX", () => {
+  beforeEach(() => {
+    addImage.mockClear();
+    addSlide.mockClear();
+    writeFile.mockClear();
+    defineLayout.mockClear();
+    vi.mocked(renderAllSlides).mockClear();
+  });
+
+  it("adds one PPTX slide per deck slide with the rasterized image", async () => {
+    const slides = [makeSlide("a", 0), makeSlide("b", 1), makeSlide("c", 2)];
+    await exportToPPTX(slides, "deck");
+
+    expect(addSlide).toHaveBeenCalledTimes(3);
+    expect(addImage).toHaveBeenCalledTimes(3);
+    // Each image is placed full-bleed with the rendered data URL.
+    expect(addImage).toHaveBeenNthCalledWith(1, {
+      data: "data:image/png;base64,IMG0",
+      x: 0,
+      y: 0,
+      w: "100%",
+      h: "100%",
+    });
+  });
+
+  it("defines a 16:9 layout and writes a file named after the title", async () => {
+    await exportToPPTX([makeSlide("a", 0)], "my-talk");
+    expect(defineLayout).toHaveBeenCalledWith({
+      name: "SLIDE_16x9",
+      width: 10,
+      height: 5.625,
+    });
+    expect(writeFile).toHaveBeenCalledWith({ fileName: "my-talk.pptx" });
+  });
+
+  it("defaults the filename when no title is given", async () => {
+    await exportToPPTX([makeSlide("a", 0)]);
+    expect(writeFile).toHaveBeenCalledWith({ fileName: "presentation.pptx" });
+  });
+
+  it("produces an empty (but valid) file for an empty deck", async () => {
+    await exportToPPTX([], "empty");
+    expect(addSlide).not.toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalledWith({ fileName: "empty.pptx" });
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
       // these numbers incrementally as tests are added. Do NOT lower them;
       // only raise.
       thresholds: {
-        lines: 20,
-        statements: 20,
-        functions: 50,
-        branches: 65,
+        lines: 22,
+        statements: 22,
+        functions: 52,
+        branches: 70,
       },
     },
   },


### PR DESCRIPTION
## 概要
品質強化計画 PR4。出力破損が即被害になる `lib/export/{pptx,pdf,png}.ts` の単体テストを追加。

## 変更内容
- pptxgenjs / jspdf / DOM ダウンロード / renderSlides をモックし、オーケストレーション(スライド数・画像データ・レイアウト・ファイル名・空デッキ処理)を決定的に検証。
- **14 テスト追加** (合計 201 -> 215)。
- カバレッジ床を **20/20/50/65 -> 22/22/52/70** に引き上げ (実測 23.07/72.42/53.19 を下回る安全マージン・下げない方針)。

## 緑証拠 (ローカル実出力)
- `npx tsc --noEmit`: exit 0 (エラーなし)
- `npm run lint`: 0 error (既存 warning 6 のみ)
- `npx vitest run`: 31 files / **215 passed**
- `npx vitest run --coverage`: 床クリア (exit 0)
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)