### PR TITLE
PR5: Fabric tool geometry unit tests (autoLayout/pen/nodeEditor)

### DIFF
--- a/web/src/lib/fabric/tools/autoLayout.test.ts
+++ b/web/src/lib/fabric/tools/autoLayout.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyAutoLayout, distributeObjects } from "./autoLayout";
+import type { Canvas } from "fabric";
+
+/**
+ * A fake Fabric object exposing only the geometry surface autoLayout touches:
+ * left/top, scaled size getters, and set/setCoords. set() mutates left/top so
+ * we can assert the resulting positions.
+ */
+function obj(left: number, top: number, w: number, h: number) {
+  return {
+    left,
+    top,
+    getScaledWidth: () => w,
+    getScaledHeight: () => h,
+    set(patch: { left?: number; top?: number }) {
+      if (patch.left !== undefined) this.left = patch.left;
+      if (patch.top !== undefined) this.top = patch.top;
+    },
+    setCoords: vi.fn(),
+  };
+}
+
+type FakeObj = ReturnType<typeof obj>;
+
+function canvasWith(objs: FakeObj[]): Canvas {
+  return {
+    getActiveObjects: () => objs,
+    renderAll: vi.fn(),
+  } as unknown as Canvas;
+}
+
+describe("applyAutoLayout", () => {
+  it("does nothing with fewer than two objects", () => {
+    const a = obj(100, 100, 50, 30);
+    applyAutoLayout(canvasWith([a]), {
+      direction: "horizontal",
+      gap: 10,
+      padding: 0,
+      align: "start",
+    });
+    // Unchanged.
+    expect(a.left).toBe(100);
+    expect(a.top).toBe(100);
+  });
+
+  it("packs objects horizontally with padding + gap, sorted by left", () => {
+    // Provided out of order to prove it sorts by left first.
+    const a = obj(200, 5, 50, 20); // rightmost
+    const b = obj(0, 5, 30, 20); // leftmost
+    applyAutoLayout(canvasWith([a, b]), {
+      direction: "horizontal",
+      gap: 10,
+      padding: 8,
+      align: "start",
+    });
+    // b (width 30) goes first at padding=8, then a at 8+30+10=48.
+    expect(b.left).toBe(8);
+    expect(a.left).toBe(48);
+    // align "start" -> top = padding.
+    expect(b.top).toBe(8);
+    expect(a.top).toBe(8);
+  });
+
+  it("packs objects vertically and centers on the cross axis", () => {
+    const a = obj(5, 0, 40, 20); // narrower
+    const b = obj(5, 100, 80, 30); // widest -> defines maxCross = 80
+    applyAutoLayout(canvasWith([a, b]), {
+      direction: "vertical",
+      gap: 5,
+      padding: 0,
+      align: "center",
+    });
+    // Stacked: a at top 0, b at 0+20+5=25.
+    expect(a.top).toBe(0);
+    expect(b.top).toBe(25);
+    // center cross: a (width 40) -> left = (80-40)/2 = 20; b (width 80) -> 0.
+    expect(a.left).toBe(20);
+    expect(b.left).toBe(0);
+  });
+
+  it("aligns to the end of the cross axis when align=end", () => {
+    const a = obj(0, 0, 40, 20);
+    const b = obj(0, 50, 80, 20); // maxCross = 80
+    applyAutoLayout(canvasWith([a, b]), {
+      direction: "vertical",
+      gap: 0,
+      padding: 0,
+      align: "end",
+    });
+    // a left = 80-40 = 40; b left = 80-80 = 0.
+    expect(a.left).toBe(40);
+    expect(b.left).toBe(0);
+  });
+
+  it("calls setCoords on every laid-out object", () => {
+    const a = obj(0, 0, 10, 10);
+    const b = obj(20, 0, 10, 10);
+    applyAutoLayout(canvasWith([a, b]), {
+      direction: "horizontal",
+      gap: 0,
+      padding: 0,
+      align: "start",
+    });
+    expect(a.setCoords).toHaveBeenCalled();
+    expect(b.setCoords).toHaveBeenCalled();
+  });
+});
+
+describe("distributeObjects", () => {
+  it("does nothing with fewer than three objects", () => {
+    const a = obj(0, 0, 10, 10);
+    const b = obj(100, 0, 10, 10);
+    distributeObjects(canvasWith([a, b]), "horizontal");
+    expect(a.left).toBe(0);
+    expect(b.left).toBe(100);
+  });
+
+  it("spreads three objects evenly between the first and last edges (horizontal)", () => {
+    // Span 0..120, three 20-wide boxes. total width = 60, free = 120-60 = 60,
+    // gap = 60 / (3-1) = 30. Positions: 0, 0+20+30=50, 50+20+30=100.
+    const a = obj(0, 0, 20, 10);
+    const mid = obj(40, 0, 20, 10);
+    const c = obj(100, 0, 20, 10);
+    distributeObjects(canvasWith([a, mid, c]), "horizontal");
+    expect(a.left).toBe(0);
+    expect(mid.left).toBe(50);
+    expect(c.left).toBe(100);
+  });
+
+  it("spreads three objects evenly on the vertical axis", () => {
+    const a = obj(0, 0, 10, 20);
+    const mid = obj(0, 30, 10, 20);
+    const c = obj(0, 100, 10, 20);
+    // last edge = 100+20 = 120, total = 60, gap = (120-0-60)/2 = 30.
+    distributeObjects(canvasWith([a, mid, c]), "vertical");
+    expect(a.top).toBe(0);
+    expect(mid.top).toBe(50);
+    expect(c.top).toBe(100);
+  });
+
+  it("keeps the first and last object pinned to their original extents", () => {
+    const a = obj(10, 0, 20, 10);
+    const mid = obj(50, 0, 20, 10);
+    const c = obj(200, 0, 20, 10);
+    distributeObjects(canvasWith([a, mid, c]), "horizontal");
+    // First stays at its original left; last keeps its original right edge.
+    expect(a.left).toBe(10);
+    expect(c.left + c.getScaledWidth()).toBe(220);
+  });
+});

