### PR TITLE
AI第一弾(案A): 話者ノート自動生成

### DIFF
--- a/web/src/features/editor/components/SpeakerNotes/SpeakerNotesPanel.tsx
+++ b/web/src/features/editor/components/SpeakerNotes/SpeakerNotesPanel.tsx
@@ -1,21 +1,26 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
+import { Sparkles } from "lucide-react";
 import { useEditorStore } from "../../stores/editorStore";
 import { useSlideStore } from "../../stores/slideStore";
 import { useAuthStore } from "@features/dashboard/stores/authStore";
 import { slidesApi } from "@shared/api/slides";
+import { extractSlideText, generateSpeakerNotes } from "@lib/ai/speakerNotes";
 
 export function SpeakerNotesPanel() {
-  const { activeSlideId, presentationId } = useEditorStore();
+  const { activeSlideId, presentationId, canvas } = useEditorStore();
   const { slides, updateSlide } = useSlideStore();
   const { accessToken } = useAuthStore();
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [genError, setGenError] = useState(false);
 
   const currentSlide = slides.find(s => s.id === activeSlideId);
 
   useEffect(() => {
     setNotes(currentSlide?.notes ?? "");
+    setGenError(false);
   }, [activeSlideId, currentSlide]);
 
   const saveNotes = useCallback(async () => {
@@ -29,14 +34,48 @@ export function SpeakerNotesPanel() {
     }
   }, [accessToken, presentationId, activeSlideId, notes, updateSlide]);
 
+  // AI 第一弾(案A): 現在のスライドのテキストから発表ノートを生成して差し込む。
+  // LFM2 Gateway 経由(@lib/ai/speakerNotes)。生成結果は textarea に入るので
+  // ユーザーが編集し、blur で永続化される(自動保存はしない)。
+  const generate = useCallback(async () => {
+    setGenError(false);
+    setGenerating(true);
+    try {
+      const text = extractSlideText(canvas);
+      const generated = await generateSpeakerNotes(text);
+      if (generated) setNotes(generated);
+    } catch {
+      setGenError(true);
+    } finally {
+      setGenerating(false);
+    }
+  }, [canvas]);
+
   if (!activeSlideId) return null;
 
   return (
     <div className="border-t p-3">
       <div className="flex items-center justify-between mb-1">
         <p className="text-xs font-medium text-gray-500">スピーカーノート</p>
-        {saving && <span className="text-xs text-gray-400">保存中...</span>}
+        <div className="flex items-center gap-2">
+          {saving && <span className="text-xs text-gray-400">保存中...</span>}
+          <button
+            type="button"
+            onClick={generate}
+            disabled={generating}
+            title="スライドのテキストから発表ノートを自動生成"
+            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-blue-600 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Sparkles className={`h-3 w-3 ${generating ? "animate-pulse" : ""}`} />
+            {generating ? "生成中..." : "AI生成"}
+          </button>
+        </div>
       </div>
+      {genError && (
+        <p className="mb-1 text-[11px] text-red-500">
+          AI サービスに接続できませんでした。
+        </p>
+      )}
       <textarea
         value={notes}
         onChange={e => setNotes(e.target.value)}

--- a/web/src/lib/ai/speakerNotes.test.ts
+++ b/web/src/lib/ai/speakerNotes.test.ts
@@ -1,0 +1,79 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import {
+  buildSpeakerNotesPrompt,
+  normalizeNote,
+  generateSpeakerNotes,
+} from "./speakerNotes";
+
+// Mock the AI client so the core logic is tested without the LFM gateway —
+// no real network/server is ever touched.
+vi.mock("./client", () => ({
+  generateText: vi.fn(),
+}));
+import { generateText } from "./client";
+
+describe("buildSpeakerNotesPrompt", () => {
+  it("embeds the slide text and asks for a spoken-style note", () => {
+    const p = buildSpeakerNotesPrompt("売上は前年比120%");
+    expect(p).toContain("売上は前年比120%");
+    expect(p).toContain("スピーカーノート");
+  });
+});
+
+describe("normalizeNote", () => {
+  it("returns empty string for blank input", () => {
+    expect(normalizeNote("")).toBe("");
+    expect(normalizeNote("   \n  ")).toBe("");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeNote("  本日はご清聴ありがとうございます。  ")).toBe(
+      "本日はご清聴ありがとうございます。",
+    );
+  });
+
+  it("strips a leading label the model sometimes prepends", () => {
+    expect(normalizeNote("スピーカーノート: これは本文です")).toBe("これは本文です");
+    expect(normalizeNote("ノート：本文")).toBe("本文");
+    expect(normalizeNote("Speaker Notes: hello")).toBe("hello");
+  });
+
+  it("collapses 3+ blank lines into a single blank line", () => {
+    expect(normalizeNote("一段落目\n\n\n\n二段落目")).toBe("一段落目\n\n二段落目");
+  });
+
+  it("leaves a normal note untouched", () => {
+    const note = "まず背景を説明します。\n次に結果を示します。";
+    expect(normalizeNote(note)).toBe(note);
+  });
+});
+
+describe("generateSpeakerNotes", () => {
+  beforeEach(() => {
+    vi.mocked(generateText).mockReset();
+  });
+
+  it("returns '' without calling the AI for blank text", async () => {
+    expect(await generateSpeakerNotes("   ")).toBe("");
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it("calls generateText with the prompt + system message and normalizes output", async () => {
+    vi.mocked(generateText).mockResolvedValue(
+      "スピーカーノート: このスライドでは第1四半期の成果を紹介します。",
+    );
+    const result = await generateSpeakerNotes("Q1 成果");
+
+    expect(generateText).toHaveBeenCalledOnce();
+    const [prompt, system] = vi.mocked(generateText).mock.calls[0];
+    expect(prompt).toContain("Q1 成果");
+    expect(system).toContain("スピーカーノート");
+    // Leading label stripped by normalizeNote.
+    expect(result).toBe("このスライドでは第1四半期の成果を紹介します。");
+  });
+
+  it("propagates AI errors so the UI can show an error state", async () => {
+    vi.mocked(generateText).mockRejectedValue(new Error("gateway down"));
+    await expect(generateSpeakerNotes("内容")).rejects.toThrow("gateway down");
+  });
+});

--- a/web/src/lib/ai/speakerNotes.ts
+++ b/web/src/lib/ai/speakerNotes.ts
@@ -1,0 +1,59 @@
+// AI speaker-notes generation (LFM AI 第一弾・案A). Reuses the in-app LFM2
+// gateway path (generateText -> /api/ai/chat -> LFM Gateway) and the same
+// canvas text-extraction used by proofreading, so the browser never sees the
+// gateway URL and the streaming plumbing is shared.
+import { generateText } from "./client";
+
+// Re-exported so the UI has a single import surface for the notes feature.
+export { extractSlideText } from "./proofread";
+
+const SYSTEM_PROMPT =
+  "あなたはプレゼンテーションの発表を支援するアシスタントです。" +
+  "スライド上のテキストを読み取り、発表者がそのまま読み上げられる" +
+  "自然な話し言葉のスピーカーノート（発表原稿）を日本語で作成します。" +
+  "箇条書きではなく、つながりのある説明文で、簡潔に。";
+
+/**
+ * Builds the user prompt that asks the model to turn the slide's text into a
+ * spoken-style speaker note. Kept separate so it can be unit-tested without the
+ * network.
+ */
+export function buildSpeakerNotesPrompt(slideText: string): string {
+  return (
+    "次のスライドに記載されたテキストをもとに、発表者が読み上げるための" +
+    "スピーカーノート（発表原稿）を作成してください。" +
+    "聴衆に語りかける自然な話し言葉で、3〜5文程度にまとめてください。" +
+    "スライドにない事実を創作しないでください。\n\n" +
+    "---\n" +
+    slideText +
+    "\n---"
+  );
+}
+
+/**
+ * Normalizes the model's raw text into a clean speaker note: trims surrounding
+ * whitespace, strips an accidental leading label ("スピーカーノート:" /
+ * "ノート:" / "原稿:"), and collapses 3+ blank lines. Returns "" for empty input.
+ */
+export function normalizeNote(raw: string): string {
+  let s = (raw ?? "").trim();
+  if (!s) return "";
+  // Drop a leading "スピーカーノート:" / "ノート:" / "原稿:" label the model
+  // sometimes prepends, with optional surrounding spaces.
+  s = s.replace(/^(?:スピーカーノート|ノート|原稿|Speaker Notes?)\s*[:：]\s*/i, "");
+  // Collapse runs of 3+ newlines down to a single blank line.
+  s = s.replace(/\n{3,}/g, "\n\n");
+  return s.trim();
+}
+
+/**
+ * Runs a full speaker-notes pass: prompt -> LFM2 -> normalize. Returns "" for
+ * blank input without calling the AI. Throws if the AI request fails so the UI
+ * can surface an error state (mirrors proofreadText).
+ */
+export async function generateSpeakerNotes(slideText: string): Promise<string> {
+  const trimmed = (slideText ?? "").trim();
+  if (!trimmed) return "";
+  const raw = await generateText(buildSpeakerNotesPrompt(trimmed), SYSTEM_PROMPT);
+  return normalizeNote(raw);
+}


### PR DESCRIPTION
## 概要
LFM AI 機能の第一弾(計画 案A)。スライド上のテキストから発表用スピーカーノートを自動生成し、`SpeakerNotesPanel` に差し込む。

## 設計
- 既存の LFM2 配管(`generateText` -> `/api/ai/chat` -> LFM Gateway)と `extractSlideText`/`proofread` パターンを流用。ブラウザは Gateway URL を見ない。
- `lib/ai/speakerNotes.ts`:
  - `buildSpeakerNotesPrompt` / `normalizeNote`(先頭ラベル除去・空行圧縮) / `generateSpeakerNotes`(空入力は AI 呼ばず '' / エラーは UI へ伝播)。
- `SpeakerNotesPanel`: 「AI生成」ボタンで生成結果を textarea に投入 -> ユーザーが編集し blur で永続化(従来通り・無断自動保存しない)。Gateway 失敗時はインラインエラー表示。

## テスト(モック・実通信なし)
- AI client をモックし、サーバー/Gateway を一切起動せず検証。9 テスト追加。

## 緑証拠 (ローカル実出力)
- `npx tsc --noEmit`: exit 0
- `npm run lint`: 0 error
- `npx vitest run`: 29 files / **210 passed**
- `npx vitest run --coverage`: 22.57/71.78/52.42 で床クリア (exit 0)
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)