### PR TITLE
Fix duplicate slides after reload (slide double-write) (#132)

### DIFF
--- a/web/src/app/(auth)/editor/[id]/page.tsx
+++ b/web/src/app/(auth)/editor/[id]/page.tsx
@@ -57,19 +57,26 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   useEffect(() => {
     if (!accessToken || !id) return;
     setPresentationId(id);
-    slidesApi.list(accessToken, id).then((res) => {
+    slidesApi.list(accessToken, id).then(async (res) => {
       const slideList = res.items as Slide[];
       setSlides(slideList);
       if (slideList.length > 0) setActiveSlide(slideList[0].id);
-      // Seed the shared doc on first join: if the room is still empty after the
-      // initial sync, this client publishes the loaded slides as the baseline.
-      // Subsequent joiners receive it over the wire and skip seeding.
-      if (doc && getSlides(doc).length === 0 && slideList.length > 0) {
-        initializeDoc(doc, slideList);
+      // Seed the shared doc on first join — but only AFTER the initial server
+      // sync has completed. Seeding against a still-empty pre-sync doc would
+      // double every slide: this client would push its REST-loaded copy while
+      // the server's already-persisted copy of the same slide is in flight, and
+      // a Y.Array does not dedupe by id, so the merge would land two entries per
+      // slide (#132). Awaiting sync means `getSlides(doc).length` reflects the
+      // server's real state; `initializeDoc` is also id-keyed as a backstop.
+      if (doc && provider) {
+        await provider.whenSynced();
+        if (getSlides(doc).length === 0 && slideList.length > 0) {
+          initializeDoc(doc, slideList);
+        }
       }
     });
     presentationsApi.get(accessToken, id).then(p => setTitle(p.title));
-  }, [id, accessToken, doc, setPresentationId, setSlides, setActiveSlide]);
+  }, [id, accessToken, doc, provider, setPresentationId, setSlides, setActiveSlide]);
 
   return (
     <SlideStructureProvider value={structure}>

--- a/web/src/lib/collab/projection.test.ts
+++ b/web/src/lib/collab/projection.test.ts
@@ -52,6 +52,32 @@ describe("projectDoc (JSONB projection)", () => {
     expect(projectDoc(doc)).toHaveLength(0);
   });
 
+  it("deduplicates slides sharing an id, keeping the first (#132)", () => {
+    // A Y.Array carries no unique-key constraint, so a concurrent seed / merge
+    // can leave two entries with the same slide id. The projection feeds the
+    // React slide list, so it must collapse duplicates or the render crashes
+    // with "two children with the same key". The first occurrence wins.
+    const doc = new Y.Doc();
+    seed(doc);
+    doc.transact(() => {
+      getSlides(doc).push([
+        slideToYMap({
+          id: "s1", // same id as the seeded slide
+          presentationId: "p",
+          position: 1,
+          content: { version: "1.0", objects: [{ id: "dupe", type: "rect" }] },
+          createdAt: "x",
+          updatedAt: "x",
+        }),
+      ]);
+    });
+    expect(getSlides(doc).length).toBe(2); // raw array genuinely has two
+    const out = projectDoc(doc);
+    expect(out).toHaveLength(1); // projection collapses them
+    expect(out[0].id).toBe("s1");
+    expect(out[0].position).toBe(0); // first occurrence wins
+  });
+
   it("survives a persistence round-trip (encode/applyUpdate) intact", () => {
     const docA = new Y.Doc();
     seed(docA);

--- a/web/src/lib/collab/projection.ts
+++ b/web/src/lib/collab/projection.ts
@@ -26,12 +26,22 @@ export interface SlideProjection {
  * Projects the whole doc into an ordered list of `{ id, position, content }`.
  * Slides without an id are skipped (a slide map is only meaningful once seeded
  * with its stable id).
+ *
+ * The output is deduplicated by id: the first Y.Map seen for a given id wins and
+ * any later duplicate is dropped. A Y.Array carries no unique-key constraint, so
+ * a concurrent seed / merge could in principle leave two entries sharing an id;
+ * this projection is the single materialization point feeding the slide store
+ * and React keys, so collapsing duplicates here is the last-line guard against
+ * the "two children with the same key" render crash (#132). The primary fix is
+ * upstream (id-keyed, sync-gated seeding) — this keeps the UI correct regardless.
  */
 export function projectDoc(doc: Y.Doc): SlideProjection[] {
   const out: SlideProjection[] = [];
+  const seen = new Set<string>();
   getSlides(doc).forEach((slide, i) => {
     const id = slide.get(SLIDE_FIELDS.id) as string | undefined;
-    if (!id) return;
+    if (!id || seen.has(id)) return;
+    seen.add(id);
     out.push({
       id,
       position: (slide.get(SLIDE_FIELDS.position) as number | undefined) ?? i,

--- a/web/src/lib/collab/provider.ts
+++ b/web/src/lib/collab/provider.ts
@@ -55,6 +55,34 @@ export class CollabProvider {
     return this.provider?.wsconnected ?? false;
   }
 
+  /** True once the initial state sync with the server has completed. */
+  get synced(): boolean {
+    return this.provider?.synced ?? false;
+  }
+
+  /**
+   * Resolves once this room's initial sync with the server has completed (or
+   * immediately if it already has). Callers that seed an empty room must await
+   * this first: seeding before the server's persisted slides have arrived would
+   * duplicate every slide once the remote update merges in, because a Y.Array
+   * does not dedupe by slide id (#132). If the provider is gone (disconnected /
+   * destroyed) the promise never resolves; callers gate seeding behind it, so a
+   * torn-down room simply never seeds, which is the safe outcome.
+   */
+  whenSynced(): Promise<void> {
+    const provider = this.provider;
+    if (!provider) return new Promise<void>(() => {});
+    if (provider.synced) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const onSync = (isSynced: boolean) => {
+        if (!isSynced) return;
+        provider.off("sync", onSync);
+        resolve();
+      };
+      provider.on("sync", onSync);
+    });
+  }
+
   /** The shared, ordered slide list (Y.Array<Y.Map>). */
   get slides(): Y.Array<YSlideMap> {
     return getSlides(this.doc);

--- a/web/src/lib/collab/schema.test.ts
+++ b/web/src/lib/collab/schema.test.ts
@@ -80,12 +80,42 @@ describe("collab schema", () => {
     expect("background" in content).toBe(false);
   });
 
-  it("initializeDoc replaces existing content", () => {
+  it("initializeDoc only appends slides whose id is not already present", () => {
     const doc = new Y.Doc();
-    initializeDoc(doc, [makeSlide({ id: "old" })]);
-    initializeDoc(doc, [makeSlide({ id: "new-1" }), makeSlide({ id: "new-2" })]);
-    expect(docToSlideContents(doc)).toHaveLength(2);
-    expect(getSlides(doc).map((s) => s.get("id"))).toEqual(["new-1", "new-2"]);
+    initializeDoc(doc, [makeSlide({ id: "a" })]);
+    // Re-seeding with an overlapping id-set must NOT re-insert "a" (idempotent),
+    // only the genuinely-new "b" is appended.
+    initializeDoc(doc, [makeSlide({ id: "a" }), makeSlide({ id: "b" })]);
+    expect(getSlides(doc).map((s) => s.get("id"))).toEqual(["a", "b"]);
+  });
+
+  it("initializeDoc is idempotent: re-seeding the same list is a no-op (#132)", () => {
+    // Regression: a client that seeds an empty room, then re-runs the seed (e.g.
+    // effect re-fire, or its own seed echoing back over the wire), must never
+    // duplicate slides. A duplicated slide id is what crashed the slide list
+    // render with "two children with the same key".
+    const doc = new Y.Doc();
+    const list = [makeSlide({ id: "s1" }), makeSlide({ id: "s2" })];
+    initializeDoc(doc, list);
+    initializeDoc(doc, list);
+    expect(getSlides(doc).map((s) => s.get("id"))).toEqual(["s1", "s2"]);
+  });
+
+  it("re-seeding a doc that already received a remote slide is a no-op (#132)", () => {
+    // The real-world race: the server's persisted slide syncs into this client's
+    // doc, THEN this client (effect re-fire / late list response) tries to seed
+    // the same slide it loaded over REST. id-keyed seeding must recognize the
+    // already-synced slide and not append a second copy.
+    const server = new Y.Doc();
+    initializeDoc(server, [makeSlide({ id: "dup" })]);
+
+    const client = new Y.Doc();
+    // Server state arrives first (post-sync).
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(server));
+    // Now the client attempts to seed the same slide from its REST load.
+    initializeDoc(client, [makeSlide({ id: "dup" })]);
+
+    expect(getSlides(client).map((s) => s.get("id"))).toEqual(["dup"]);
   });
 
   it("syncs a doc update to a second peer via encoded state", () => {

--- a/web/src/lib/collab/schema.ts
+++ b/web/src/lib/collab/schema.ts
@@ -72,14 +72,29 @@ export function slideToYMap(slide: Slide): YSlideMap {
 }
 
 /**
- * Populates the shared doc from a plain slide list. Runs inside a single
- * transaction so observers see one atomic update. Existing content is replaced.
+ * Seeds the shared doc from a plain slide list, idempotently by slide id.
+ *
+ * This is the baseline-publish path taken by the first client to join an empty
+ * room. It is deliberately *additive and id-keyed*: only slides whose id is not
+ * already present in the doc are pushed. A Y.Array does not dedupe by a logical
+ * key, so if this client seeds a slide while the server's already-persisted copy
+ * of the same slide is still in flight, a naive `push` would land two Y.Map
+ * entries with the same id once the remote update merges in — the source of the
+ * "two children with the same key" duplicate-slide bug (#132). Keying on id makes
+ * a concurrent or repeated seed a no-op for slides the doc already knows about.
+ *
+ * Runs inside a single transaction so observers see one atomic update.
  */
 export function initializeDoc(doc: Y.Doc, slides: Slide[]): void {
   const arr = getSlides(doc);
   doc.transact(() => {
-    if (arr.length > 0) arr.delete(0, arr.length);
-    arr.push(slides.map((s) => slideToYMap(s)));
+    const present = new Set<string>();
+    for (let i = 0; i < arr.length; i++) {
+      const id = arr.get(i).get(SLIDE_FIELDS.id) as string | undefined;
+      if (id) present.add(id);
+    }
+    const fresh = slides.filter((s) => !present.has(s.id));
+    if (fresh.length > 0) arr.push(fresh.map((s) => slideToYMap(s)));
   });
 }
 


### PR DESCRIPTION
Fixes #132 — the slide list crashed with React's "Encountered two children with the same key, \`133b38bf-...\`" after a hard reload, because slides were duplicated in the shared Yjs doc.

## Root cause: a pre-sync seed race

`useCollaboration` creates a **fresh, empty `Y.Doc`** and connects to the realtime server asynchronously. The editor page (`editor/[id]/page.tsx`) seeded the doc the moment the REST slide list resolved, guarded only by `getSlides(doc).length === 0`:

```ts
if (doc && getSlides(doc).length === 0 && slideList.length > 0) {
  initializeDoc(doc, slideList);
}
```

That length check ran **before the server sync completed**, while the local doc was still empty. So this client seeded its REST-loaded slides, and then the server's **already-persisted copies of the same slides** synced in over the websocket. A `Y.Array` has no unique-key constraint, so the CRDT merge landed **two `Y.Map` entries per slide id**. That doubled state was then re-persisted, which is why it survived a reload. The duplicated id then crashed the slide-list render (`key={slide.id}`).

The server side was already idempotent (PUT updates by id, create generates the id), so this was purely a client-side seed/merge bug — matching the "二重書き込み" diagnosis.

## Fix (idempotency at the source + guards)

| Layer | Change | Why |
|---|---|---|
| `initializeDoc` (schema) | Seed **additively by slide id** — skip any id already present | A concurrent / repeated / echoed seed can never re-insert a known slide |
| `CollabProvider.whenSynced()` (provider) | New: resolves once the initial server sync completes | Lets callers gate seeding until the doc reflects the server's real state |
| `editor/[id]/page.tsx` | `await provider.whenSynced()` before the emptiness check + seed | Closes the pre-sync race: only seed a genuinely-empty room |
| `projectDoc` (projection) | Dedupe by id, first occurrence wins | Last-line guard — the projection is the single feed into the slide store + React keys, so the UI stays correct even if a stray duplicate ever lands |

Why this is the root fix and not a band-aid: the duplication is eliminated where it originates (sync-gated, id-keyed seeding), and the projection dedupe is defense-in-depth so the render can never crash on a duplicate again.

## Tests

- `npm run type-check` — clean
- `npx vitest run` — **244 passed (35 files)**

Added regression tests:
- `schema.test.ts`: idempotent re-seed is a no-op; id-keyed append; no duplication after a server slide has already synced in.
- `projection.test.ts`: two `Y.Array` entries sharing an id collapse to one in the projection.

(Updated the prior `initializeDoc replaces existing content` test to assert the corrected idempotent/id-keyed contract.)

## Notes
- Did not touch the running dev server (HMR picks up the changes).
- No DB / schema / backend changes needed — the server was already id-idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)