--- a/web/src/lib/fabric/tools/nodeEditor.test.ts
+++ b/web/src/lib/fabric/tools/nodeEditor.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Path } from "fabric";
+import { NodeEditor } from "./nodeEditor";
+import type { Canvas } from "fabric";
+
+function makeCanvas() {
+  const objects: object[] = [];
+  return {
+    add: vi.fn((o: object) => objects.push(o)),
+    remove: vi.fn((o: object) => {
+      const i = objects.indexOf(o);
+      if (i >= 0) objects.splice(i, 1);
+    }),
+    renderAll: vi.fn(),
+    _objects: objects,
+  };
+}
+
+describe("NodeEditor", () => {
+  let canvas: ReturnType<typeof makeCanvas>;
+  let editor: NodeEditor;
+
+  beforeEach(() => {
+    canvas = makeCanvas();
+    editor = new NodeEditor(canvas as unknown as Canvas);
+  });
+
+  it("adds one draggable handle per M/L/Q/C anchor point", () => {
+    // M, L, Q, L -> 4 anchor points -> 4 handles.
+    const path = new Path("M 0 0 L 10 0 Q 15 5 20 10 L 30 30", {
+      left: 100,
+      top: 50,
+    });
+    editor.edit(path);
+    expect(canvas.add).toHaveBeenCalledTimes(4);
+    expect(canvas._objects).toHaveLength(4);
+  });
+
+  it("offsets handles by the path's left/top origin", () => {
+    const path = new Path("M 0 0 L 40 0", { left: 100, top: 200 });
+    editor.edit(path);
+    // First handle anchors at path origin (0,0) -> left = 100 + 0 - 6 (radius).
+    const firstHandle = canvas._objects[0] as { left: number; top: number };
+    expect(firstHandle.left).toBe(100 + 0 - 6);
+    expect(firstHandle.top).toBe(200 + 0 - 6);
+  });
+
+  it("removes all handles on clear", () => {
+    const path = new Path("M 0 0 L 10 10 L 20 20", { left: 0, top: 0 });
+    editor.edit(path);
+    expect(canvas._objects.length).toBeGreaterThan(0);
+    editor.clear();
+    expect(canvas._objects).toHaveLength(0);
+  });
+
+  it("replaces prior handles when editing a new path", () => {
+    editor.edit(new Path("M 0 0 L 1 1", { left: 0, top: 0 })); // 2 handles
+    editor.edit(new Path("M 0 0 L 1 1 L 2 2", { left: 0, top: 0 })); // 3 handles
+    // Old handles cleared first, so only the latest path's handles remain.
+    expect(canvas._objects).toHaveLength(3);
+  });
+});

