### PR TITLE
Externalize AI gateway URL and model name via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,38 @@ cd services/realtime && go run ./cmd/realtime  # Realtime WS at :8082
 
 ## AI Features Setup
 
-The AI coaching and content generation require a local LFM2 gateway:
+The AI speaker-notes / content generation feature talks to any local
+**OpenAI-compatible** chat endpoint (`POST /v1/chat/completions`). No external
+API is used. The `/api/ai/chat` route reads two server-side env vars:
+
+- `LLM_GATEWAY_URL` — base URL of the local gateway (the route appends
+  `/v1/chat/completions`; a trailing `/v1` is tolerated). Default
+  `http://localhost:4242`.
+- `LLM_MODEL` — model name sent to the gateway. Default `lfm2-2.6b-f16`.
+
+Option A - Ollama (CLI):
 
 ```bash
-# Start LFM2 gateway on port 4242 (OpenAI-compatible)
-# Example using LM Studio or similar:
-# Set NEXT_PUBLIC_LLM_GATEWAY_URL=http://localhost:4242/v1
-
-# Real-time coaching uses Web Speech API (Chrome/Edge only)
+# One-time (requires user-approved global install):
+brew install ollama
+ollama pull qwen2.5:3b        # ~2 GB; or llama3.2:3b
+ollama serve                  # OpenAI-compatible on :11434
+# Then in web/.env.local:
+#   LLM_GATEWAY_URL=http://localhost:11434
+#   LLM_MODEL=qwen2.5:3b
 ```
+
+Option B - LM Studio (GUI):
+
+```bash
+# Download a model in LM Studio, start its OpenAI-compatible server on :4242.
+# Then in web/.env.local:
+#   LLM_GATEWAY_URL=http://localhost:4242
+#   LLM_MODEL=<the model id LM Studio reports>
+```
+
+Real-time speech coaching uses the Web Speech API (Chrome/Edge only) and is
+independent of the gateway.
 
 ## Environment Variables
 
@@ -95,7 +118,10 @@ PORT=8080
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_COLLAB_URL=ws://localhost:8081
 NEXT_PUBLIC_REALTIME_URL=ws://localhost:8082
-NEXT_PUBLIC_LLM_GATEWAY_URL=http://localhost:4242/v1
+
+# AI gateway (server-side; read by /api/ai/chat). OpenAI-compatible endpoint.
+LLM_GATEWAY_URL=http://localhost:4242   # Ollama: http://localhost:11434
+LLM_MODEL=lfm2-2.6b-f16                 # Ollama: qwen2.5:3b
 ```
 
 ## PR History (021-040)

--- a/web/src/app/api/ai/chat/route.ts
+++ b/web/src/app/api/ai/chat/route.ts
@@ -2,7 +2,18 @@
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const GATEWAY_URL = process.env.LLM_GATEWAY_URL ?? "http://localhost:4242";
+// Gateway base URL. The route appends "/v1/chat/completions" itself, so a
+// trailing "/v1" (as shown in the README env example) is stripped to avoid a
+// duplicated "/v1/v1". Any OpenAI-compatible server works (LM Studio :4242,
+// Ollama's OpenAI-compat endpoint http://localhost:11434, etc.).
+const GATEWAY_URL = (process.env.LLM_GATEWAY_URL ?? "http://localhost:4242")
+  .replace(/\/+$/, "")
+  .replace(/\/v1$/, "");
+
+// Model name sent to the gateway. Defaults to LFM2 but is overridable so the
+// same code drives a different local model (e.g. LLM_MODEL=qwen2.5:3b for
+// Ollama, or llama3.2:3b) without touching source.
+const MODEL = process.env.LLM_MODEL ?? "lfm2-2.6b-f16";
 
 interface ChatBody {
   messages: { role: string; content: string }[];
@@ -10,8 +21,6 @@ interface ChatBody {
   temperature?: number;
   response_format?: { type: string };
 }
-
-const MODEL = "lfm2-2.6b-f16";
 
 export async function POST(req: Request) {
   let body: ChatBody;


### PR DESCRIPTION
## What

The AI speaker-notes generation feature is already fully implemented end-to-end (AI生成 button -> `generateSpeakerNotes` -> `/api/ai/chat` BFF -> `${LLM_GATEWAY_URL}/v1/chat/completions`). The only thing preventing use was that the **model name was hardcoded** and the gateway URL had no documented override, so pointing it at a local LLM other than the LFM2 default required editing source.

This PR makes the feature usable with **any local OpenAI-compatible runtime, no external API**:

- `LLM_MODEL` env overrides the hardcoded `lfm2-2.6b-f16` (default unchanged).
- `LLM_GATEWAY_URL` now strips a trailing `/v1` so the README-style `http://host/v1` value no longer produces `/v1/v1`.
- README documents both env vars and adds Ollama (`:11434`) + LM Studio (`:4242`) setup, including the OpenAI-compat endpoint differences.

## Why

The blocker was never the code — it was that no local LLM runtime is running on this machine. This PR removes the remaining hard-coding so an operator can wire the feature to Ollama/LM Studio purely via `.env.local`.

## Tests

- `src/app/api/ai/chat/route.test.ts` — 5 passed (model still defaults to `lfm2-2.6b-f16`).
- `src/lib/ai/*` — 24 passed.
- `eslint` on the changed route — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)