--- a/web/src/lib/fabric/tools/pen.test.ts
+++ b/web/src/lib/fabric/tools/pen.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Point, Path } from "fabric";
+import { PenTool } from "./pen";
+import type { Canvas } from "fabric";
+
+/**
+ * Fake canvas recording added/removed objects and the event handlers the
+ * PenTool registers, so we can replay mouse events and inspect the resulting
+ * Fabric Path geometry without a DOM canvas.
+ */
+function makeCanvas() {
+  const handlers: Record<string, (e: { pointer?: Point }) => void> = {};
+  const objects: object[] = [];
+  return {
+    isDrawingMode: false,
+    selection: true,
+    on: vi.fn((evt: string, fn: (e: { pointer?: Point }) => void) => {
+      handlers[evt] = fn;
+    }),
+    off: vi.fn((evt: string) => {
+      delete handlers[evt];
+    }),
+    add: vi.fn((o: object) => objects.push(o)),
+    remove: vi.fn((o: object) => {
+      const i = objects.indexOf(o);
+      if (i >= 0) objects.splice(i, 1);
+    }),
+    setActiveObject: vi.fn(),
+    renderAll: vi.fn(),
+    _handlers: handlers,
+    _objects: objects,
+  };
+}
+
+function down(canvas: ReturnType<typeof makeCanvas>, x: number, y: number) {
+  canvas._handlers["mouse:down"]({ pointer: new Point(x, y) });
+}
+
+describe("PenTool", () => {
+  let canvas: ReturnType<typeof makeCanvas>;
+  let pen: PenTool;
+
+  beforeEach(() => {
+    canvas = makeCanvas();
+    pen = new PenTool(canvas as unknown as Canvas);
+    pen.enable();
+  });
+
+  it("registers mouse handlers and disables free-draw on enable", () => {
+    expect(canvas.isDrawingMode).toBe(false);
+    expect(canvas.selection).toBe(false);
+    expect(canvas._handlers["mouse:down"]).toBeTypeOf("function");
+    expect(canvas._handlers["mouse:move"]).toBeTypeOf("function");
+    expect(canvas._handlers["mouse:dblclick"]).toBeTypeOf("function");
+  });
+
+  it("finalizes a Path starting with a moveto at the first clicked point", () => {
+    down(canvas, 10, 20);
+    down(canvas, 40, 60);
+    canvas._handlers["mouse:dblclick"]({});
+
+    // The last added object is the finalized Path (preview paths are removed).
+    const final = canvas._objects[canvas._objects.length - 1] as Path;
+    expect(final).toBeInstanceOf(Path);
+    const d = final.path.map((c) => c.join(" ")).join(" ");
+    expect(d.startsWith("M 10 20")).toBe(true);
+    // A second point produces a quadratic segment.
+    expect(d).toContain("Q");
+    expect(canvas.setActiveObject).toHaveBeenCalled();
+  });
+
+  it("does not finalize a path from a single point", () => {
+    down(canvas, 5, 5);
+    canvas._handlers["mouse:dblclick"]({});
+    // No persisted Path was activated (needs >= 2 points).
+    expect(canvas.setActiveObject).not.toHaveBeenCalled();
+  });
+
+  it("clears handlers and resets state on disable", () => {
+    down(canvas, 1, 1);
+    pen.disable();
+    expect(canvas.selection).toBe(true);
+    expect(canvas._handlers["mouse:down"]).toBeUndefined();
+    expect(canvas._handlers["mouse:move"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要
品質強化計画 PR5。`lib/fabric/tools/` の幾何ロジック(位置計算・パス生成)の単体テスト。

## 変更内容 (17 テスト追加, 合計 218)
- **autoLayout**: 水平/垂直パッキング(padding+gap)、cross 軸 start/center/end 整列、均等配置の数式、位置ソート、<2/<3 個での no-op、setCoords 呼び出し。
- **pen**: 第一点の moveto、第二点での二次曲線セグメント、単一点の拒否、enable/disable のハンドラ登録・解除。
- **nodeEditor**: M/L/Q/C アンカーごとに1ハンドル、原点オフセット、clear で全削除、再 edit で前ハンドル置換。
- フェイクの Fabric canvas/object を使い DOM canvas 非依存。

## 緑証拠 (ローカル実出力)
- `npx tsc --noEmit`: exit 0 (エラーなし)
- `npm run lint`: 0 error (既存 warning 6)
- `npx vitest run`: 31 files / **218 passed**
- `npx vitest run --coverage`: 24.56/71.77/53.61 で床クリア (exit 0)
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)